### PR TITLE
refactor: tx/rx between executor and subscription manager

### DIFF
--- a/src/eth/executor.rs
+++ b/src/eth/executor.rs
@@ -1,14 +1,16 @@
 use std::sync::Arc;
 use std::sync::Mutex;
 
+use tokio::sync::broadcast;
+
+use super::primitives::LogMined;
 use crate::eth::evm::Evm;
 use crate::eth::miner::BlockMiner;
+use crate::eth::primitives::Block;
 use crate::eth::primitives::CallInput;
 use crate::eth::primitives::StoragerPointInTime;
 use crate::eth::primitives::TransactionExecution;
 use crate::eth::primitives::TransactionInput;
-use crate::eth::rpc::RpcBlockNotifier;
-use crate::eth::rpc::RpcLogNotifier;
 use crate::eth::storage::EthStorage;
 use crate::eth::EthError;
 
@@ -18,9 +20,11 @@ pub struct EthExecutor {
     miner: Mutex<BlockMiner>,
     eth_storage: Arc<dyn EthStorage>,
 
-    rpc_block_notifier: Option<RpcBlockNotifier>,
-    rpc_log_notifier: Option<RpcLogNotifier>,
+    block_notifier: broadcast::Sender<Block>,
+    log_notifier: broadcast::Sender<LogMined>,
 }
+
+const NOTIFIER_CAPACITY: usize = u16::MAX as usize;
 
 impl EthExecutor {
     /// Creates a new executor.
@@ -29,19 +33,9 @@ impl EthExecutor {
             evm: Mutex::new(evm),
             miner: Mutex::new(BlockMiner::new(Arc::clone(&eth_storage))),
             eth_storage,
-            rpc_block_notifier: None,
-            rpc_log_notifier: None,
+            block_notifier: broadcast::channel(NOTIFIER_CAPACITY).0,
+            log_notifier: broadcast::channel(NOTIFIER_CAPACITY).0,
         }
-    }
-
-    /// Sets the RPC block notifier.
-    pub fn set_rpc_block_notifier(&mut self, block_notifier: RpcBlockNotifier) {
-        self.rpc_block_notifier = Some(block_notifier);
-    }
-
-    /// Sets the RPC log notifier.
-    pub fn set_rpc_log_notifier(&mut self, log_notifier: RpcLogNotifier) {
-        self.rpc_log_notifier = Some(log_notifier);
     }
 
     /// Execute a transaction, mutate the state and return function output.
