### PR TITLE
feat: unify all develoment features behind `dev` flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,5 @@ semicolon_if_nothing_returned = "warn"
 # ------------------------------------------------------------------------------
 
 [features]
-default = ["tests"]
-tests = ["evm-set-timestamp", "evm-mine"]
-evm-set-timestamp = []
-evm-mine = []
+default = []
+dev = [] # Development features that help debugging and testing.

--- a/justfile
+++ b/justfile
@@ -28,12 +28,12 @@ setup:
 # Stratus: Run main service with debug options
 run *args="":
     #!/bin/bash
-    RUST_LOG={{env("RUST_LOG", "stratus=info")}} cargo run --bin stratus -- --enable-genesis --enable-test-accounts {{args}}
+    RUST_LOG={{env("RUST_LOG", "stratus=info")}} cargo run --bin stratus --features dev -- --enable-genesis --enable-test-accounts {{args}}
     exit 0
 
 # Stratus: Run main service with release options
 run-release *args="":
-    RUST_LOG={{env("RUST_LOG", "stratus=info")}} cargo run --release --bin stratus -- --enable-genesis --enable-test-accounts {{args}}
+    RUST_LOG={{env("RUST_LOG", "stratus=info")}} cargo run --bin stratus --features dev --release -- --enable-genesis --enable-test-accounts {{args}}
 
 run-substrate-mock:
     npm init -y
@@ -85,11 +85,11 @@ update:
 # ------------------------------------------------------------------------------
 # Importer: Download external RPC blocks to temporary storage
 importer-download *args="":
-    cargo run --bin importer-download --release -- --postgres {{postgres_url}} --external-rpc {{testnet_url}} {{args}}
+    RUST_LOG={{env("RUST_LOG", "importer-download=info,stratus=info")}} cargo run --bin importer-download --features dev --release -- --postgres {{postgres_url}} --external-rpc {{testnet_url}} {{args}}
 
 # Importer: Import downloaded external RPC blocks to Stratus storage
 importer-import *args="":
-    cargo run --bin importer-import --release -- --postgres {{postgres_url}} {{args}}
+    RUST_LOG={{env("RUST_LOG", "importer-import=info,stratus=info")}} cargo run --bin importer-import   --features dev --release -- --postgres {{postgres_url}} {{args}}
 
 # ------------------------------------------------------------------------------
 # Test tasks

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,10 +15,12 @@ use tokio::runtime::Runtime;
 
 use crate::eth::evm::revm::Revm;
 use crate::eth::evm::Evm;
+#[cfg(feature = "dev")]
 use crate::eth::primitives::test_accounts;
 use crate::eth::primitives::Address;
 use crate::eth::primitives::BlockNumber;
 use crate::eth::primitives::BlockSelection;
+#[cfg(feature = "dev")]
 use crate::eth::primitives::StoragePointInTime;
 use crate::eth::storage::InMemoryPermanentStorage;
 use crate::eth::storage::InMemoryTemporaryStorage;
@@ -26,6 +28,7 @@ use crate::eth::storage::PermanentStorage;
 use crate::eth::storage::StratusStorage;
 use crate::eth::BlockMiner;
 use crate::eth::EthExecutor;
+#[cfg(feature = "dev")]
 use crate::ext::not;
 use crate::infra::postgres::Postgres;
 
@@ -93,10 +96,6 @@ pub struct RpcPollerConfig {
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 pub struct CommonConfig {
-    /// Environment where the application is running.
-    #[arg(value_enum, short = 'e', long = "env", env = "ENV", default_value_t = Environment::Development)]
-    pub env: Environment,
-
     /// Storage implementation.
     #[arg(short = 's', long = "storage", env = "STORAGE", default_value_t = StorageConfig::InMemory)]
     pub storage: StorageConfig,
@@ -118,6 +117,7 @@ pub struct CommonConfig {
     pub enable_genesis: bool,
 
     /// Enables test accounts with max wei on startup.
+    #[cfg(feature = "dev")]
     #[arg(long = "enable-test-accounts", env = "ENABLE_TEST_ACCOUNTS", default_value = "false")]
     pub enable_test_accounts: bool,
 }
@@ -135,22 +135,19 @@ impl CommonConfig {
             }
         }
 
+        #[cfg(feature = "dev")]
         if self.enable_test_accounts {
-            if self.env.is_development() {
-                let mut test_accounts_to_insert = Vec::new();
-                for test_account in test_accounts() {
-                    let storage_account = storage.read_account(&test_account.address, &StoragePointInTime::Present).await?;
-                    if storage_account.is_empty() {
-                        test_accounts_to_insert.push(test_account);
-                    }
+            let mut test_accounts_to_insert = Vec::new();
+            for test_account in test_accounts() {
+                let storage_account = storage.read_account(&test_account.address, &StoragePointInTime::Present).await?;
+                if storage_account.is_empty() {
+                    test_accounts_to_insert.push(test_account);
                 }
+            }
 
-                if not(test_accounts_to_insert.is_empty()) {
-                    tracing::info!(accounts = ?test_accounts_to_insert, "enabling test accounts");
-                    storage.save_accounts_to_perm(test_accounts_to_insert).await?;
-                }
-            } else {
-                tracing::warn!("cannot enable test accounts in non-development environment");
+            if not(test_accounts_to_insert.is_empty()) {
+                tracing::info!(accounts = ?test_accounts_to_insert, "enabling test accounts");
+                storage.save_accounts_to_perm(test_accounts_to_insert).await?;
             }
         }
 
@@ -222,38 +219,6 @@ impl FromStr for StorageConfig {
             "inmemory" => Ok(Self::InMemory),
             s if s.starts_with("postgres://") => Ok(Self::Postgres { url: s.to_string() }),
             s => Err(anyhow!("unknown storage: {}", s)),
-        }
-    }
-}
-
-/// Enviroment where the application is running.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
-pub enum Environment {
-    Development,
-    Production,
-}
-
-impl Environment {
-    /// Checks if the current environment is production.
-    pub fn is_production(&self) -> bool {
-        matches!(self, Self::Production)
-    }
-
-    /// Checks if the current environment is development.
-    pub fn is_development(&self) -> bool {
-        matches!(self, Self::Development)
-    }
-}
-
-impl FromStr for Environment {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let s = s.trim().to_lowercase();
-        match s.as_str() {
-            "dev" | "development" => Ok(Self::Development),
-            "prod" | "production" => Ok(Self::Production),
-            s => Err(anyhow!("unknown environment: {}", s)),
         }
     }
 }

