### PR TITLE
feat: Migrate to async traits for EthStorage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3110,6 +3110,7 @@ name = "stratus"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "binary_macros",
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
 triehash = "0.8.4"
 clap = { version = "4.4.18", features = ["derive", "env"] }
 anyhow = "1.0.79"
+async-trait = "0.1.77"
 
 [dev-dependencies]
 binary_macros = "1.0.0"

--- a/src/eth/evm/revm.rs
+++ b/src/eth/evm/revm.rs
@@ -142,7 +142,7 @@ impl Database for RevmDatabaseSession {
         let rt = tokio::runtime::Handle::current();
         // retrieve account
         let address: Address = revm_address.into();
-        let account = rt.block_on(async {self.storage.read_account(&address, &self.storage_point_in_time).await})?;
+        let account = rt.block_on(async { self.storage.read_account(&address, &self.storage_point_in_time).await })?;
 
         // warn if the loaded account is the `to` account and it does not have a bytecode
         if let Some(ref to_address) = self.to {
@@ -170,7 +170,7 @@ impl Database for RevmDatabaseSession {
         // retrieve slot
         let address: Address = revm_address.into();
         let index: SlotIndex = revm_index.into();
-        let slot = rt.block_on(async {self.storage.read_slot(&address, &index, &self.storage_point_in_time).await})?;
+        let slot = rt.block_on(async { self.storage.read_slot(&address, &index, &self.storage_point_in_time).await })?;
 
         // track original value
         match self.storage_changes.get_mut(&address) {

--- a/src/eth/evm/revm.rs
+++ b/src/eth/evm/revm.rs
@@ -139,9 +139,10 @@ impl Database for RevmDatabaseSession {
     type Error = anyhow::Error;
 
     fn basic(&mut self, revm_address: RevmAddress) -> anyhow::Result<Option<AccountInfo>> {
+        let rt = tokio::runtime::Handle::current();
         // retrieve account
         let address: Address = revm_address.into();
-        let account = self.storage.read_account(&address, &self.storage_point_in_time)?;
+        let account = rt.block_on(async {self.storage.read_account(&address, &self.storage_point_in_time).await})?;
 
         // warn if the loaded account is the `to` account and it does not have a bytecode
         if let Some(ref to_address) = self.to {
@@ -164,10 +165,12 @@ impl Database for RevmDatabaseSession {
     }
 
     fn storage(&mut self, revm_address: RevmAddress, revm_index: U256) -> anyhow::Result<U256> {
+        let rt = tokio::runtime::Handle::current();
+
         // retrieve slot
         let address: Address = revm_address.into();
         let index: SlotIndex = revm_index.into();
-        let slot = self.storage.read_slot(&address, &index, &self.storage_point_in_time)?;
+        let slot = rt.block_on(async {self.storage.read_slot(&address, &index, &self.storage_point_in_time).await})?;
 
         // track original value
         match self.storage_changes.get_mut(&address) {

--- a/src/eth/executor.rs
+++ b/src/eth/executor.rs
@@ -62,6 +62,8 @@ impl EthExecutor {
 
         // acquire locks
         let mut miner_lock = self.miner.lock().await;
+        let mut _evm_lock = self.evm.lock().await;
+
 
         let mut evm = Revm::new(self.eth_storage.clone());
         let tclone = transaction.clone();
@@ -98,6 +100,7 @@ impl EthExecutor {
             "evm executing call"
         );
 
+        let mut _evm_lock = self.evm.lock().await;
         // execute, but not save
         let mut evm = Revm::new(self.eth_storage.clone());
 

--- a/src/eth/executor.rs
+++ b/src/eth/executor.rs
@@ -64,8 +64,7 @@ impl EthExecutor {
         let mut miner_lock = self.miner.lock().await;
         let mut _evm_lock = self.evm.lock().await;
 
-
-        let mut evm = Revm::new(self.eth_storage.clone());
+        let mut evm = Revm::new(Arc::clone(&self.eth_storage));
         let tclone = transaction.clone();
 
         // execute, mine and save
@@ -102,9 +101,9 @@ impl EthExecutor {
 
         let mut _evm_lock = self.evm.lock().await;
         // execute, but not save
-        let mut evm = Revm::new(self.eth_storage.clone());
+        let mut evm = Revm::new(Arc::clone(&self.eth_storage));
 
-        let execution = tokio::task::spawn_blocking(move || {evm.execute((input, point_in_time).into())}).await??;
+        let execution = tokio::task::spawn_blocking(move || evm.execute((input, point_in_time).into())).await??;
         Ok(execution)
     }
 

--- a/src/eth/miner/block_miner.rs
+++ b/src/eth/miner/block_miner.rs
@@ -29,17 +29,17 @@ impl BlockMiner {
     }
 
     /// Mine one block with a single transaction.
-    pub fn mine_with_one_transaction(&mut self, input: TransactionInput, execution: TransactionExecution) -> anyhow::Result<Block> {
+    pub async fn mine_with_one_transaction(&mut self, input: TransactionInput, execution: TransactionExecution) -> anyhow::Result<Block> {
         let transactions = NonEmpty::new((input, execution));
-        self.mine_with_many_transactions(transactions)
+        self.mine_with_many_transactions(transactions).await
     }
 
     /// Mine one block from one or more transactions.
     ///
     /// TODO: maybe break this in multiple functions after the logic is complete.
-    pub fn mine_with_many_transactions(&mut self, transactions: NonEmpty<(TransactionInput, TransactionExecution)>) -> anyhow::Result<Block> {
+    pub async fn mine_with_many_transactions(&mut self, transactions: NonEmpty<(TransactionInput, TransactionExecution)>) -> anyhow::Result<Block> {
         // init block
-        let number = self.storage.increment_block_number()?;
+        let number = self.storage.increment_block_number().await?;
         let block_timpestamp = transactions
             .minimum_by(|(_, e1), (_, e2)| e1.block_timestamp_in_secs.cmp(&e2.block_timestamp_in_secs))
             .1

--- a/src/eth/miner/block_miner.rs
+++ b/src/eth/miner/block_miner.rs
@@ -38,7 +38,6 @@ impl BlockMiner {
         Block::new_with_capacity(BlockNumber::ZERO, 1702568764, 0)
     }
 
-
     /// Mine one block with a single transaction.
     /// Internally, it wraps the single transaction into a format suitable for `mine_with_many_transactions`,
     /// enabling consistent processing for both single and multiple transaction scenarios.

--- a/src/eth/primitives/log_filter_input.rs
+++ b/src/eth/primitives/log_filter_input.rs
@@ -38,23 +38,23 @@ pub struct LogFilterInput {
 
 impl LogFilterInput {
     /// Parses itself into a filter that can be applied in produced log events or to query the storage.
-    pub fn parse(self, storage: &Arc<dyn EthStorage>) -> anyhow::Result<LogFilter> {
+    pub async fn parse(self, storage: &Arc<dyn EthStorage>) -> anyhow::Result<LogFilter> {
         // parse point-in-time
         let (from, to) = match self.block_hash {
             Some(hash) => {
-                let from_to = storage.translate_to_point_in_time(&BlockSelection::Hash(hash))?;
+                let from_to = storage.translate_to_point_in_time(&BlockSelection::Hash(hash)).await?;
                 (from_to.clone(), from_to)
             }
             None => {
-                let from = storage.translate_to_point_in_time(&self.from_block.unwrap_or(BlockSelection::Latest))?;
-                let to = storage.translate_to_point_in_time(&self.to_block.unwrap_or(BlockSelection::Latest))?;
+                let from = storage.translate_to_point_in_time(&self.from_block.unwrap_or(BlockSelection::Latest)).await?;
+                let to = storage.translate_to_point_in_time(&self.to_block.unwrap_or(BlockSelection::Latest)).await?;
                 (from, to)
             }
         };
 
         // translate point-in-time to block according to context
         let from = match from {
-            StoragePointInTime::Present => storage.read_current_block_number()?,
+            StoragePointInTime::Present => storage.read_current_block_number().await?,
             StoragePointInTime::Past(number) => number,
         };
         let to = match to {

--- a/src/eth/storage/eth_storage.rs
+++ b/src/eth/storage/eth_storage.rs
@@ -1,5 +1,5 @@
 use anyhow::anyhow;
-use jsonrpsee::core::async_trait;
+use async_trait::async_trait;
 
 use crate::eth::primitives::Account;
 use crate::eth::primitives::Address;

--- a/src/eth/storage/inmemory.rs
+++ b/src/eth/storage/inmemory.rs
@@ -6,6 +6,7 @@ use std::sync::atomic::Ordering;
 use std::sync::RwLock;
 
 use indexmap::IndexMap;
+use jsonrpsee::core::async_trait;
 
 use crate::eth::miner::BlockMiner;
 use crate::eth::primitives::Account;
@@ -66,16 +67,17 @@ impl Default for InMemoryStorage {
     }
 }
 
+#[async_trait]
 impl EthStorage for InMemoryStorage {
     // -------------------------------------------------------------------------
     // Block number operations
     // -------------------------------------------------------------------------
 
-    fn read_current_block_number(&self) -> anyhow::Result<BlockNumber> {
+    async fn read_current_block_number(&self) -> anyhow::Result<BlockNumber> {
         Ok(self.block_number.load(Ordering::SeqCst).into())
     }
 
-    fn increment_block_number(&self) -> anyhow::Result<BlockNumber> {
+    async fn increment_block_number(&self) -> anyhow::Result<BlockNumber> {
         let next = self.block_number.fetch_add(1, Ordering::SeqCst) + 1;
         Ok(next.into())
     }
@@ -84,7 +86,7 @@ impl EthStorage for InMemoryStorage {
     // State operations
     // -------------------------------------------------------------------------
 
-    fn read_account(&self, address: &Address, point_in_time: &StoragePointInTime) -> anyhow::Result<Account> {
+    async fn read_account(&self, address: &Address, point_in_time: &StoragePointInTime) -> anyhow::Result<Account> {
         tracing::debug!(%address, "reading account");
 
         let state_lock = self.state.read().unwrap();
@@ -112,7 +114,7 @@ impl EthStorage for InMemoryStorage {
         }
     }
 
-    fn read_slot(&self, address: &Address, slot_index: &SlotIndex, point_in_time: &StoragePointInTime) -> anyhow::Result<Slot> {
+    async fn read_slot(&self, address: &Address, slot_index: &SlotIndex, point_in_time: &StoragePointInTime) -> anyhow::Result<Slot> {
         tracing::debug!(%address, %slot_index, ?point_in_time, "reading slot");
 
         let state_lock = self.state.read().unwrap();
@@ -137,7 +139,7 @@ impl EthStorage for InMemoryStorage {
         }
     }
 
-    fn read_block(&self, selection: &BlockSelection) -> anyhow::Result<Option<Block>> {
+    async fn read_block(&self, selection: &BlockSelection) -> anyhow::Result<Option<Block>> {
         tracing::debug!(?selection, "reading block");
 
         let state_lock = self.state.read().unwrap();
@@ -159,7 +161,7 @@ impl EthStorage for InMemoryStorage {
         }
     }
 
-    fn read_mined_transaction(&self, hash: &Hash) -> anyhow::Result<Option<TransactionMined>> {
+    async fn read_mined_transaction(&self, hash: &Hash) -> anyhow::Result<Option<TransactionMined>> {
         tracing::debug!(%hash, "reading transaction");
         let state_lock = self.state.read().unwrap();
 
@@ -175,7 +177,7 @@ impl EthStorage for InMemoryStorage {
         }
     }
 
-    fn read_logs(&self, filter: &LogFilter) -> anyhow::Result<Vec<LogMined>> {
+    async fn read_logs(&self, filter: &LogFilter) -> anyhow::Result<Vec<LogMined>> {
         tracing::debug!(?filter, "reading logs");
         let state_lock = self.state.read().unwrap();
 
@@ -193,7 +195,7 @@ impl EthStorage for InMemoryStorage {
         Ok(logs)
     }
 
-    fn save_block(&self, block: Block) -> anyhow::Result<()> {
+    async fn save_block(&self, block: Block) -> anyhow::Result<()> {
         let mut state_lock = self.state.write().unwrap();
 
         // save block

--- a/src/eth/storage/inmemory.rs
+++ b/src/eth/storage/inmemory.rs
@@ -5,8 +5,8 @@ use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::sync::RwLock;
 
+use async_trait::async_trait;
 use indexmap::IndexMap;
-use jsonrpsee::core::async_trait;
 
 use crate::eth::miner::BlockMiner;
 use crate::eth::primitives::Account;

--- a/src/eth/storage/metrified.rs
+++ b/src/eth/storage/metrified.rs
@@ -1,6 +1,5 @@
 use std::time::Instant;
 
-
 use async_trait::async_trait;
 
 use crate::eth::primitives::Account;

--- a/src/eth/storage/metrified.rs
+++ b/src/eth/storage/metrified.rs
@@ -1,5 +1,7 @@
 use std::time::Instant;
 
+use jsonrpsee::core::async_trait;
+
 use crate::eth::primitives::Account;
 use crate::eth::primitives::Address;
 use crate::eth::primitives::Block;
@@ -26,53 +28,54 @@ impl<T: EthStorage> MetrifiedStorage<T> {
     }
 }
 
+#[async_trait]
 impl<T: EthStorage> EthStorage for MetrifiedStorage<T> {
-    fn read_current_block_number(&self) -> anyhow::Result<BlockNumber> {
-        self.inner.read_current_block_number()
+    async fn read_current_block_number(&self) -> anyhow::Result<BlockNumber> {
+        self.inner.read_current_block_number().await
     }
 
-    fn increment_block_number(&self) -> anyhow::Result<BlockNumber> {
-        self.inner.increment_block_number()
+    async fn increment_block_number(&self) -> anyhow::Result<BlockNumber> {
+        self.inner.increment_block_number().await
     }
 
-    fn read_account(&self, address: &Address, point_in_time: &StoragePointInTime) -> anyhow::Result<Account> {
+    async fn read_account(&self, address: &Address, point_in_time: &StoragePointInTime) -> anyhow::Result<Account> {
         let start = Instant::now();
-        let result = self.inner.read_account(address, point_in_time);
+        let result = self.inner.read_account(address, point_in_time).await;
         metrics::inc_storage_accounts_read(start.elapsed(), point_in_time, result.is_ok());
         result
     }
 
-    fn read_slot(&self, address: &Address, slot: &SlotIndex, point_in_time: &StoragePointInTime) -> anyhow::Result<Slot> {
+    async fn read_slot(&self, address: &Address, slot: &SlotIndex, point_in_time: &StoragePointInTime) -> anyhow::Result<Slot> {
         let start = Instant::now();
-        let result = self.inner.read_slot(address, slot, point_in_time);
+        let result = self.inner.read_slot(address, slot, point_in_time).await;
         metrics::inc_storage_slots_read(start.elapsed(), point_in_time, result.is_ok());
         result
     }
 
-    fn read_block(&self, block_selection: &BlockSelection) -> anyhow::Result<Option<Block>> {
+    async fn read_block(&self, block_selection: &BlockSelection) -> anyhow::Result<Option<Block>> {
         let start = Instant::now();
-        let result = self.inner.read_block(block_selection);
+        let result = self.inner.read_block(block_selection).await;
         metrics::inc_storage_blocks_read(start.elapsed(), result.is_ok());
         result
     }
 
-    fn read_mined_transaction(&self, hash: &Hash) -> anyhow::Result<Option<TransactionMined>> {
+    async fn read_mined_transaction(&self, hash: &Hash) -> anyhow::Result<Option<TransactionMined>> {
         let start = Instant::now();
-        let result = self.inner.read_mined_transaction(hash);
+        let result = self.inner.read_mined_transaction(hash).await;
         metrics::inc_storage_transactions_read(start.elapsed(), result.is_ok());
         result
     }
 
-    fn read_logs(&self, filter: &LogFilter) -> anyhow::Result<Vec<LogMined>> {
+    async fn read_logs(&self, filter: &LogFilter) -> anyhow::Result<Vec<LogMined>> {
         let start = Instant::now();
-        let result = self.inner.read_logs(filter);
+        let result = self.inner.read_logs(filter).await;
         metrics::inc_storage_logs_read(start.elapsed(), result.is_ok());
         result
     }
 
-    fn save_block(&self, block: Block) -> anyhow::Result<()> {
+    async fn save_block(&self, block: Block) -> anyhow::Result<()> {
         let start = Instant::now();
-        let result = self.inner.save_block(block);
+        let result = self.inner.save_block(block).await;
         metrics::inc_storage_blocks_written(start.elapsed(), result.is_ok());
         result
     }

--- a/src/eth/storage/metrified.rs
+++ b/src/eth/storage/metrified.rs
@@ -1,6 +1,7 @@
 use std::time::Instant;
 
-use jsonrpsee::core::async_trait;
+
+use async_trait::async_trait;
 
 use crate::eth::primitives::Account;
 use crate::eth::primitives::Address;

--- a/src/eth/storage/postgres/postgres.rs
+++ b/src/eth/storage/postgres/postgres.rs
@@ -1,3 +1,5 @@
+use jsonrpsee::core::async_trait;
+
 use crate::eth::primitives::Account;
 use crate::eth::primitives::Address;
 use crate::eth::primitives::Block;
@@ -17,21 +19,21 @@ use crate::eth::storage::postgres::types::PostgresTransaction;
 use crate::eth::storage::EthStorage;
 use crate::infra::postgres::Postgres;
 
+#[async_trait]
 impl EthStorage for Postgres {
-    fn read_account(&self, address: &Address, point_in_time: &StoragePointInTime) -> anyhow::Result<Account> {
+    async fn read_account(&self, address: &Address, point_in_time: &StoragePointInTime) -> anyhow::Result<Account> {
         tracing::debug!(%address, "reading account");
 
-        let rt = tokio::runtime::Handle::current();
 
         // TODO: use HistoricalValue
         let block = match point_in_time {
-            StoragePointInTime::Present => self.read_current_block_number()?,
+            StoragePointInTime::Present => self.read_current_block_number().await?,
             StoragePointInTime::Past(number) => *number,
         };
 
         let block_number = i64::try_from(block)?;
 
-        let account = rt.block_on(async {
+        let account =
             sqlx::query_as!(
                 Account,
                 r#"
@@ -47,19 +49,17 @@ impl EthStorage for Postgres {
                 block_number,
             )
             .fetch_one(&self.connection_pool)
-            .await
-        })?;
+            .await?;
 
         Ok(account)
     }
-    fn read_slot(&self, address: &Address, slot_index: &SlotIndex, point_in_time: &StoragePointInTime) -> anyhow::Result<Slot> {
+    async fn read_slot(&self, address: &Address, slot_index: &SlotIndex, point_in_time: &StoragePointInTime) -> anyhow::Result<Slot> {
         tracing::debug!(%address, %slot_index, "reading slot");
 
-        let rt = tokio::runtime::Handle::current();
 
         // TODO: use HistoricalValue
         let block = match point_in_time {
-            StoragePointInTime::Present => self.read_current_block_number()?,
+            StoragePointInTime::Present => self.read_current_block_number().await?,
             StoragePointInTime::Past(number) => *number,
         };
 
@@ -68,7 +68,7 @@ impl EthStorage for Postgres {
         // TODO: improve this conversion
         let slot_index: [u8; 32] = slot_index.clone().into();
 
-        let slot = rt.block_on(async {
+        let slot =
             sqlx::query_as!(
                 Slot,
                 r#"
@@ -83,24 +83,20 @@ impl EthStorage for Postgres {
                 block_number,
             )
             .fetch_one(&self.connection_pool)
-            .await
-        })?;
+            .await?;
 
         Ok(slot)
     }
 
-    fn read_block(&self, block: &BlockSelection) -> anyhow::Result<Option<Block>> {
+    async fn read_block(&self, block: &BlockSelection) -> anyhow::Result<Option<Block>> {
         tracing::debug!(block = ?block, "reading block");
-
-        let rt = tokio::runtime::Handle::current();
 
         match block {
             BlockSelection::Latest => {
-                let current = self.read_current_block_number()?;
+                let current = self.read_current_block_number().await?;
 
                 let block_number = i64::try_from(current)?;
 
-                rt.block_on(async {
                     let _header = sqlx::query_as!(
                         BlockHeader,
                         r#"
@@ -116,13 +112,13 @@ impl EthStorage for Postgres {
                     "#,
                         block_number,
                     )
-                    .fetch_one(&self.connection_pool);
-                });
+                    .fetch_one(&self.connection_pool).await?;
+
 
                 todo!()
             }
             BlockSelection::Hash(hash) => {
-                rt.block_on(async {
+
                     let header_query = sqlx::query_as!(
                         BlockHeader,
                         r#"
@@ -212,14 +208,14 @@ impl EthStorage for Postgres {
                     // };
 
                     // Ok(block)
-                });
+
 
                 todo!()
             }
             BlockSelection::Number(number) => {
                 let block_number = i64::try_from(*number)?;
 
-                let _ = rt.block_on(async {
+                let _ =
                     sqlx::query_as!(
                         BlockHeader,
                         r#"
@@ -236,8 +232,7 @@ impl EthStorage for Postgres {
                         block_number,
                     )
                     .fetch_one(&self.connection_pool)
-                    .await
-                });
+                    .await;
             }
             BlockSelection::Earliest => {
                 todo!()
@@ -247,54 +242,48 @@ impl EthStorage for Postgres {
         todo!();
     }
 
-    fn read_mined_transaction(&self, hash: &Hash) -> anyhow::Result<Option<TransactionMined>> {
+    async fn read_mined_transaction(&self, hash: &Hash) -> anyhow::Result<Option<TransactionMined>> {
         tracing::debug!(%hash, "reading transaction");
         todo!()
     }
 
-    fn read_logs(&self, _: &LogFilter) -> anyhow::Result<Vec<LogMined>> {
+    async fn read_logs(&self, _: &LogFilter) -> anyhow::Result<Vec<LogMined>> {
         Ok(Vec::new())
     }
 
-    fn save_block(&self, block: Block) -> anyhow::Result<()> {
+    async fn save_block(&self, block: Block) -> anyhow::Result<()> {
         tracing::debug!(block = ?block, "saving block");
         todo!()
     }
 
-    fn read_current_block_number(&self) -> anyhow::Result<BlockNumber> {
+    async fn read_current_block_number(&self) -> anyhow::Result<BlockNumber> {
         tracing::debug!("reading current block number");
 
-        let rt = tokio::runtime::Handle::current();
-
-        let currval: i64 = rt.block_on(async {
+        let currval: i64 =
             sqlx::query_scalar!(
                 r#"
                         SELECT CURRVAL('block_number_seq') as "n!: _"
                     "#
             )
             .fetch_one(&self.connection_pool)
-            .await
-        })?;
+            .await?;
 
         let block_number = BlockNumber::from(currval);
 
         Ok(block_number)
     }
 
-    fn increment_block_number(&self) -> anyhow::Result<BlockNumber> {
+    async fn increment_block_number(&self) -> anyhow::Result<BlockNumber> {
         tracing::debug!("incrementing block number");
 
-        let rt = tokio::runtime::Handle::current();
-
-        let nextval: i64 = rt.block_on(async {
+        let nextval: i64 =
             sqlx::query_scalar!(
                 r#"
                         SELECT NEXTVAL('block_number_seq') as "n!: _"
                     "#
             )
             .fetch_one(&self.connection_pool)
-            .await
-        })?;
+            .await?;
 
         let block_number = BlockNumber::from(nextval);
 

--- a/src/eth/storage/postgres/postgres.rs
+++ b/src/eth/storage/postgres/postgres.rs
@@ -1,4 +1,3 @@
-
 use async_trait::async_trait;
 
 use crate::eth::primitives::Account;

--- a/src/eth/storage/postgres/postgres.rs
+++ b/src/eth/storage/postgres/postgres.rs
@@ -1,4 +1,5 @@
-use jsonrpsee::core::async_trait;
+
+use async_trait::async_trait;
 
 use crate::eth::primitives::Account;
 use crate::eth::primitives::Address;


### PR DESCRIPTION
Note that in the file `src/eth/executor.rs` in the functions `EthExecutor::transact` and `EthExecutor::call`, I aquire the `evm_lock`, do nothing with it, and then create a new `Revm` object and pass that to `spawn_blocking`. There are two ways that I thought of to circumvent this, but I'd like further discussion before implementing either of them.

1. Run the EVM in a dedicated thread (instead of spawning a thread for each call) with some form of communication, maybe a channel or queue.
2. Require `Clone` for `EthStorage` and `Evm`. Then I could aquire the lock and clone the underlying struct. However implementing clone for dyn traits is not trivial, to solve this there is a popular crate that includes a macro for it (https://github.com/dtolnay/dyn-clone).

Are either of these approaches desirable at this time?