### PR TITLE
fix(e2e-contracts): wrap test return code in a conditional

### DIFF
--- a/e2e-contracts/test-contracts.sh
+++ b/e2e-contracts/test-contracts.sh
@@ -26,8 +26,10 @@ test() {
     # go back to previous directory
     cd -
 
-    # exit with same return code as the test
-    exit $result_code
+    # exit with same return code as the test if an error ocurred
+    if [ $result_code -ne 0 ]; then
+        exit $result_code
+    fi
 }
 
 # ------------------------------------------------------------------------------

--- a/justfile
+++ b/justfile
@@ -267,7 +267,7 @@ contracts-remove:
 contracts-test-stratus:
     #!/bin/bash
     echo "-> Starting Stratus"
-    RUST_LOG=info just run -a 0.0.0.0:3000 &
+    RUST_LOG=info just run -a 0.0.0.0:3000 > /dev/null &
 
     echo "-> Waiting Stratus to start"
     wait-service --tcp 0.0.0.0:3000 -t 300 -- echo


### PR DESCRIPTION
Fixes the problem found by @carneiro-cw in which the script stops at the first successful test suite

we needed to make yield streamer public