--- a/src/eth/block_miner.rs
+++ b/src/eth/block_miner.rs
@@ -41,7 +41,7 @@ impl BlockMiner {
     }
 
     /// Mine one block with no transactions.
-    #[cfg(feature = "evm-mine")]
+    #[cfg(feature = "dev")]
     pub async fn mine_with_no_transactions(&mut self) -> anyhow::Result<Block> {
         let number = self.storage.increment_block_number().await?;
         Ok(Block::new_with_capacity(number, UnixTime::now(), 0))

--- a/src/eth/evm/revm.rs
+++ b/src/eth/evm/revm.rs
@@ -10,7 +10,6 @@ use std::time::Instant;
 
 use anyhow::anyhow;
 use itertools::Itertools;
-use revm::interpreter::InstructionResult;
 use revm::primitives::AccountInfo;
 use revm::primitives::Address as RevmAddress;
 use revm::primitives::Bytecode as RevmBytecode;
@@ -23,7 +22,6 @@ use revm::primitives::TransactTo;
 use revm::primitives::B256;
 use revm::primitives::U256;
 use revm::Database;
-use revm::Inspector;
 use revm::EVM;
 use tokio::runtime::Handle;
 
@@ -97,10 +95,6 @@ impl Evm for Revm {
         tx.value = input.value.into();
 
         // execute evm
-        #[cfg(debug_assertions)]
-        let evm_result = evm.inspect(RevmInspector {});
-
-        #[cfg(not(debug_assertions))]
         let evm_result = evm.transact();
 
         // parse result and track metrics
@@ -199,32 +193,6 @@ impl Database for RevmDatabaseSession {
 
     fn block_hash(&mut self, _: U256) -> anyhow::Result<B256> {
         todo!()
-    }
-}
-
-// -----------------------------------------------------------------------------
-// Inspector
-// -----------------------------------------------------------------------------
-struct RevmInspector;
-
-impl Inspector<RevmDatabaseSession> for RevmInspector {
-    fn step(&mut self, _interpreter: &mut revm::interpreter::Interpreter, _: &mut revm::EVMData<'_, RevmDatabaseSession>) -> InstructionResult {
-        // let arg1 = unsafe { *interpreter.instruction_pointer.add(1) };
-        // let arg2 = unsafe { *interpreter.instruction_pointer.add(2) };
-        // println!(
-        //     "{:02x} {:<9} {:<4x} {:<4x} {:?}",
-        //     interpreter.current_opcode(),
-        //     opcode::OPCODE_JUMPMAP[interpreter.current_opcode() as usize].unwrap(),
-        //     arg1,
-        //     arg2,
-        //     interpreter.stack.data(),
-        // );
-        // use revm::interpreter::opcode;
-        // match opcode::OPCODE_JUMPMAP[_interpreter.current_opcode() as usize] {
-        //     Some(opcode) => println!("{} ", opcode),
-        //     None => println!("{:#x} ", _interpreter.current_opcode() as usize),
-        // }
-        InstructionResult::Continue
     }
 }
 

--- a/src/eth/executor.rs
+++ b/src/eth/executor.rs
@@ -200,7 +200,7 @@ impl EthExecutor {
         result
     }
 
-    #[cfg(feature = "evm-mine")]
+    #[cfg(feature = "dev")]
     pub async fn mine_empty_block(&self) -> anyhow::Result<()> {
         let mut miner_lock = self.miner.lock().await;
         let block = miner_lock.mine_with_no_transactions().await?;

--- a/src/eth/rpc/rpc_context.rs
+++ b/src/eth/rpc/rpc_context.rs
@@ -1,7 +1,6 @@
 use std::fmt::Debug;
 use std::sync::Arc;
 
-use crate::config::Environment;
 use crate::eth::rpc::RpcSubscriptions;
 use crate::eth::storage::StratusStorage;
 use crate::eth::EthExecutor;
@@ -18,7 +17,6 @@ pub struct RpcContext {
     pub executor: EthExecutor,
     pub storage: Arc<StratusStorage>,
     pub subs: Arc<RpcSubscriptions>,
-    pub env: Environment,
 }
 
 impl Debug for RpcContext {
@@ -26,7 +24,6 @@ impl Debug for RpcContext {
         f.debug_struct("RpcContext")
             .field("chain_id", &self.chain_id)
             .field("client_version", &self.client_version)
-            .field("environment", &self.env)
             .field("gas_price", &self.gas_price)
             .finish_non_exhaustive()
     }


### PR DESCRIPTION
All developments features are now behind the `dev` compilation flag.

The flag is not enabled by default, but Justfile pass the `dev` flag in `cargo run` commands.

If necessary, we can create more granular flags, but we should try to fit the feature behind `dev` first, and only if really necessary we should create additional flags.

`RevmInspector` was removed, but that is a good candidate of feature that we may want to have a more granular flag if we want it back, because even in `dev` mode, we may not want to execute Evm with an inspector.