@@ -75,20 +69,16 @@ impl EthExecutor {
         self.eth_storage.save_block(block.clone())?;
 
         // notify new blocks
-        if let Some(block_notifier) = &self.rpc_block_notifier {
-            if let Err(e) = block_notifier.send(block.clone()) {
-                tracing::error!(reason = ?e, "failed to send block notification");
-            };
-        }
+        if let Err(e) = self.block_notifier.send(block.clone()) {
+            tracing::error!(reason = ?e, "failed to send block notification");
+        };
 
         // notify transaction logs
-        if let Some(log_notifier) = &self.rpc_log_notifier {
-            for trx in block.transactions {
-                for log in trx.logs {
-                    if let Err(e) = log_notifier.send(log) {
-                        tracing::error!(reason = ?e, "failed to send log notification");
-                    };
-                }
+        for trx in block.transactions {
+            for log in trx.logs {
+                if let Err(e) = self.log_notifier.send(log) {
+                    tracing::error!(reason = ?e, "failed to send log notification");
+                };
             }
         }
 
@@ -96,7 +86,6 @@ impl EthExecutor {
     }
 
     /// Execute a function and return the function output. State changes are ignored.
-    /// TODO: return value
     pub fn call(&self, input: CallInput, point_in_time: StoragerPointInTime) -> Result<TransactionExecution, EthError> {
         tracing::info!(
             from = %input.from,
@@ -110,5 +99,15 @@ impl EthExecutor {
         let mut executor_lock = self.evm.lock().unwrap();
         let execution = executor_lock.execute((input, point_in_time).into())?;
         Ok(execution)
+    }
+
+    /// Subscribe to new blocks events.
+    pub fn subscribe_to_new_heads(&self) -> broadcast::Receiver<Block> {
+        self.block_notifier.subscribe()
+    }
+
+    /// Subscribe to new logs events.
+    pub fn subscribe_to_logs(&self) -> broadcast::Receiver<LogMined> {
+        self.log_notifier.subscribe()
     }
 }

--- a/src/eth/rpc/mod.rs
+++ b/src/eth/rpc/mod.rs
@@ -12,6 +12,4 @@ use rpc_parser::next_rpc_param;
 use rpc_parser::parse_rpc_rlp;
 pub use rpc_parser::rpc_internal_error;
 pub use rpc_server::serve_rpc;
-pub use rpc_subscriptions::RpcBlockNotifier;
-pub use rpc_subscriptions::RpcLogNotifier;
 pub use rpc_subscriptions::RpcSubscriptions;

--- a/src/eth/rpc/rpc_server.rs
+++ b/src/eth/rpc/rpc_server.rs
@@ -36,12 +36,12 @@ use crate::eth::EthExecutor;
 // Server
 // -----------------------------------------------------------------------------
 
-pub async fn serve_rpc(mut executor: EthExecutor, eth_storage: Arc<dyn EthStorage>) -> eyre::Result<()> {
+pub async fn serve_rpc(executor: EthExecutor, eth_storage: Arc<dyn EthStorage>) -> eyre::Result<()> {
     // configure subscriptions
     let subs = Arc::new(RpcSubscriptions::default());
     Arc::clone(&subs).spawn_subscriptions_cleaner();
-    executor.set_rpc_block_notifier(Arc::clone(&subs).spawn_new_heads_notifier());
-    executor.set_rpc_log_notifier(Arc::clone(&subs).spawn_logs_notifier());
+    Arc::clone(&subs).spawn_logs_notifier(executor.subscribe_to_logs());
+    Arc::clone(&subs).spawn_new_heads_notifier(executor.subscribe_to_new_heads());
 
     // configure context
     let ctx = RpcContext {

--- a/src/eth/rpc/rpc_subscriptions.rs
+++ b/src/eth/rpc/rpc_subscriptions.rs
@@ -4,7 +4,7 @@ use dashmap::mapref::multiple::RefMulti;
 use dashmap::DashMap;
 use jsonrpsee::SubscriptionMessage;
 use jsonrpsee::SubscriptionSink;
-use tokio::sync::mpsc;
+use tokio::sync::broadcast;
 use tokio::time::sleep;
 use tokio::time::Duration;
 
@@ -17,9 +17,6 @@ const CLEANING_FREQUENCY: Duration = Duration::from_secs(10);
 /// Timeout used when sending notifications to subscribers.
 const NOTIFICATION_TIMEOUT: Duration = Duration::from_secs(1);
 
-pub type RpcBlockNotifier = mpsc::UnboundedSender<Block>;
-pub type RpcLogNotifier = mpsc::UnboundedSender<LogMined>;
-
 #[derive(Debug, Default)]
 pub struct RpcSubscriptions {
     pub new_heads: DashMap<usize, SubscriptionSink>,
@@ -27,10 +24,6 @@ pub struct RpcSubscriptions {
 }
 
 impl RpcSubscriptions {
-    // -------------------------------------------------------------------------
-    // Background tasks
-    // -------------------------------------------------------------------------
-
     /// Spawns a new thread to clean up closed subscriptions from time to time.
     pub fn spawn_subscriptions_cleaner(self: Arc<Self>) {
         fn remove_closed_subs(map: &DashMap<usize, SubscriptionSink>) {
@@ -41,14 +34,14 @@ impl RpcSubscriptions {
         tokio::spawn(async move {
             loop {
                 remove_closed_subs(&self.new_heads);
+                remove_closed_subs(&self.logs);
                 sleep(CLEANING_FREQUENCY).await;
             }
         });
     }
 
     /// Spawns a new thread that notifies subscribers about new heads.
-    pub fn spawn_new_heads_notifier(self: Arc<Self>) -> RpcBlockNotifier {
-        let (tx, mut rx) = mpsc::unbounded_channel::<Block>();
+    pub fn spawn_new_heads_notifier(self: Arc<Self>, mut rx: broadcast::Receiver<Block>) {
         tokio::spawn(async move {
             loop {
                 let block = rx.recv().await.expect("newHeads notifier channel should never be closed");
@@ -58,14 +51,12 @@ impl RpcSubscriptions {
                 }
             }
         });
-        tx
     }
 
     /// Spawns a new thread that notifies subscribers about transactions logs.
     ///
     /// TODO: must consider filters.
-    pub fn spawn_logs_notifier(self: Arc<Self>) -> RpcLogNotifier {
-        let (tx, mut rx) = mpsc::unbounded_channel::<LogMined>();
+    pub fn spawn_logs_notifier(self: Arc<Self>, mut rx: broadcast::Receiver<LogMined>) {
         tokio::spawn(async move {
             loop {
                 let log = rx.recv().await.expect("logs notifier channel should never be closed");
@@ -75,7 +66,6 @@ impl RpcSubscriptions {
                 }
             }
         });
-        tx
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
Changes the dynamics of how TX and RX are set when producing events.

`RpcSubscriptions` now receives the `rx` channel, making it possible to spawn multiple tasks from multiple sources. 

For example, we can have a notifier that notify about events produced by the server and another that notifies from other nodes.