### PR TITLE
feat: debug_setHead

### DIFF
--- a/e2e/test/e2e.test.ts
+++ b/e2e/test/e2e.test.ts
@@ -31,9 +31,18 @@ const CONTRACT_TOPIC_SUB = "0xf9c652bcdb0eed6299c6a878897eb3af110dbb265833e7af75
 // RPC tests
 // -----------------------------------------------------------------------------
 describe("JSON-RPC methods", () => {
+    describe("State", () => {
+        it("debug_setHead", async () => {
+            (await rpc.sendExpect("debug_setHead", [ZERO])).eq(ZERO);
+        });
+    });
+
     describe("Metadata", () => {
         it("eth_chainId", async () => {
             (await rpc.sendExpect("eth_chainId")).eq(CHAIN_ID);
+        });
+        it("net_listening", async () => {
+            (await rpc.sendExpect("net_listening")).eq("true");
         });
         it("net_version", async () => {
             (await rpc.sendExpect("net_version")).eq(CHAIN_ID_DEC + "");
@@ -83,6 +92,9 @@ describe("Transaction: wei transfer", () => {
     var _txHash: string;
     var _block: Block;
 
+    it("Resets blockchain", async () => {
+        await rpc.reset();
+    });
     it("Send transaction", async () => {
         let txSigned = await ALICE.signer().signTransaction({
             chainId: CHAIN_ID_DEC,
@@ -138,6 +150,9 @@ describe("Transaction: serial requests", () => {
     var _contract: TestContractBalances;
     var _block: number;
 
+    it("Resets blockchain", async () => {
+        await rpc.reset();
+    });
     it("Contract is deployed", async () => {
         _contract = await rpc.deployTestContractBalances();
     });
@@ -197,6 +212,11 @@ describe("Transaction: serial requests", () => {
 // -----------------------------------------------------------------------------
 describe("Transaction: TestContractBalances", async () => {
     var _contract: TestContractBalances;
+
+    it("Resets blockchain", async () => {
+        await rpc.reset();
+    });
+
     it("Deploy TestContractBalances", async () => {
         _contract = await rpc.deployTestContractBalances();
     });
@@ -252,6 +272,11 @@ describe("Transaction: TestContractBalances", async () => {
 
 describe("Transaction: TestContractCounter", async () => {
     var _contract: TestContractCounter;
+
+    it("Resets blockchain", async () => {
+        await rpc.reset();
+    });
+
     it("Deploy TestContractCounter", async () => {
         _contract = await rpc.deployTestContractCounter();
     });

--- a/e2e/test/helpers/rpc.ts
+++ b/e2e/test/helpers/rpc.ts
@@ -117,9 +117,14 @@ export function calculateAddressStoragePosition(address: string, slot: number): 
 // RPC methods wrappers
 // -----------------------------------------------------------------------------
 
-/// Retrieves the current nonce of an account.
+/// Sends a signed transaction to the blockchain.
 export async function sendRawTransaction(signed: string): Promise<string> {
     return await send("eth_sendRawTransaction", [signed]);
+}
+
+/// Resets the blockchain state to the specified block number.
+export async function reset(blockNumber: number = 0): Promise<void> {
+    await send("debug_setHead", [toHex(blockNumber)]);
 }
 
 /// Retrieves the current nonce of an account.

--- a/src/eth/primitives/block_number.rs
+++ b/src/eth/primitives/block_number.rs
@@ -86,6 +86,12 @@ impl From<BlockNumber> for U64 {
     }
 }
 
+impl From<BlockNumber> for u64 {
+    fn from(block_number: BlockNumber) -> Self {
+        block_number.0.as_u64()
+    }
+}
+
 impl TryFrom<BlockNumber> for i64 {
     type Error = TryFromIntError;
 

--- a/src/eth/storage/eth_storage.rs
+++ b/src/eth/storage/eth_storage.rs
@@ -58,6 +58,9 @@ pub trait EthStorage: Send + Sync {
     /// Persist atomically all changes from a block.
     async fn save_block(&self, block: Block) -> anyhow::Result<(), EthStorageError>;
 
+    /// Resets all state to a specific block number.
+    async fn reset(&self, number: BlockNumber) -> anyhow::Result<()>;
+
     // -------------------------------------------------------------------------
     // Default operations
     // -------------------------------------------------------------------------

--- a/src/eth/storage/metrified.rs
+++ b/src/eth/storage/metrified.rs
@@ -89,4 +89,9 @@ impl<T: EthStorage> EthStorage for MetrifiedStorage<T> {
         metrics::inc_storage_blocks_written(start.elapsed(), result.is_ok());
         result
     }
+
+    // TODO: track metric
+    async fn reset(&self, number: BlockNumber) -> anyhow::Result<()> {
+        self.inner.reset(number).await
+    }
 }

--- a/src/eth/storage/postgres/postgres.rs
+++ b/src/eth/storage/postgres/postgres.rs
@@ -557,6 +557,11 @@ impl EthStorage for Postgres {
 
         Ok(block_number)
     }
+
+    /// TODO
+    async fn reset(&self, _number: BlockNumber) -> anyhow::Result<()> {
+        Ok(())
+    }
 }
 
 fn partition_logs(logs: impl IntoIterator<Item = PostgresLog>) -> HashMap<Hash, Vec<PostgresLog>> {


### PR DESCRIPTION
Implements `debug_setHead`. It allows resetting the blockchain entire state to a past block.

Like other functions like `test_accounts`, this method should be put behind a future-flag in the future to avoid destructive actions in production.