### PR TITLE
test: add concurrency management to actions

### DIFF
--- a/.github/workflows/doc-test.yml
+++ b/.github/workflows/doc-test.yml
@@ -11,6 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/doc-test.yml
+++ b/.github/workflows/doc-test.yml
@@ -6,7 +6,7 @@ on:
       - '*'
 
 jobs:
-  unit_tests:
+  doc_unit_tests:
     name: Documentation Unit Tests
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -11,6 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/lint-check.yml
+++ b/.github/workflows/lint-check.yml
@@ -11,6 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -11,6 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
### Changes

- Set a concurrency rule to cancel in-progress runs if a commit is made to the same pull request
- Fix doc test job name (it wasn't unique)

With that, we might save resources by not completing runs that will no longer be useful