### PR TITLE
test: add action to run e2e-stratus

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -1,0 +1,39 @@
+name: E2E Tests
+
+on:
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  e2e-stratus:
+    name: Stratus e2e tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Rust
+        run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+
+      - name: Set up Just
+        uses: extractions/setup-just@v1
+
+      - name: Set up ASDF Version Manager
+        uses: asdf-vm/actions/setup@v3
+
+      - name: Install Node.js
+        run: |
+            asdf plugin add nodejs https://github.com/asdf-vm/asdf-nodejs.git
+            asdf install nodejs 20.10.0
+            asdf global nodejs 20.10.0
+
+      - name: Set up Test Dependencies
+        run: |
+            cargo install killport
+            cargo install wait-service
+
+      - name: Run e2e tests
+        run: just e2e-stratus no-kill

--- a/justfile
+++ b/justfile
@@ -147,10 +147,10 @@ e2e-stratus:
     fi
 
     echo "-> Starting Stratus"
-    RUST_LOG=info just run &
+    RUST_LOG=info just run -r 0.0.0.0:3000 &
 
     echo "-> Waiting Stratus to start"
-    wait-service --tcp localhost:3000 -- echo
+    wait-service --tcp 0.0.0.0:3000 -- echo
 
     echo "-> Running E2E tests"
     just e2e stratus

--- a/justfile
+++ b/justfile
@@ -147,7 +147,7 @@ e2e-stratus:
     fi
 
     echo "-> Starting Stratus"
-    RUST_LOG=info just run -r 0.0.0.0:3000 &
+    RUST_LOG=info just run -a 0.0.0.0:3000 &
 
     echo "-> Waiting Stratus to start"
     wait-service --tcp 0.0.0.0:3000 -t 300 -- echo

--- a/justfile
+++ b/justfile
@@ -140,7 +140,7 @@ e2e-hardhat:
     killport 8545
 
 # E2E: Starts and execute Hardhat tests in Stratus
-e2e-stratus:
+e2e-stratus no-kill="":
     #!/bin/bash
     if [ -d e2e ]; then
         cd e2e
@@ -154,6 +154,9 @@ e2e-stratus:
 
     echo "-> Running E2E tests"
     just e2e stratus
+
+    # Do not kill Stratus if no-kill is set
+    [ "{{no-kill}}" ] && exit 0
 
     echo "-> Killing Stratus"
     killport 3000

--- a/justfile
+++ b/justfile
@@ -150,7 +150,7 @@ e2e-stratus:
     RUST_LOG=info just run -r 0.0.0.0:3000 &
 
     echo "-> Waiting Stratus to start"
-    wait-service --tcp 0.0.0.0:3000 -- echo
+    wait-service --tcp 0.0.0.0:3000 -t 300 -- echo
 
     echo "-> Running E2E tests"
     just e2e stratus


### PR DESCRIPTION
### Changes

The following changes were necessary/convenient to run the test in Github Actions

- hardcode the address in the justfile
- make killport run optional
- increase timeout for wait-service

The action is already checking this PR.

obs: in another PR I'll change the way we clone contracts so we can `just setup` in the actions too.