### PR TITLE
test: pin commit to repo clones

### DIFF
--- a/.github/workflows/e2e-contracts.yml
+++ b/.github/workflows/e2e-contracts.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   contract_test:
-    name: Run contracts e2e
+    name: Contracts E2E Tests
     runs-on: ubuntu-latest
     timeout-minutes: 25
 

--- a/e2e-contracts/clone-contracts.sh
+++ b/e2e-contracts/clone-contracts.sh
@@ -11,6 +11,7 @@ source $(dirname $0)/_functions.sh
 # Clone a project to the projects directory.
 clone() {
     repo=$1
+    commit=$2
     target=repos/$repo
 
     mkdir -p repos
@@ -22,6 +23,13 @@ clone() {
         log "Cloning: $repo"
         # git clone git@github.com:cloudwalk/$repo.git $target
         git clone https://github.com/cloudwalk/$repo.git $target
+        
+        # checkout commit if specified and it's different from HEAD
+        head_commit=$(git -C $target rev-parse --short HEAD)
+        if [ -n "$commit" ] && [ "$commit" != "$head_commit" ]; then
+            log "Checking out commit: $commit"
+            git -C $target checkout $commit --quiet
+        fi
     fi
 
     log "Installing dependencies: $repo"
@@ -33,9 +41,9 @@ clone() {
 # ------------------------------------------------------------------------------
 
 log "Cloning or updating repositories"
-clone brlc-multisig
-clone brlc-periphery
-clone brlc-token
-clone compound-periphery
-clone brlc-yield-streamer
-clone brlc-pix-cashier
+clone brlc-multisig       918a226
+clone brlc-periphery      b8d507a
+clone brlc-token          55770b9
+clone compound-periphery  e4d68df
+clone brlc-yield-streamer e63d8ba
+clone brlc-pix-cashier    00cc007


### PR DESCRIPTION
To avoid breaking Contracts E2E automated test, this PR checkouts each contract repo in a specific commit after cloning.