### PR TITLE
feat: use rayon threadpool to run evms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,19 +160,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
-name = "async-channel"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ca33f4bc4ed1babef42cad36cc1f51fa88be00420404e5b1e80ab1b18f7678c"
-dependencies = [
- "concurrent-queue",
- "event-listener 4.0.3",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -519,15 +506,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
-name = "concurrent-queue"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16048cd947b08fa32c24458a22f5dc5e835264f689f4f5653210c69fd107363"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "const-hex"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -581,6 +559,25 @@ name = "crc-catalog"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "176dc175b78f56c0f321911d9c8eb2b77a78a4860b9c19db83835fea1a46649b"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "crossbeam-epoch"
@@ -944,27 +941,6 @@ name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
-
-[[package]]
-name = "event-listener"
-version = "4.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b215c49b2b248c855fb73579eb1f4f26c38ffdc12973e20e07b91d78d5646e"
-dependencies = [
- "concurrent-queue",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener-strategy"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3"
-dependencies = [
- "event-listener 4.0.3",
- "pin-project-lite",
-]
 
 [[package]]
 name = "fake"
@@ -2027,12 +2003,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
-
-[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2381,6 +2351,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c297679cb867470fa8c9f67dbba74a78d78e3e98d7cf2b08d6d71540f797332"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "rayon"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7237101a77a10773db45d62004a272517633fbcc3df19d96455ede1122e051"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -2971,7 +2961,7 @@ dependencies = [
  "crossbeam-queue",
  "dotenvy",
  "either",
- "event-listener 2.5.3",
+ "event-listener",
  "futures-channel",
  "futures-core",
  "futures-intrusive",
@@ -3159,12 +3149,12 @@ name = "stratus"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-channel",
  "async-trait",
  "binary_macros",
  "chrono",
  "clap",
  "const-hex",
+ "crossbeam-channel",
  "dashmap",
  "derive-new",
  "derive_more",
@@ -3172,6 +3162,7 @@ dependencies = [
  "ethereum-types",
  "ethers-core",
  "fake",
+ "futures",
  "glob",
  "hex-literal",
  "indexmap 2.1.0",
@@ -3187,6 +3178,7 @@ dependencies = [
  "phf_codegen",
  "pin-project",
  "quote",
+ "rayon",
  "revm",
  "rlp",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,9 @@ triehash = "0.8.4"
 clap = { version = "4.4.18", features = ["derive", "env"] }
 anyhow = "1.0.79"
 async-trait = "0.1.77"
-async-channel = "2.1.1"
+rayon = "1.8.1"
+crossbeam-channel = "0.5.11"
+futures = "0.3.30"
 
 [dev-dependencies]
 binary_macros = "1.0.0"

--- a/src/eth/evm/revm.rs
+++ b/src/eth/evm/revm.rs
@@ -21,7 +21,6 @@ use revm::primitives::U256;
 use revm::Database;
 use revm::Inspector;
 use revm::EVM;
-use tokio::runtime::Handle;
 
 use crate::eth::evm::Evm;
 use crate::eth::evm::EvmInput;
@@ -147,7 +146,7 @@ impl Database for RevmDatabaseSession {
     fn basic(&mut self, revm_address: RevmAddress) -> anyhow::Result<Option<AccountInfo>> {
         // retrieve account
         let address: Address = revm_address.into();
-        let account = Handle::current().block_on(self.storage.read_account(&address, &self.storage_point_in_time))?;
+        let account = futures::executor::block_on(self.storage.read_account(&address, &self.storage_point_in_time))?;
 
         // warn if the loaded account is the `to` account and it does not have a bytecode
         if let Some(ref to_address) = self.to {
@@ -173,7 +172,7 @@ impl Database for RevmDatabaseSession {
         // retrieve slot
         let address: Address = revm_address.into();
         let index: SlotIndex = revm_index.into();
-        let slot = Handle::current().block_on(self.storage.read_slot(&address, &index, &self.storage_point_in_time))?;
+        let slot = futures::executor::block_on(self.storage.read_slot(&address, &index, &self.storage_point_in_time))?;
 
         // track original value
         match self.storage_changes.get_mut(&address) {

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -4,11 +4,6 @@
 // Macros
 // -----------------------------------------------------------------------------
 
-use std::time::Duration;
-
-use tokio::runtime::Builder;
-use tokio::runtime::Runtime;
-
 /// Generates [`From`] implementation for a [newtype](https://doc.rust-lang.org/rust-by-example/generics/new_types.html) that delegates to the inner type [`From`].
 #[macro_export]
 macro_rules! gen_newtype_from {
@@ -48,22 +43,6 @@ macro_rules! if_else {
             $_false
         }
     };
-}
-
-// -----------------------------------------------------------------------------
-// Tokio
-// -----------------------------------------------------------------------------
-
-/// Creates a new Tokio runtime with the specified configuration.
-pub fn new_tokio_runtime(thread_name: &'static str, num_async_threads: usize, num_blocking_threads: usize) -> Runtime {
-    Builder::new_multi_thread()
-        .enable_all()
-        .thread_name(thread_name)
-        .worker_threads(num_async_threads)
-        .max_blocking_threads(num_blocking_threads)
-        .thread_keep_alive(Duration::from_secs(u64::MAX))
-        .build()
-        .expect("failed to build tokio runtime")
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
* Tokio nested runtimes are not allowed, so use a Rayon thread-pool instead.
* Use crossbeam-channel instead of async-channel because Rayon is not async.
* Use `futures::executor::block_on` instead of `tokio::block_on` inside EVM because Tokio runtime is not available for EVM execution. It just blocks on the current thread, that is the desired behavior.
* Stop EVM threads when task channel is closed.