### PR TITLE
refactor: use UnixTime instead of u64 everywhere

### DIFF
--- a/.sqlx/query-e8a32893d991a776633dbba4e35b868c31f91cfe0c3e4081e7749c6a76cee5d1.json
+++ b/.sqlx/query-e8a32893d991a776633dbba4e35b868c31f91cfe0c3e4081e7749c6a76cee5d1.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT\n    number as \"number: _\"\n    ,hash as \"hash: _\"\n    ,transactions_root as \"transactions_root: _\"\n    ,gas as \"gas: _\"\n    ,logs_bloom as \"bloom: _\"\n    ,timestamp_in_secs as \"timestamp_in_secs: _\"\n    ,parent_hash as \"parent_hash: _\"\nFROM blocks\nWHERE number = $1",
+  "query": "SELECT\n    number as \"number: _\"\n    ,hash as \"hash: _\"\n    ,transactions_root as \"transactions_root: _\"\n    ,gas as \"gas: _\"\n    ,logs_bloom as \"bloom: _\"\n    ,timestamp_in_secs as \"timestamp: _\"\n    ,parent_hash as \"parent_hash: _\"\nFROM blocks\nWHERE number = $1",
   "describe": {
     "columns": [
       {
@@ -30,7 +30,7 @@
       },
       {
         "ordinal": 5,
-        "name": "timestamp_in_secs: _",
+        "name": "timestamp: _",
         "type_info": "Int4"
       },
       {
@@ -54,5 +54,5 @@
       false
     ]
   },
-  "hash": "bd1b3ba714c5a4b3b2caea9e9a66c5227b097c9d9ce8b73e62d3cf67b41352b2"
+  "hash": "e8a32893d991a776633dbba4e35b868c31f91cfe0c3e4081e7749c6a76cee5d1"
 }

--- a/.sqlx/query-f401ecc9e454519dd2398bd17f2c0d9c99e4e980bd0de506ddd20d5ab753ff04.json
+++ b/.sqlx/query-f401ecc9e454519dd2398bd17f2c0d9c99e4e980bd0de506ddd20d5ab753ff04.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT\n    number as \"number: _\"\n    ,hash as \"hash: _\"\n    ,transactions_root as \"transactions_root: _\"\n    ,gas as \"gas: _\"\n    ,logs_bloom as \"bloom: _\"\n    ,timestamp_in_secs as \"timestamp_in_secs: _\"\n    ,parent_hash as \"parent_hash: _\"\nFROM blocks\nWHERE hash = $1\n",
+  "query": "SELECT\n    number as \"number: _\"\n    ,hash as \"hash: _\"\n    ,transactions_root as \"transactions_root: _\"\n    ,gas as \"gas: _\"\n    ,logs_bloom as \"bloom: _\"\n    ,timestamp_in_secs as \"timestamp: _\"\n    ,parent_hash as \"parent_hash: _\"\nFROM blocks\nWHERE hash = $1\n",
   "describe": {
     "columns": [
       {
@@ -30,7 +30,7 @@
       },
       {
         "ordinal": 5,
-        "name": "timestamp_in_secs: _",
+        "name": "timestamp: _",
         "type_info": "Int4"
       },
       {
@@ -54,5 +54,5 @@
       false
     ]
   },
-  "hash": "d5a625e8c1272a44bf40c9a33fd8928bde879c2325f207e58325d6b109f83592"
+  "hash": "f401ecc9e454519dd2398bd17f2c0d9c99e4e980bd0de506ddd20d5ab753ff04"
 }

--- a/src/eth/miner/block_miner.rs
+++ b/src/eth/miner/block_miner.rs
@@ -19,6 +19,7 @@ use crate::eth::primitives::Index;
 use crate::eth::primitives::LogMined;
 use crate::eth::primitives::TransactionInput;
 use crate::eth::primitives::TransactionMined;
+use crate::eth::primitives::UnixTime;
 use crate::eth::storage::EthStorage;
 use crate::ext::not;
 
