### PR TITLE
test: creating test scenario for parallel wei transfer

### DIFF
--- a/e2e/test/e2e-json-rpc.test.ts
+++ b/e2e/test/e2e-json-rpc.test.ts
@@ -4,7 +4,7 @@ import { Block, Transaction, TransactionReceipt } from "web3-types";
 
 import { ALICE } from "./helpers/account";
 import { CURRENT_NETWORK, Network } from "./helpers/network";
-import { CHAIN_ID, CHAIN_ID_DEC, ZERO, send, sendExpect } from "./helpers/rpc";
+import { CHAIN_ID, CHAIN_ID_DEC, MAX, ZERO, send, sendExpect } from "./helpers/rpc";
 
 describe("JSON-RPC", () => {
     describe("State", () => {
@@ -42,6 +42,10 @@ describe("JSON-RPC", () => {
         it("eth_getTransactionCount", async () => {
             (await sendExpect("eth_getTransactionCount", [ALICE])).eq(ZERO);
             (await sendExpect("eth_getTransactionCount", [ALICE, "latest"])).eq(ZERO);
+        });
+        it("eth_getBalance", async () => {
+            (await sendExpect("eth_getBalance", [ALICE])).eq(MAX);
+            (await sendExpect("eth_getBalance", [ALICE, "latest"])).eq(MAX);
         });
     });
 

--- a/e2e/test/e2e-tx-parallel-transfer.test.ts
+++ b/e2e/test/e2e-tx-parallel-transfer.test.ts
@@ -1,0 +1,35 @@
+import { expect } from "chai";
+
+import { TEST_ACCOUNTS, randomAccounts } from "./helpers/account";
+import { sendGetBalance, sendRawTransactions, sendReset } from "./helpers/rpc";
+
+describe("Transaction: parallel transfer", () => {
+    it("Resets blockchain", async () => {
+        await sendReset();
+    });
+    it("Sends parallel requests", async () => {
+        const counterParty = randomAccounts(1)[0];
+        expect(await sendGetBalance(counterParty.address)).eq(0);
+
+        // sign transactions from accounts that have balance
+        let expectedCounterPartyBalance = 0;
+        const signedTxs = [];
+        for (let i = 0; i < TEST_ACCOUNTS.length; i++) {
+            const amount = i + 1;
+            const account = TEST_ACCOUNTS[i];
+            signedTxs.push(await account.signWeiTransfer(counterParty.address, amount));
+            expectedCounterPartyBalance += amount;
+        }
+
+        // sign transaction from accounts that have no balance
+        for (const account of randomAccounts(100)) {
+            signedTxs.push(await account.signWeiTransfer(counterParty.address, 0));
+        }
+
+        // send transactions in parallel
+        await sendRawTransactions(signedTxs);
+
+        // verify
+        expect(await sendGetBalance(counterParty.address)).eq(expectedCounterPartyBalance);
+    });
+});

--- a/e2e/test/e2e-tx-serial-transfer.test.ts
+++ b/e2e/test/e2e-tx-serial-transfer.test.ts
@@ -24,13 +24,7 @@ describe("Transaction: serial transfer", () => {
         await sendReset();
     });
     it("Send transaction", async () => {
-        let txSigned = await ALICE.signer().signTransaction({
-            chainId: CHAIN_ID_DEC,
-            to: BOB,
-            value: 0,
-            gasPrice: 0,
-            gasLimit: 500_000,
-        });
+        let txSigned = await ALICE.signWeiTransfer(BOB.address, 0);
         _txHash = await sendRawTransaction(txSigned);
         expect(_txHash).eq(keccak256(txSigned));
     });

--- a/e2e/test/helpers/account.ts
+++ b/e2e/test/helpers/account.ts
@@ -1,6 +1,6 @@
 import { Addressable, Signer, Wallet } from "ethers";
 
-import { ETHERJS } from "./rpc";
+import { CHAIN_ID_DEC, ETHERJS } from "./rpc";
 
 export class Account implements Addressable {
     constructor(
@@ -14,6 +14,16 @@ export class Account implements Addressable {
 
     signer(): Signer {
         return new Wallet(this.privateKey, ETHERJS);
+    }
+
+    async signWeiTransfer(counterParty: string, amount: number): Promise<string> {
+        return await this.signer().signTransaction({
+            to: counterParty,
+            value: amount,
+            chainId: CHAIN_ID_DEC,
+            gasPrice: 0,
+            gasLimit: 1_000_000,
+        });
     }
 }
 
@@ -46,6 +56,8 @@ export const FERDIE = new Account(
     "0x976EA74026E726554dB657fA54763abd0C3a0aa9",
     "0x92db14e403b83dfe3df233f83dfa3a0d7096f21ca9b0d6d6b8d88b2b4ec1564e",
 );
+
+export const TEST_ACCOUNTS = [ALICE, BOB, CHARLIE, DAVE, EVE, FERDIE];
 
 /// Generates N random accounts.
 export function randomAccounts(n: number): Account[] {

--- a/e2e/test/helpers/rpc.ts
+++ b/e2e/test/helpers/rpc.ts
@@ -17,6 +17,7 @@ export const CHAIN_ID = toHex(CHAIN_ID_DEC);
 // Special numbers
 export const ZERO = "0x0";
 export const ONE = "0x1";
+export const MAX = "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
 
 // Special hashes
 export const HASH_EMPTY_UNCLES = "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347";
@@ -131,9 +132,23 @@ export function calculateSlotPosition(address: string, slot: number): string {
 // RPC methods wrappers
 // -----------------------------------------------------------------------------
 
-/// Sends a signed transaction to the blockchain.
+/// Sends a single signed transaction.
 export async function sendRawTransaction(signed: string): Promise<string> {
     return await send("eth_sendRawTransaction", [signed]);
+}
+
+/// Sends multiple signed transactions in parallel.
+export async function sendRawTransactions(signedTxs: string[]): Promise<string[]> {
+    // shuffle
+    signedTxs.sort(() => Math.random() - 0.5);
+
+    // send
+    const txHashes = [];
+    for (const signedTx of signedTxs) {
+        const txHash = sendRawTransaction(signedTx);
+        txHashes.push(txHash);
+    }
+    return Promise.all(txHashes);
 }
 
 /// Resets the blockchain state to the specified block number.
@@ -142,7 +157,13 @@ export async function sendReset(blockNumber: number = 0): Promise<void> {
 }
 
 /// Retrieves the current nonce of an account.
-export async function sendGetNonce(address: string): Promise<number> {
+export async function sendGetBalance(address: string | Account): Promise<number> {
+    const result = await send("eth_getBalance", [address]);
+    return parseInt(result, 16);
+}
+
+/// Retrieves the current nonce of an account.
+export async function sendGetNonce(address: string | Account): Promise<number> {
     const result = await send("eth_getTransactionCount", [address]);
     return parseInt(result, 16);
 }

--- a/justfile
+++ b/justfile
@@ -92,8 +92,6 @@ test-unit name="":
 test-int name="":
     cargo test --test '*' {{name}} -- --nocapture
 
-
-
 # ------------------------------------------------------------------------------
 # E2E tasks
 # ------------------------------------------------------------------------------
@@ -111,7 +109,7 @@ e2e network="stratus" test="":
     if [ -z "{{test}}" ]; then
         npx hardhat test test/*.test.ts --network {{network}}
     else
-        npx hardhat test test/*.test.ts --network {{network}} --grep {{test}}
+        npx hardhat test test/*.test.ts --network {{network}} --grep "{{test}}"
     fi
 
 # E2E: Starts and execute Hardhat tests in Anvil

--- a/src/eth/primitives/address.rs
+++ b/src/eth/primitives/address.rs
@@ -43,14 +43,22 @@ impl Address {
         Self(H160(bytes))
     }
 
-    /// Check if current address is the zero address.
+    /// Checks if current address is the zero address.
     pub fn is_zero(&self) -> bool {
         self == &Self::ZERO
     }
 
-    /// Check if current address is the coinbase address.
+    /// Checks if current address is the coinbase address.
     pub fn is_coinbase(&self) -> bool {
         self == &Self::COINBASE
+    }
+
+    /// Checks if current address should have their updates ignored.
+    ///
+    /// * Coinbase is ignored because we do not charge gas, otherwise it will have to be updated for every transaction.
+    /// * Not sure if zero address should be ignored or not.
+    pub fn is_ignored(&self) -> bool {
+        self.is_coinbase() || self.is_zero()
     }
 }
 

--- a/src/eth/primitives/execution_conflict.rs
+++ b/src/eth/primitives/execution_conflict.rs
@@ -33,6 +33,7 @@ impl ExecutionConflictsBuilder {
         });
     }
 
+    /// Builds the list of tracked conflicts into a non-empty list of conflicts.
     pub fn build(self) -> Option<ExecutionConflicts> {
         if self.0.is_empty() {
             None
@@ -42,7 +43,7 @@ impl ExecutionConflictsBuilder {
     }
 }
 
-#[derive(Debug, derive_new::new)]
+#[derive(Debug)]
 pub enum ExecutionConflict {
     /// Account nonce mismatch.
     Nonce { address: Address, expected: Nonce, actual: Nonce },

--- a/src/eth/storage/eth_storage.rs
+++ b/src/eth/storage/eth_storage.rs
@@ -108,6 +108,8 @@ pub fn test_accounts() -> Vec<Account> {
         hex!("70997970c51812dc3a010c7d01b50e0d17dc79c8"),
         hex!("3c44cdddb6a900fa2b585dd299e03d12fa4293bc"),
         hex!("15d34aaf54267db7d7c367839aaf71a00a2c6a65"),
+        hex!("9965507d1a55bcc2695c58ba16fb37d819b0a4dc"),
+        hex!("976ea74026e726554db657fa54763abd0c3a0aa9"),
     ]
     .into_iter()
     .map(|address| Account {

--- a/src/eth/storage/inmemory/inmemory.rs
+++ b/src/eth/storage/inmemory/inmemory.rs
@@ -326,38 +326,29 @@ fn check_conflicts(state: &InMemoryStorageState, execution: &Execution) -> Optio
     for change in &execution.changes {
         let address = &change.address;
 
-        match state.accounts.get(address) {
-            Some(account) => {
-                // check account info conflicts
-                if let Some(touched_nonce) = change.nonce.take_original_ref() {
-                    if touched_nonce != account.nonce.get_current_ref() {
-                        conflicts.add_nonce(address.clone(), account.nonce.get_current(), touched_nonce.clone());
-                    }
+        if let Some(account) = state.accounts.get(address) {
+            // check account info conflicts
+            if let Some(touched_nonce) = change.nonce.take_original_ref() {
+                if touched_nonce != account.nonce.get_current_ref() {
+                    conflicts.add_nonce(address.clone(), account.nonce.get_current(), touched_nonce.clone());
                 }
-                if let Some(touched_balance) = change.balance.take_original_ref() {
-                    if touched_balance != account.balance.get_current_ref() {
-                        conflicts.add_balance(address.clone(), account.balance.get_current(), touched_balance.clone());
-                    }
+            }
+            if let Some(touched_balance) = change.balance.take_original_ref() {
+                if touched_balance != account.balance.get_current_ref() {
+                    conflicts.add_balance(address.clone(), account.balance.get_current(), touched_balance.clone());
                 }
+            }
 
-                // check slots conflicts
-                for (touched_slot_index, touched_slot) in &change.slots {
-                    match account.slots.get(touched_slot_index) {
-                        Some(slot) =>
-                            if let Some(touched_slot) = touched_slot.take_original_ref() {
-                                let slot_value = slot.get_current().value;
-                                if touched_slot.value != slot_value {
-                                    conflicts.add_slot(address.clone(), touched_slot_index.clone(), slot_value, touched_slot.value.clone());
-                                }
-                            },
-                        None => {
-                            // todo: handle slot creation conflict
+            // check slots conflicts
+            for (touched_slot_index, touched_slot) in &change.slots {
+                if let Some(slot) = account.slots.get(touched_slot_index) {
+                    if let Some(touched_slot) = touched_slot.take_original_ref() {
+                        let slot_value = slot.get_current().value;
+                        if touched_slot.value != slot_value {
+                            conflicts.add_slot(address.clone(), touched_slot_index.clone(), slot_value, touched_slot.value.clone());
                         }
                     }
                 }
-            }
-            None => {
-                // todo: handle account creation conflicts
             }
         }
     }


### PR DESCRIPTION
* Created test that sends paralell wei transfer.
* Created utilities for E2E like `sendRawTransactions` that sends multiple transactions in parallel.
* Do not track changes to special accounts like ZERO and COINBASE.
* Removed TODOs from change detection code in InMemory.