### PR TITLE
chore: add import call into rpc server poller

### DIFF
--- a/src/bin/rpc_server_poller.rs
+++ b/src/bin/rpc_server_poller.rs
@@ -23,7 +23,7 @@ async fn main() -> anyhow::Result<()> {
     init_tracing();
     let config = Config::parse();
 
-    let rpc_url = config.extra.clone().unwrap();
+    let rpc_url = config.external_rpc.clone().unwrap();
     let chain = Arc::new(BlockchainClient::new(&rpc_url, Duration::from_secs(1))?);
 
     // TODO instead of gathering the current block all the time, we should track the first block and just keep polling onwards aggregating by 1

--- a/src/bin/rpc_server_poller.rs
+++ b/src/bin/rpc_server_poller.rs
@@ -2,15 +2,15 @@ use std::env;
 use std::sync::Arc;
 use std::time::Duration;
 
-use clap::Parser;
 use anyhow::anyhow;
 use anyhow::Context;
+use clap::Parser;
 use hex_literal::hex;
 use stratus::config::Config;
-use stratus::eth::EthExecutor;
 use stratus::eth::primitives::Address;
 use stratus::eth::primitives::BlockNumber;
 use stratus::eth::primitives::Hash;
+use stratus::eth::EthExecutor;
 use stratus::infra::init_tracing;
 use stratus::infra::BlockchainClient;
 use tokio::time::sleep;
@@ -42,7 +42,6 @@ async fn main() -> anyhow::Result<()> {
         let receipt_json = serde_json::to_string(&receipt)?;
         tracing::info!("receipt_json: {:?}", receipt_json);
         let ethers_core_receipts = stratus::eth::sync_parser::parse_receipt(vec![&receipt_json])?;
-
 
         let storage = config.init_storage().await?;
         let evms = config.init_evms(Arc::clone(&storage));

--- a/src/bin/rpc_server_poller.rs
+++ b/src/bin/rpc_server_poller.rs
@@ -2,9 +2,15 @@ use std::env;
 use std::sync::Arc;
 use std::time::Duration;
 
+use clap::Parser;
 use anyhow::anyhow;
 use anyhow::Context;
+use hex_literal::hex;
+use stratus::config::Config;
+use stratus::eth::EthExecutor;
+use stratus::eth::primitives::Address;
 use stratus::eth::primitives::BlockNumber;
+use stratus::eth::primitives::Hash;
 use stratus::infra::init_tracing;
 use stratus::infra::BlockchainClient;
 use tokio::time::sleep;
@@ -15,21 +21,34 @@ const POLL_LATENCY: Duration = Duration::from_secs(1);
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> anyhow::Result<()> {
     init_tracing();
+    let config = Config::parse();
 
-    let Some(rpc_url) = env::args().nth(1) else {
-        return Err(anyhow!("rpc url not provided as argument"));
-    };
-
+    let rpc_url = config.extra.clone().unwrap();
     let chain = Arc::new(BlockchainClient::new(&rpc_url, Duration::from_secs(1))?);
 
     // TODO instead of gathering the current block all the time, we should track the first block and just keep polling onwards aggregating by 1
     loop {
         tracing::debug!("polling for new blocks");
-        let current_block = Arc::clone(&chain).get_current_block_number().await.unwrap();
+        let current_block = Arc::clone(&chain).get_current_block_number().await?;
         tracing::info!("current block number: {}", current_block);
         // TODO call storage in order to save the block details
-        let json = block_json(Arc::clone(&chain), current_block).await.unwrap();
-        tracing::info!("block: {}", json);
+        let block_json = block_json(Arc::clone(&chain), current_block).await?;
+        tracing::info!("block: {}", block_json);
+        let ethers_core_block = stratus::eth::sync_parser::parse_block(&block_json)?;
+
+        let receipt = Arc::clone(&chain)
+            .get_transaction_receipt(&Hash::new(hex!("5a493d5b9e4f36a7569407988e2f9506334de3a7ce3b451c594ab1496cc5e13f")))
+            .await?;
+        let receipt_json = serde_json::to_string(&receipt)?;
+        tracing::info!("receipt_json: {:?}", receipt_json);
+        let ethers_core_receipts = stratus::eth::sync_parser::parse_receipt(vec![&receipt_json])?;
+
+
+        let storage = config.init_storage().await?;
+        let evms = config.init_evms(Arc::clone(&storage));
+        let executor = EthExecutor::new(evms, Arc::clone(&storage));
+        executor.import(ethers_core_block, ethers_core_receipts).await?;
+
         sleep(POLL_LATENCY).await;
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -50,10 +50,6 @@ pub struct Config {
     /// External RPC endpoint to sync blocks with Stratus.
     #[arg(short = 'r', long = "external-rpc", env = "EXTERNAL_RPC")]
     pub external_rpc: Option<String>,
-
-    /// External RPC endpoint to sync blocks with Stratus.
-    #[arg(long = "extra")]
-    pub extra: Option<String>,
 }
 
 impl Config {

--- a/src/config.rs
+++ b/src/config.rs
@@ -50,6 +50,10 @@ pub struct Config {
     /// External RPC endpoint to sync blocks with Stratus.
     #[arg(short = 'r', long = "external-rpc", env = "EXTERNAL_RPC")]
     pub external_rpc: Option<String>,
+
+    /// External RPC endpoint to sync blocks with Stratus.
+    #[arg(long = "extra")]
+    pub extra: Option<String>,
 }
 
 impl Config {

--- a/src/eth/mod.rs
+++ b/src/eth/mod.rs
@@ -26,6 +26,6 @@ pub mod miner;
 pub mod primitives;
 pub mod rpc;
 pub mod storage;
-mod sync_parser;
+pub mod sync_parser;
 
 pub use executor::EthExecutor;


### PR DESCRIPTION
Calling import from rpc poller, the next step is making import properly execute transactions and extract the state root