@@ -36,7 +37,7 @@ impl BlockMiner {
     /// Constructs the genesis block, the first block in the blockchain.
     /// This block serves as the foundation of the blockchain, with a fixed state and no previous block.
     pub fn genesis() -> Block {
-        Block::new_with_capacity(BlockNumber::ZERO, 1702568764, 0)
+        Block::new_with_capacity(BlockNumber::ZERO, UnixTime::from(1702568764), 0)
     }
 
     /// Mine one block with a single transaction.
@@ -55,11 +56,11 @@ impl BlockMiner {
     pub async fn mine_with_many_transactions(&mut self, transactions: NonEmpty<(TransactionInput, Execution)>) -> anyhow::Result<Block> {
         // init block
         let number = self.storage.increment_block_number().await?;
-        let block_timpestamp = transactions
-            .minimum_by(|(_, e1), (_, e2)| e1.block_timestamp_in_secs.cmp(&e2.block_timestamp_in_secs))
+        let block_timestamp = transactions
+            .minimum_by(|(_, e1), (_, e2)| e1.block_timestamp.cmp(&e2.block_timestamp))
             .1
-            .block_timestamp_in_secs;
-        let mut block = Block::new_with_capacity(number, block_timpestamp, transactions.len());
+            .block_timestamp;
+        let mut block = Block::new_with_capacity(number, block_timestamp, transactions.len());
 
         // mine transactions and logs
         let mut log_index = Index::ZERO;

--- a/src/eth/primitives/block.rs
+++ b/src/eth/primitives/block.rs
@@ -20,6 +20,7 @@ use crate::eth::primitives::BlockHeader;
 use crate::eth::primitives::BlockNumber;
 use crate::eth::primitives::Hash;
 use crate::eth::primitives::TransactionMined;
+use crate::eth::primitives::UnixTime;
 
 #[derive(Debug, Clone, PartialEq, Eq, fake::Dummy, serde::Serialize, serde::Deserialize)]
 pub struct Block {
@@ -29,9 +30,9 @@ pub struct Block {
 
 impl Block {
     /// Creates a new block with the given number and transactions capacity.
-    pub fn new_with_capacity(number: BlockNumber, timestamp_in_secs: u64, capacity: usize) -> Self {
+    pub fn new_with_capacity(number: BlockNumber, timestamp: UnixTime, capacity: usize) -> Self {
         Self {
-            header: BlockHeader::new(number, timestamp_in_secs),
+            header: BlockHeader::new(number, timestamp),
             transactions: Vec::with_capacity(capacity),
         }
     }

--- a/src/eth/primitives/block_header.rs
+++ b/src/eth/primitives/block_header.rs
@@ -36,20 +36,20 @@ pub struct BlockHeader {
     pub transactions_root: Hash,
     pub gas: Gas,
     pub bloom: LogsBloom,
-    pub timestamp_in_secs: UnixTime,
+    pub timestamp: UnixTime,
     pub parent_hash: Hash,
 }
 
 impl BlockHeader {
     /// Creates a new block header with the given number.
-    pub fn new(number: BlockNumber, timestamp_in_secs: u64) -> Self {
+    pub fn new(number: BlockNumber, timestamp: UnixTime) -> Self {
         Self {
             number,
             hash: number.hash(),
             transactions_root: HASH_EMPTY_TRANSACTIONS_ROOT,
             gas: Gas::ZERO,
             bloom: LogsBloom::default(),
-            timestamp_in_secs: UnixTime::from(timestamp_in_secs),
+            timestamp,
             parent_hash: number.prev().map(|n| n.hash()).unwrap_or(Hash::zero()),
         }
     }
@@ -63,7 +63,7 @@ impl Dummy<Faker> for BlockHeader {
             transactions_root: faker.fake_with_rng(rng),
             gas: faker.fake_with_rng(rng),
             bloom: Default::default(),
-            timestamp_in_secs: faker.fake_with_rng(rng),
+            timestamp: faker.fake_with_rng(rng),
             parent_hash: faker.fake_with_rng(rng),
         }
     }
@@ -89,7 +89,7 @@ where
             parent_hash: header.parent_hash.into(),
 
             // mining: identifiers
-            timestamp: (*header.timestamp_in_secs).into(),
+            timestamp: (*header.timestamp).into(),
             author: Some(Address::COINBASE.into()),
 
             // minining: difficulty

--- a/src/eth/primitives/block_number.rs
+++ b/src/eth/primitives/block_number.rs
@@ -30,6 +30,7 @@ pub struct BlockNumber(U64);
 
 impl BlockNumber {
     pub const ZERO: BlockNumber = BlockNumber(U64::zero());
+    pub const ONE: BlockNumber = BlockNumber(U64::one());
 
     /// Calculates the keccak256 hash of the block number.
     pub fn hash(&self) -> Hash {

--- a/src/eth/primitives/execution.rs
+++ b/src/eth/primitives/execution.rs
@@ -18,6 +18,7 @@ use crate::eth::primitives::ExecutionAccountChanges;
 use crate::eth::primitives::ExecutionResult;
 use crate::eth::primitives::Gas;
 use crate::eth::primitives::Log;
+use crate::eth::primitives::UnixTime;
 use crate::log_and_err;
 
 pub type ExecutionChanges = HashMap<Address, ExecutionAccountChanges>;
@@ -38,8 +39,7 @@ pub struct Execution {
     pub gas: Gas,
 
     /// Assumed block timestamp during the execution.
-    // TODO: use UnixTime type
-    pub block_timestamp_in_secs: u64,
+    pub block_timestamp: UnixTime,
 
     /// Storage changes that happened during the transaction execution.
     pub changes: Vec<ExecutionAccountChanges>,

--- a/src/eth/primitives/external_block.rs
+++ b/src/eth/primitives/external_block.rs
@@ -42,7 +42,7 @@ impl From<ExternalBlock> for Block {
                 transactions_root: value.transactions_root.into(),
                 gas: value.gas_used.into(),
                 bloom: value.logs_bloom.unwrap().into(),
-                timestamp_in_secs: value.timestamp.as_u64().into(),
+                timestamp: value.timestamp.into(),
                 parent_hash: value.parent_hash.into(),
             },
             transactions: vec![],

--- a/src/eth/primitives/mod.rs
+++ b/src/eth/primitives/mod.rs
@@ -195,27 +195,25 @@ mod tests {
     gen_test_serde!(TransactionMined);
     gen_test_serde!(Wei);
 
+    // TODO: move these tests to block_header module
     #[test]
     fn block_hash_calculation() {
-        let number: BlockNumber = 0x0.into();
-        let timestamp_in_secs = 1234567890;
-        let b = BlockHeader::new(number, timestamp_in_secs);
-        assert_eq!(b.hash.to_string(), "0x011b4d03dd8c01f1049143cf9c4c817e4b167f1d1b83e5c6f0f10d89ba1e7bce");
+        let header = BlockHeader::new(BlockNumber::ZERO, UnixTime::from(1234567890));
+        assert_eq!(header.hash.to_string(), "0x011b4d03dd8c01f1049143cf9c4c817e4b167f1d1b83e5c6f0f10d89ba1e7bce");
     }
 
     #[test]
     fn parent_hash() {
-        let number: BlockNumber = 0x1.into();
-        let timestamp_in_secs = 1234567891;
-        let b = BlockHeader::new(number, timestamp_in_secs);
-        assert_eq!(b.parent_hash.to_string(), "0x011b4d03dd8c01f1049143cf9c4c817e4b167f1d1b83e5c6f0f10d89ba1e7bce");
+        let header = BlockHeader::new(BlockNumber::ONE, UnixTime::from(1234567891));
+        assert_eq!(
+            header.parent_hash.to_string(),
+            "0x011b4d03dd8c01f1049143cf9c4c817e4b167f1d1b83e5c6f0f10d89ba1e7bce"
+        );
     }
 
     #[test]
     fn genesis_parent_hash() {
-        let number: BlockNumber = 0x0.into();
-        let timestamp_in_secs = 1234567890;
-        let b = BlockHeader::new(number, timestamp_in_secs);
-        assert_eq!(b.parent_hash, Hash::zero());
+        let header = BlockHeader::new(BlockNumber::ZERO, UnixTime::from(1234567890));
+        assert_eq!(header.parent_hash, Hash::zero());
     }
 }

--- a/src/eth/storage/postgres/postgres.rs
+++ b/src/eth/storage/postgres/postgres.rs
@@ -423,7 +423,7 @@ impl EthStorage for Postgres {
             block.header.transactions_root.as_ref(),
             BigDecimal::try_from(block.header.gas)?,
             block.header.bloom.as_ref(),
-            i32::try_from(block.header.timestamp_in_secs).context("failed to convert block timestamp")?,
+            i32::try_from(block.header.timestamp).context("failed to convert block timestamp")?, // TODO: this is wrong, it should be using a type that support u64
             block.header.parent_hash.as_ref()
         )
         .execute(&mut *tx)

--- a/src/eth/storage/postgres/queries/select_block_header_by_hash.sql
+++ b/src/eth/storage/postgres/queries/select_block_header_by_hash.sql
@@ -4,7 +4,7 @@ SELECT
     ,transactions_root as "transactions_root: _"
     ,gas as "gas: _"
     ,logs_bloom as "bloom: _"
-    ,timestamp_in_secs as "timestamp_in_secs: _"
+    ,timestamp_in_secs as "timestamp: _"
     ,parent_hash as "parent_hash: _"
 FROM blocks
 WHERE hash = $1

--- a/src/eth/storage/postgres/queries/select_block_header_by_number.sql
+++ b/src/eth/storage/postgres/queries/select_block_header_by_number.sql
@@ -4,7 +4,7 @@ SELECT
     ,transactions_root as "transactions_root: _"
     ,gas as "gas: _"
     ,logs_bloom as "bloom: _"
-    ,timestamp_in_secs as "timestamp_in_secs: _"
+    ,timestamp_in_secs as "timestamp: _"
     ,parent_hash as "parent_hash: _"
 FROM blocks
 WHERE number = $1

--- a/src/eth/storage/postgres/types.rs
+++ b/src/eth/storage/postgres/types.rs
@@ -17,6 +17,7 @@ use crate::eth::primitives::LogTopic;
 use crate::eth::primitives::Nonce;
 use crate::eth::primitives::TransactionInput;
 use crate::eth::primitives::TransactionMined;
+use crate::eth::primitives::UnixTime;
 use crate::eth::primitives::Wei;
 
 pub struct PostgresTransaction {
@@ -53,7 +54,7 @@ impl PostgresTransaction {
         let execution = Execution {
             gas: self.gas.clone(),
             output: self.output,
-            block_timestamp_in_secs: 0, //*self.block_timestamp,
+            block_timestamp: UnixTime::ZERO, //*self.block_timestamp,
             result: self.result,
             logs: inner_logs,
             // TODO: do this correctly

--- a/static/schema/001-init.sql
+++ b/static/schema/001-init.sql
@@ -5,7 +5,7 @@ CREATE TABLE IF NOT EXISTS blocks (
     ,transactions_root BYTEA NOT NULL CHECK (LENGTH(transactions_root) = 32)
     ,gas NUMERIC NOT NULL CHECK (gas >= 0)
     ,logs_bloom BYTEA NOT NULL CHECK (LENGTH(logs_bloom) = 256)
-    ,timestamp_in_secs INTEGER NOT NULL CHECK (timestamp_in_secs >= 0) -- UNIQUE
+    ,timestamp_in_secs INTEGER NOT NULL CHECK (timestamp_in_secs >= 0) -- UNIQUE | TODO: INTEGER is the wrong type for timestamps
     ,parent_hash BYTEA NOT NULL CHECK (LENGTH(parent_hash) = 32) UNIQUE
     ,created_at TIMESTAMP NOT NULL
     ,PRIMARY KEY (number, hash)


### PR DESCRIPTION
Codebase was inconsistent state where in some places Unix timestamps are represented as `u64`, and in other they are represents with the struct `UnixTime`.

Unify all representations using `UnixTime`.