### PR TITLE
test: add action to lint and fmt checks

### DIFF
--- a/.github/workflows/lint-check.yml
+++ b/.github/workflows/lint-check.yml
@@ -1,0 +1,25 @@
+name: Lint
+
+on:
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  run_lint:
+    name: Lint and Style checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Rust Nightly
+        run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain nightly
+
+      - name: Checking formatting
+        run: cargo +nightly fmt --check
+
+      - name: Linting
+        run: cargo +nightly clippy --all-targets


### PR DESCRIPTION
Action to automatically check code formatting and common errors.
It differs from `just lint` in the `fmt` step: this action will just check and report, it will not fix the formatting.