### PR TITLE
feat: performance measurements and improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1068,6 +1068,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fancy-duration"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3ae60718ae501dca9d27fd0e322683c86a95a1a01fac1807aa2f9b035cc0882"
+dependencies = [
+ "anyhow",
+ "lazy_static",
+ "regex",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3725,6 +3736,7 @@ dependencies = [
  "ethereum-types",
  "ethers-core",
  "fake",
+ "fancy-duration",
  "futures",
  "glob",
  "hex-literal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,7 @@ fake = { version = "2.9.2", features = ["derive"] }
 
 [dev-dependencies]
 binary_macros = "1.0.0"
+fancy-duration = "0.9.2"
 serial_test = "2.0.0"
 stringreader = "0.1.1"
 

--- a/src/eth/primitives/bytes.rs
+++ b/src/eth/primitives/bytes.rs
@@ -12,6 +12,7 @@ use std::fmt::Display;
 use std::ops::Deref;
 
 use ethers_core::types::Bytes as EthersBytes;
+use revm::interpreter::analysis::to_analysed;
 use revm::primitives::Bytecode as RevmBytecode;
 use revm::primitives::Bytes as RevmBytes;
 use revm::primitives::Output as RevmOutput;
@@ -135,6 +136,6 @@ impl From<Bytes> for RevmBytes {
 
 impl From<Bytes> for RevmBytecode {
     fn from(value: Bytes) -> Self {
-        RevmBytecode::new_raw(value.0.into())
+        to_analysed(RevmBytecode::new_raw(value.0.into()))
     }
 }

--- a/tests/test_import_offline_snapshot.rs
+++ b/tests/test_import_offline_snapshot.rs
@@ -1,6 +1,8 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use const_format::formatcp;
+use fancy_duration::AsFancyDuration;
 use itertools::Itertools;
 use stratus::config::CommonConfig;
 use stratus::eth::primitives::ExternalBlock;
@@ -106,8 +108,15 @@ async fn test_import_offline_snapshot() {
             }
 
             for result in results {
-                let value = result.get("value").unwrap().as_array().unwrap().last().unwrap().as_str().unwrap();
-                println!("{:<64} = {}", query, value);
+                let value: &str = result.get("value").unwrap().as_array().unwrap().last().unwrap().as_str().unwrap();
+                let value: f64 = value.parse().unwrap();
+
+                if query.contains("_count") {
+                    println!("{:<64} = {}", query, value);
+                } else {
+                    let secs = Duration::from_secs_f64(value);
+                    println!("{:<64} = {}", query, secs.fancy_duration().truncate(1));
+                }
             }
             break;
         }

--- a/tests/test_import_offline_snapshot.rs
+++ b/tests/test_import_offline_snapshot.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 use std::time::Duration;
+use std::time::Instant;
 
 use const_format::formatcp;
 use fancy_duration::AsFancyDuration;
@@ -99,8 +100,9 @@ async fn test_import_offline_snapshot() {
 
         // get metrics and print them
         // iterate until prometheus returns something
+        let start = Instant::now();
         let url = format!("{}?query={}", docker.prometheus_api_url(), query);
-        loop {
+        while Instant::now() <= (start + Duration::from_secs(10)) {
             let response = reqwest::get(&url).await.unwrap().json::<serde_json::Value>().await.unwrap();
             let results = response.get("data").unwrap().get("result").unwrap().as_array().unwrap();
             if results.is_empty() {


### PR DESCRIPTION
* Improvements to test_import_offline_snapshot test
* Always calling `to_analysed` in the bytecode conversion decreased 200ms from EVM execution.

Other possible improvements spots like using a faster keccak256 implementation were identified, but we are using REVM 3.5.0 and the latest version is 7.1.0, so we should upgrade REVM before focusing on more EVM related optimizations.