### PR TITLE
feat: pass block number and timestamp as parameters to evm instead of assuming default values

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,6 +1,6 @@
 import '.justfile_helpers' # _lint, _outdated
 
-postgres_url := "postgres://postgres:123@0.0.0.0:5432/stratus"
+postgres_url := env("POSTGRES_URL", "postgres://postgres:123@0.0.0.0:5432/stratus")
 testnet_url  := "https://rpc.testnet.cloudwalk.io/"
 
 # Project: Show available tasks

--- a/src/eth/evm/evm.rs
+++ b/src/eth/evm/evm.rs
@@ -7,17 +7,21 @@
 //! or requirements while maintaining a consistent execution interface.
 
 use crate::eth::primitives::Address;
+use crate::eth::primitives::BlockNumber;
 use crate::eth::primitives::Bytes;
 use crate::eth::primitives::CallInput;
 use crate::eth::primitives::Execution;
+use crate::eth::primitives::ExternalBlock;
 use crate::eth::primitives::ExternalReceipt;
 use crate::eth::primitives::ExternalTransaction;
 use crate::eth::primitives::Gas;
 use crate::eth::primitives::Nonce;
 use crate::eth::primitives::StoragePointInTime;
 use crate::eth::primitives::TransactionInput;
+use crate::eth::primitives::UnixTime;
 use crate::eth::primitives::Wei;
 use crate::ext::OptionExt;
+use crate::if_else;
 
 /// EVM operations.
 pub trait Evm: Send + Sync + 'static {
@@ -26,6 +30,7 @@ pub trait Evm: Send + Sync + 'static {
 }
 
 /// EVM input data. Usually derived from a transaction or call.
+#[derive(Debug, Clone)]
 pub struct EvmInput {
     /// Operation party address.
     ///
@@ -69,9 +74,13 @@ pub struct EvmInput {
     /// Gas price paid by each unit of gas consumed by the transaction.
     pub gas_price: Wei,
 
-    /// Block number indicating the point-in-time the EVM state will be used to compute the transaction.
-    ///
-    /// When not specified, assumes the current state.
+    /// Number of the block where the transaction will be or was included.
+    pub block_number: BlockNumber,
+
+    /// Timestamp of the block where the transaction will be or was included.
+    pub block_timestamp: UnixTime,
+
+    /// Point-in-time from where accounts and slots will be read.
     pub point_in_time: StoragePointInTime,
 }
 
@@ -86,6 +95,8 @@ impl EvmInput {
             gas_limit: input.gas_limit,
             gas_price: Wei::ZERO, // XXX: use value from input?
             nonce: Some(input.nonce),
+            block_number: BlockNumber::ZERO, // TODO: use number of block being mined
+            block_timestamp: UnixTime::now(),
             point_in_time: StoragePointInTime::Present,
         }
     }
@@ -100,13 +111,21 @@ impl EvmInput {
             gas_limit: Gas::MAX,  // XXX: use value from input?
             gas_price: Wei::ZERO, // XXX: use value from input?
             nonce: None,
+            block_number: match point_in_time {
+                StoragePointInTime::Present => BlockNumber::ZERO, // TODO: use number of block being mined
+                StoragePointInTime::Past(number) => number,
+            },
+            block_timestamp: match point_in_time {
+                StoragePointInTime::Present => UnixTime::now(),
+                StoragePointInTime::Past(_) => UnixTime::now(), // TODO: use timestamp of the specified block
+            },
             point_in_time,
         }
     }
 
     /// Creates a transaction that was executed in an external blockchain and imported to Stratus.
