### PR TITLE
fix: tokio runtime available to spawned threads. also remove rayon.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -570,16 +570,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-deque"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2354,26 +2344,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rayon"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7237101a77a10773db45d62004a272517633fbcc3df19d96455ede1122e051"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3162,7 +3132,6 @@ dependencies = [
  "ethereum-types",
  "ethers-core",
  "fake",
- "futures",
  "glob",
  "hex-literal",
  "indexmap 2.1.0",
@@ -3178,7 +3147,6 @@ dependencies = [
  "phf_codegen",
  "pin-project",
  "quote",
- "rayon",
  "revm",
  "rlp",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,9 +40,7 @@ triehash = "0.8.4"
 clap = { version = "4.4.18", features = ["derive", "env"] }
 anyhow = "1.0.79"
 async-trait = "0.1.77"
-rayon = "1.8.1"
 crossbeam-channel = "0.5.11"
-futures = "0.3.30"
 
 [dev-dependencies]
 binary_macros = "1.0.0"

--- a/src/eth/evm/revm.rs
+++ b/src/eth/evm/revm.rs
@@ -21,6 +21,7 @@ use revm::primitives::U256;
 use revm::Database;
 use revm::Inspector;
 use revm::EVM;
+use tokio::runtime::Handle;
 
 use crate::eth::evm::Evm;
 use crate::eth::evm::EvmInput;
@@ -146,7 +147,7 @@ impl Database for RevmDatabaseSession {
     fn basic(&mut self, revm_address: RevmAddress) -> anyhow::Result<Option<AccountInfo>> {
         // retrieve account
         let address: Address = revm_address.into();
-        let account = futures::executor::block_on(self.storage.read_account(&address, &self.storage_point_in_time))?;
+        let account = Handle::current().block_on(self.storage.read_account(&address, &self.storage_point_in_time))?;
 
         // warn if the loaded account is the `to` account and it does not have a bytecode
         if let Some(ref to_address) = self.to {
@@ -172,7 +173,7 @@ impl Database for RevmDatabaseSession {
         // retrieve slot
         let address: Address = revm_address.into();
         let index: SlotIndex = revm_index.into();
-        let slot = futures::executor::block_on(self.storage.read_slot(&address, &index, &self.storage_point_in_time))?;
+        let slot = Handle::current().block_on(self.storage.read_slot(&address, &index, &self.storage_point_in_time))?;
 
         // track original value
         match self.storage_changes.get_mut(&address) {

--- a/src/eth/storage/inmemory.rs
+++ b/src/eth/storage/inmemory.rs
@@ -98,7 +98,7 @@ impl EthStorage for InMemoryStorage {
 
     // -------------------------------------------------------------------------
     // State operations
-    // -------------------------------------------------------------------------
+    // ------------------------------------------------------------------------
 
     async fn read_account(&self, address: &Address, point_in_time: &StoragePointInTime) -> anyhow::Result<Account> {
         tracing::debug!(%address, "reading account");

--- a/src/infra/tracing.rs
+++ b/src/infra/tracing.rs
@@ -12,6 +12,8 @@ pub fn init_tracing() {
     tracing_subscriber::fmt()
         .compact()
         .with_target(false)
+        .with_thread_ids(true)
+        .with_thread_names(true)
         .with_env_filter(EnvFilter::from_default_env())
         .try_init()
         .expect("Tracing initialization failed");

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ fn main() -> anyhow::Result<()> {
 pub fn init_async_runtime() -> Runtime {
     Builder::new_multi_thread()
         .enable_all()
+        .thread_name("tokio")
         .worker_threads(1)
         .max_blocking_threads(1)
         .thread_keep_alive(Duration::from_secs(u64::MAX))


### PR DESCRIPTION
* EVM threads will have Tokio runtime available, so SQLx should not panic anymore.
* Removed rayon in favor of spawning native threads.