### PR TITLE
fix: Add cmake into Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY Cargo.toml /app/Cargo.toml
 COPY Cargo.lock /app/Cargo.lock
 
 RUN apt update
-RUN apt-get install -y libclang-dev
+RUN apt-get install -y libclang-dev cmake
 
 RUN cargo build --release
 


### PR DESCRIPTION
 44.88   failed to execute command: No such file or directory (os error 2)
 44.88   is `cmake` not installed?
 44.88
 44.88   build script failed, must exit now
 44.88   note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 44.88 warning: build failed, waiting for other jobs to finish...