-    pub fn from_external_transaction(tx: ExternalTransaction, receipt: &ExternalReceipt) -> Self {
-        let gas_limit = tx.gas_limit(receipt);
+    pub fn from_external_transaction(block: &ExternalBlock, tx: ExternalTransaction, receipt: &ExternalReceipt) -> Self {
+        let gas_limit = if_else!(receipt.is_success(), Gas::MAX, tx.0.gas.into());
         Self {
             from: tx.0.from.into(),
             to: tx.0.to.map_into(),
@@ -116,6 +135,8 @@ impl EvmInput {
             gas_limit,
             gas_price: tx.0.gas_price.expect("gas_price must be set for ExternalTransaction").into(), // XXX: how to handle transactions without gas price?
             point_in_time: StoragePointInTime::Present,
+            block_number: block.number(),
+            block_timestamp: block.timestamp(),
         }
     }
 }

--- a/src/eth/executor.rs
+++ b/src/eth/executor.rs
@@ -86,7 +86,7 @@ impl EthExecutor {
             // re-execute transaction
             let json_tx = serde_json::to_string(&tx).unwrap();
             let json_receipt = serde_json::to_string(&receipt).unwrap();
-            let evm_input = EvmInput::from_external_transaction(tx.clone(), receipt);
+            let evm_input = EvmInput::from_external_transaction(&block, tx.clone(), receipt);
             let execution = self.execute_in_evm(evm_input).await;
 
             // handle execution result

--- a/src/eth/primitives/block_number.rs
+++ b/src/eth/primitives/block_number.rs
@@ -18,6 +18,7 @@ use ethereum_types::U64;
 use ethers_core::utils::keccak256;
 use fake::Dummy;
 use fake::Faker;
+use revm::primitives::U256 as RevmU256;
 use sqlx::database::HasValueRef;
 use sqlx::error::BoxDynError;
 
@@ -118,6 +119,12 @@ impl From<BlockNumber> for U64 {
 impl From<BlockNumber> for u64 {
     fn from(block_number: BlockNumber) -> Self {
         block_number.0.as_u64()
+    }
+}
+
+impl From<BlockNumber> for RevmU256 {
+    fn from(block_number: BlockNumber) -> Self {
+        Self::from_limbs([block_number.0.as_u64(), 0, 0, 0])
     }
 }
 

--- a/src/eth/primitives/external_block.rs
+++ b/src/eth/primitives/external_block.rs
@@ -3,8 +3,10 @@ use ethers_core::types::Transaction as EthersTransaction;
 
 use super::Block;
 use super::BlockNumber;
+use crate::eth::primitives::BlockHeader;
 use crate::eth::primitives::ExternalTransaction;
 use crate::eth::primitives::Hash;
+use crate::eth::primitives::UnixTime;
 use crate::log_and_err;
 
 #[derive(Debug, Clone, derive_more:: Deref, serde::Deserialize, serde::Serialize)]
@@ -21,6 +23,11 @@ impl ExternalBlock {
     pub fn number(&self) -> BlockNumber {
         self.0.number.expect("external block must have number").into()
     }
+
+    /// Returns the block timestamp.
+    pub fn timestamp(&self) -> UnixTime {
+        self.0.timestamp.into()
+    }
 }
 
 // -----------------------------------------------------------------------------
@@ -36,7 +43,7 @@ impl From<ExternalBlock> for EthersBlock<ExternalTransaction> {
 impl From<ExternalBlock> for Block {
     fn from(value: ExternalBlock) -> Self {
         Block {
-            header: super::BlockHeader {
+            header: BlockHeader {
                 number: value.number.unwrap().into(),
                 hash: value.hash.unwrap().into(),
                 transactions_root: value.transactions_root.into(),

--- a/src/eth/primitives/external_transaction.rs
+++ b/src/eth/primitives/external_transaction.rs
@@ -1,8 +1,6 @@
 use ethers_core::types::Transaction as EthersTransaction;
 
 use crate::eth::primitives::transaction_input::ConversionError;
-use crate::eth::primitives::ExternalReceipt;
-use crate::eth::primitives::Gas;
 use crate::eth::primitives::Hash;
 use crate::eth::primitives::TransactionInput;
 
@@ -14,17 +12,6 @@ impl ExternalTransaction {
     /// Returns the transaction hash.
     pub fn hash(&self) -> Hash {
         self.0.hash.into()
-    }
-
-    /// Returns the gas limit according to the transaction type.
-    pub fn gas_limit(&self, receipt: &ExternalReceipt) -> Gas {
-        // when external transaction is success, use max gas to avoid failing locally due to different gas calculation
-        if receipt.is_success() {
-            return Gas::MAX;
-        }
-
-        // in case of failure, try to reproduce the same original behavior using the original gas
-        self.0.gas.into()
     }
 }
 


### PR DESCRIPTION
There are a lot of TODOs in this PR, but they are just the actual incomplete behavior made explicit.

What this PR improves is that at least for external blocks being imported, the block number and timestamp set in the context are now correct and external contracts that relies on it like CompoundProtocol does not break anymore