### PR TITLE
feat: make importer work with current storage design

### DIFF
--- a/src/eth/primitives/block_header.rs
+++ b/src/eth/primitives/block_header.rs
@@ -19,6 +19,7 @@ use jsonrpsee::SubscriptionMessage;
 use crate::eth::primitives::logs_bloom::LogsBloom;
 use crate::eth::primitives::Address;
 use crate::eth::primitives::BlockNumber;
+use crate::eth::primitives::ExternalBlock;
 use crate::eth::primitives::Gas;
 use crate::eth::primitives::Hash;
 use crate::eth::primitives::UnixTime;
@@ -121,6 +122,23 @@ where
                                  // withdrawals_root: todo!(),
                                  // withdrawals: todo!(),
                                  // other: todo!(),
+        }
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Conversions: Other -> Self
+// -----------------------------------------------------------------------------
+impl From<ExternalBlock> for BlockHeader {
+    fn from(value: ExternalBlock) -> Self {
+        Self {
+            number: value.number(),
+            hash: value.hash(),
+            transactions_root: value.transactions_root.into(),
+            gas: value.gas_used.into(),
+            bloom: value.logs_bloom.unwrap_or_default().into(),
+            timestamp: value.timestamp.into(),
+            parent_hash: value.parent_hash.into(),
         }
     }
 }

--- a/src/eth/primitives/external_receipt.rs
+++ b/src/eth/primitives/external_receipt.rs
@@ -19,6 +19,11 @@ impl ExternalReceipt {
         self.0.block_number.expect("external receipt must have block number").into()
     }
 
