### PR TITLE
feat: pass gas and gas_price to evm when executing external transaction

### DIFF
--- a/justfile
+++ b/justfile
@@ -82,7 +82,7 @@ importer-download *args="":
 
 # Importer: Import downloaded external RPC blocks to Stratus storage
 importer-import:
-    cargo run --bin importer-import -- --postgres {{postgres_url}} --storage inmemory
+    cargo run --bin importer-import --release -- --postgres {{postgres_url}} --storage inmemory
 
 # ------------------------------------------------------------------------------
 # Test tasks

--- a/src/eth/evm/revm.rs
+++ b/src/eth/evm/revm.rs
@@ -63,8 +63,6 @@ impl Revm {
         evm.env.block.coinbase = Address::COINBASE.into();
 
         // evm tx config
-        evm.env.tx.gas_limit = u64::MAX; // todo: must come from transaction
-        evm.env.tx.gas_price = U256::ZERO;
         evm.env.tx.gas_priority_fee = None;
 
         Self { evm, storage }
@@ -91,6 +89,8 @@ impl Evm for Revm {
             Some(contract) => TransactTo::Call(contract.into()),
             None => TransactTo::Create(CreateScheme::Create),
         };
+        tx.gas_limit = input.gas_limit.into();
+        tx.gas_price = input.gas_price.into();
         tx.nonce = input.nonce.map_into();
         tx.data = input.data.into();
         tx.value = input.value.into();
@@ -243,7 +243,7 @@ fn parse_revm_execution(
     let (result, output, logs, gas) = parse_revm_result(revm_result.result);
     let execution_changes = parse_revm_state(revm_result.state, execution_changes)?;
 
-    tracing::info!(%result, %gas, output_len = %output.len(), %output, "evm executed");
+    tracing::info!(?result, %gas, output_len = %output.len(), %output, "evm executed");
     Ok(Execution {
         result,
         output,

--- a/src/eth/primitives/external_transaction.rs
+++ b/src/eth/primitives/external_transaction.rs
@@ -1,6 +1,7 @@
 use ethers_core::types::Transaction as EthersTransaction;
 
 use crate::eth::primitives::transaction_input::ConversionError;
+use crate::eth::primitives::Gas;
 use crate::eth::primitives::Hash;
 use crate::eth::primitives::TransactionInput;
 
@@ -9,9 +10,18 @@ use crate::eth::primitives::TransactionInput;
 pub struct ExternalTransaction(#[deref] pub EthersTransaction);
 
 impl ExternalTransaction {
-    /// Returns the block hash.
+    /// Returns the transaction hash.
     pub fn hash(&self) -> Hash {
         self.0.hash.into()
+    }
+
+    /// Returns the gas limit according to the transaction type.
+    pub fn gas_limit(&self) -> Gas {
+        match self.0.transaction_type {
+            Some(tx_type) if tx_type.is_zero() => Gas::MAX,
+            Some(_) => self.0.gas.into(),
+            None => Gas::MAX,
+        }
     }
 }
 

--- a/src/eth/primitives/gas.rs
+++ b/src/eth/primitives/gas.rs
@@ -20,12 +20,14 @@ use sqlx::types::BigDecimal;
 
 use crate::gen_newtype_from;
 
+// XXX: should we use U256 or U64?
 #[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(transparent)]
 pub struct Gas(U256);
 
 impl Gas {
     pub const ZERO: Gas = Gas(U256::zero());
+    pub const MAX: Gas = Gas(U256::MAX);
 }
 
 impl Display for Gas {
@@ -79,9 +81,9 @@ impl From<Gas> for U256 {
     }
 }
 
-impl From<Gas> for usize {
+impl From<Gas> for u64 {
     fn from(value: Gas) -> Self {
-        value.0.as_usize()
+        value.0.low_u64()
     }
 }
 

--- a/src/eth/primitives/transaction_input.rs
+++ b/src/eth/primitives/transaction_input.rs
@@ -146,21 +146,3 @@ impl TryFrom<EthersTransaction> for TransactionInput {
         })
     }
 }
-
-// impl TryFrom<Vec<u8>> for TransactionInput {
-//     type Error = EthError;
-
-//     fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
-//         let input = Self {
-//             hash: value.hash.into(),
-//             nonce: value.nonce.into(),
-//             from: value.from.into(),
-//             to: value.to.map_into(),
-//             input: value.input.clone().into(),
-//             gas: value.gas.into(),
-//             inner: value,
-//         };
-
-//         Ok(input)
-//     }
-// }


### PR DESCRIPTION
* When executing an external transaction, uses original gas_limit and gas_price to reproduce original behavior.

* When executing an eth_call or eth_sendRawTransaction, keep using max values (current behavior), but it can be changed to start using the input values if necessary instead of being hardcoded inside the REVM.

* Original gas_limit is calculated according to the transaction type.