### PR TITLE
feat: remove check_conflicts from TemporaryStorage because it is not working

### DIFF
--- a/src/eth/executor.rs
+++ b/src/eth/executor.rs
@@ -207,10 +207,6 @@ impl EthExecutor {
             // execute and check conflicts before mining block
             let evm_input = EvmInput::from_eth_transaction(transaction.clone());
             let execution = self.execute_in_evm(evm_input).await?;
-            if let Some(conflicts) = self.storage.check_conflicts(&execution).await? {
-                tracing::warn!(?conflicts, "storage conflict detected before mining block");
-                continue;
-            }
 
             // mine and commit block
             let mut miner_lock = self.miner.lock().await;

--- a/src/eth/storage/stratus_storage.rs
+++ b/src/eth/storage/stratus_storage.rs
@@ -9,7 +9,6 @@ use crate::eth::primitives::Block;
 use crate::eth::primitives::BlockNumber;
 use crate::eth::primitives::BlockSelection;
 use crate::eth::primitives::Execution;
-use crate::eth::primitives::ExecutionConflicts;
 use crate::eth::primitives::Hash;
 use crate::eth::primitives::LogFilter;
 use crate::eth::primitives::LogMined;
@@ -67,14 +66,6 @@ impl StratusStorage {
     // -------------------------------------------------------------------------
     // State queries
     // -------------------------------------------------------------------------
-
-    /// Checks if the transaction execution conflicts with the current storage state.
-    pub async fn check_conflicts(&self, execution: &Execution) -> anyhow::Result<Option<ExecutionConflicts>> {
-        let start = Instant::now();
-        let result = self.temp.check_conflicts(execution).await;
-        metrics::inc_storage_check_conflicts(start.elapsed(), result.as_ref().is_ok_and(|v| v.is_some()), result.is_ok());
-        result
-    }
 
     /// Retrieves an account from the storage. Returns default value when not found.
     pub async fn read_account(&self, address: &Address, point_in_time: &StoragePointInTime) -> anyhow::Result<Account> {

--- a/src/eth/storage/temporary_storage.rs
+++ b/src/eth/storage/temporary_storage.rs
@@ -4,7 +4,6 @@ use crate::eth::primitives::Account;
 use crate::eth::primitives::Address;
 use crate::eth::primitives::BlockNumber;
 use crate::eth::primitives::Execution;
-use crate::eth::primitives::ExecutionConflicts;
 use crate::eth::primitives::Slot;
 use crate::eth::primitives::SlotIndex;
 use crate::eth::primitives::StoragePointInTime;
@@ -12,9 +11,6 @@ use crate::eth::primitives::StoragePointInTime;
 /// Temporary storage (in-between blocks) operations
 #[async_trait]
 pub trait TemporaryStorage: Send + Sync {
-    /// Checks if the transaction execution conflicts with the current storage state.
-    async fn check_conflicts(&self, execution: &Execution) -> anyhow::Result<Option<ExecutionConflicts>>;
-
     /// Retrieves an account from the storage. Returns Option when not found.
     async fn maybe_read_account(&self, address: &Address, point_in_time: &StoragePointInTime) -> anyhow::Result<Option<Account>>;
 


### PR DESCRIPTION
Conflict detection is only working when trying to save the block.

The implementation in the temporary storage never triggers the conflict.

So at least for now it will be removed, and in the future we can try again to make a single conflict resolution algorithm in the temporary storage and remove them from the permanent storage.