+    /// Returns the block hash.
+    pub fn block_hash(&self) -> Hash {
+        self.0.block_hash.expect("external receipt must have block hash").into()
+    }
+
     /// Checks if the receipt is for a transaction that was completed successfully.
     pub fn is_success(&self) -> bool {
         match self.0.status {

--- a/src/eth/primitives/external_transaction.rs
+++ b/src/eth/primitives/external_transaction.rs
@@ -1,8 +1,11 @@
 use ethers_core::types::Transaction as EthersTransaction;
 
-use crate::eth::primitives::transaction_input::ConversionError;
+use crate::eth::primitives::Execution;
+use crate::eth::primitives::ExternalReceipt;
 use crate::eth::primitives::Hash;
 use crate::eth::primitives::TransactionInput;
+
+pub type ExternalTransactionExecution = (ExternalTransaction, ExternalReceipt, Execution);
 
 #[derive(Debug, Clone, Default, derive_more:: Deref, serde::Deserialize, serde::Serialize)]
 #[serde(transparent)]
@@ -16,7 +19,7 @@ impl ExternalTransaction {
 }
 
 impl TryFrom<ExternalTransaction> for TransactionInput {
-    type Error = ConversionError;
+    type Error = anyhow::Error;
     fn try_from(value: ExternalTransaction) -> Result<Self, Self::Error> {
         value.0.try_into()
     }

--- a/src/eth/primitives/index.rs
+++ b/src/eth/primitives/index.rs
@@ -14,6 +14,8 @@ use sqlx::error::BoxDynError;
 use crate::gen_newtype_from;
 
 /// Represents a transaction index or log index.
+///
+/// TODO: representing it as u16 is probably wrong because external libs uses u64.
 #[derive(Debug, Clone, PartialEq, Eq, fake::Dummy, serde::Serialize, serde::Deserialize, derive_more::Add, Copy, Hash)]
 pub struct Index(u16);
 
@@ -34,6 +36,18 @@ gen_newtype_from!(self = Index, other = u16);
 impl From<i32> for Index {
     fn from(value: i32) -> Self {
         Index::new(value as u16)
+    }
+}
+
+impl From<U64> for Index {
+    fn from(value: U64) -> Self {
+        Index::new(value.low_u64() as u16) // TODO: this will break things if the value is bigger than u16
+    }
+}
+
+impl From<U256> for Index {
+    fn from(value: U256) -> Self {
+        Index::new(value.low_u64() as u16) // TODO: this will break things if the value is bigger than u16
     }
 }
 

--- a/src/eth/primitives/log.rs
+++ b/src/eth/primitives/log.rs
@@ -6,6 +6,7 @@
 //! emitting address, topics, and additional data. It also provides conversion
 //! functions to translate between internal and external log representations.
 
+use ethers_core::types::Log as EthersLog;
 use itertools::Itertools;
 use revm::primitives::Log as RevmLog;
 
@@ -31,6 +32,16 @@ pub struct Log {
 // ----------------------------------------------------------------------------
 impl From<RevmLog> for Log {
     fn from(value: RevmLog) -> Self {
+        Self {
+            address: value.address.into(),
+            topics: value.topics.into_iter().map_into().collect(),
+            data: value.data.into(),
+        }
+    }
+}
+
+impl From<EthersLog> for Log {
+    fn from(value: EthersLog) -> Self {
         Self {
             address: value.address.into(),
             topics: value.topics.into_iter().map_into().collect(),

--- a/src/eth/primitives/log_mined.rs
+++ b/src/eth/primitives/log_mined.rs
@@ -59,6 +59,22 @@ impl LogMined {
 }
 
 // -----------------------------------------------------------------------------
+// Conversions: Other -> Self
+// -----------------------------------------------------------------------------
+impl From<EthersLog> for LogMined {
+    fn from(value: EthersLog) -> Self {
+        Self {
+            transaction_hash: value.transaction_hash.expect("log must have transaction_hash").into(),
+            transaction_index: value.transaction_index.expect("log must have transaction_index").into(),
+            log_index: value.log_index.expect("log must have log_index").into(),
+            block_number: value.block_number.expect("log must have block_number").into(),
+            block_hash: value.block_hash.expect("log must have block_hash").into(),
+            log: value.into(),
+        }
+    }
+}
+
+// -----------------------------------------------------------------------------
 // Conversions: Self -> Other
 // -----------------------------------------------------------------------------
 impl From<LogMined> for EthersLog {

--- a/src/eth/primitives/log_topic.rs
+++ b/src/eth/primitives/log_topic.rs
@@ -13,6 +13,8 @@ use fake::Dummy;
 use fake::Faker;
 use revm::primitives::B256 as RevmB256;
 
+use crate::gen_newtype_from;
+
 /// Topic is part of a [`Log`](super::Log) emitted by the EVM during contract execution.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct LogTopic(H256);
@@ -38,6 +40,8 @@ impl Dummy<Faker> for LogTopic {
 // -----------------------------------------------------------------------------
 // Conversions: Other -> Self
 // -----------------------------------------------------------------------------
+gen_newtype_from!(self = LogTopic, other = H256);
+
 impl AsRef<[u8]> for LogTopic {
     fn as_ref(&self) -> &[u8] {
         self.0.as_ref()

--- a/src/eth/primitives/mod.rs
+++ b/src/eth/primitives/mod.rs
@@ -136,6 +136,7 @@ pub use execution_value_change::ExecutionValueChange;
 pub use external_block::ExternalBlock;
 pub use external_receipt::ExternalReceipt;
 pub use external_transaction::ExternalTransaction;
+pub use external_transaction::ExternalTransactionExecution;
 pub use gas::Gas;
 pub use hash::Hash;
 pub use index::Index;

--- a/src/eth/primitives/transaction_mined.rs
+++ b/src/eth/primitives/transaction_mined.rs
@@ -13,6 +13,7 @@ use serde_json::Value as JsonValue;
 
 use crate::eth::primitives::BlockNumber;
 use crate::eth::primitives::Execution;
+use crate::eth::primitives::ExternalTransactionExecution;
 use crate::eth::primitives::Hash;
 use crate::eth::primitives::Index;
 use crate::eth::primitives::LogMined;
@@ -43,6 +44,21 @@ pub struct TransactionMined {
 }
 
 impl TransactionMined {
+    /// Creates a new mined transaction from an external mined transaction that was re-executed locally.
+    ///
+    /// TODO: this kind of conversion should be infallibe.
+    pub fn from_external(execution: ExternalTransactionExecution) -> anyhow::Result<Self> {
+        let (tx, receipt, execution) = execution;
+        Ok(Self {
+            input: tx.try_into()?,
+            execution,
+            block_number: receipt.block_number(),
+            block_hash: receipt.block_hash(),
+            transaction_index: receipt.transaction_index.into(),
+            logs: receipt.0.logs.into_iter().map_into().collect(),
+        })
+    }
+
     /// Check if the current transaction was completed normally.
     pub fn is_success(&self) -> bool {
         self.execution.is_success()


### PR DESCRIPTION
**Main points**

This PR makes the block importer fully works with the in-memory `EthStorage` implementation, but performance is awful.

It works this way for each block to import:
* For each block to import, each transaction is re-executed and the temporary account changes are stored in the storage and the transaction execution changes are collected to a vector.
* After all transactions are re-executed in the block, the external block is converted to the internal block format with the related transactions and executions.
* The storage state is rolled-back using `reset` to its initial state before all temporary data was stored.
* The produced block with the is saved permanently to the storage.

The bottleneck of this flow is the `reset` method. Even the in-memory implementation is slow and can possibly be improved.

PostgreSQL is not working yet because `save_account_changes` method is not implemented, and it probably requires some changes to make it work. Saving temporary account changes to PostgreSQL without having a related block is not possible because the foreign key constraint that does not exist in the in-memory implementation, but exists in PostgreSQL.

It is clear that this approach is not the best and #222 is the correct way to handle this by splitting temporary and permanent storage.

**Additional points**

* I removed the `ConversionError` enum in favor of `anyhow` error because it is how errors are being handled in the entire application. There was no specific use that required `ConversionError` to exist.
* There are several possible conversion problems that I annotated with TODOs.
