### PR TITLE
chore: upgrade revm to 7.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,9 +47,9 @@ checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
 name = "alloy-primitives"
-version = "0.4.2"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0628ec0ba5b98b3370bb6be17b12f23bfce8ee4ad83823325a20546d9b03b78"
+checksum = "600d34d8de81e23b6d909c094e23b3d357e01ca36b78a8c5424c501eedbe86f0"
 dependencies = [
  "alloy-rlp",
  "bytes",
@@ -58,7 +58,12 @@ dependencies = [
  "derive_more",
  "hex-literal",
  "itoa",
+ "k256",
+ "keccak-asm",
+ "proptest",
+ "rand",
  "ruint",
+ "serde",
  "tiny-keccak",
 ]
 
@@ -68,20 +73,8 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d58d9f5da7b40e9bfff0b7e7816700be4019db97d4b6359fe7f94a9e22e42ac"
 dependencies = [
- "alloy-rlp-derive",
  "arrayvec",
  "bytes",
-]
-
-[[package]]
-name = "alloy-rlp-derive"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a047897373be4bbb0224c1afdabca92648dc57a9c9ef6e7b0be3aff7a859c83"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.48",
 ]
 
 [[package]]
@@ -154,6 +147,130 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
 
 [[package]]
+name = "ark-ff"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b3235cc41ee7a12aaaf2c575a2ad7b46713a8a50bda2fc3b003a04845c05dd6"
+dependencies = [
+ "ark-ff-asm 0.3.0",
+ "ark-ff-macros 0.3.0",
+ "ark-serialize 0.3.0",
+ "ark-std 0.3.0",
+ "derivative",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "rustc_version 0.3.3",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
+dependencies = [
+ "ark-ff-asm 0.4.2",
+ "ark-ff-macros 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
+ "derivative",
+ "digest 0.10.7",
+ "itertools 0.10.5",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "rustc_version 0.4.0",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db02d390bf6643fb404d3d22d31aee1c4bc4459600aef9113833d17e786c6e44"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6c2b318ee6e10f8c2853e73a83adc0ccb88995aa978d8a3408d492ab2ee671"
+dependencies = [
+ "ark-std 0.3.0",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
+dependencies = [
+ "ark-std 0.4.0",
+ "digest 0.10.7",
+ "num-bigint",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
+dependencies = [
+ "num-traits",
+ "rand",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
+dependencies = [
+ "num-traits",
+ "rand",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -201,10 +318,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "auto_impl"
-version = "1.1.2"
+name = "aurora-engine-modexp"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "823b8bb275161044e2ac7a25879cb3e2480cb403e3943022c7c769c599b756aa"
+checksum = "bfacad86e9e138fca0670949eb8ed4ffdf73a55bded8887efe0863cd1a3a6f70"
+dependencies = [
+ "hex",
+ "num",
+]
+
+[[package]]
+name = "auto_impl"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -298,27 +425,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "bindgen"
-version = "0.66.1"
+name = "bit-set"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
 dependencies = [
- "bitflags 2.4.2",
- "cexpr",
- "clang-sys",
- "lazy_static",
- "lazycell",
- "log",
- "peeking_take_while",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "syn 2.0.48",
- "which",
+ "bit-vec",
 ]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
@@ -416,11 +535,10 @@ dependencies = [
 
 [[package]]
 name = "c-kzg"
-version = "0.1.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac926d808fb72fe09ebf471a091d6d72918876ccf0b4989766093d2d0d24a0ef"
+checksum = "94a4bc5367b6284358d2a6a6a1dc2d92ec4b86034561c3b9d3341909752fd848"
 dependencies = [
- "bindgen",
  "blst",
  "cc",
  "glob",
@@ -436,15 +554,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
 ]
 
 [[package]]
@@ -466,17 +575,6 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-targets 0.52.0",
-]
-
-[[package]]
-name = "clang-sys"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67523a3b4be3ce1989d607a828d036249522dd9c1c8de7f4dd2dae43a37369d1"
-dependencies = [
- "glob",
- "libc",
- "libloading",
 ]
 
 [[package]]
@@ -791,6 +889,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "derive-new"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -810,7 +919,7 @@ dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "rustc_version",
+ "rustc_version 0.4.0",
  "syn 1.0.109",
 ]
 
@@ -864,6 +973,12 @@ dependencies = [
  "quote",
  "syn 2.0.48",
 ]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
 name = "ecdsa"
@@ -1083,6 +1198,17 @@ name = "fastrand"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+
+[[package]]
+name = "fastrlp"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139834ddba373bbdd213dffe02c8d110508dcf1726c2be27e8d1f7d7e1856418"
+dependencies = [
+ "arrayvec",
+ "auto_impl",
+ "bytes",
+]
 
 [[package]]
 name = "ff"
@@ -1676,6 +1802,15 @@ checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
 name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
@@ -1857,6 +1992,7 @@ dependencies = [
  "elliptic-curve",
  "once_cell",
  "sha2",
+ "signature",
 ]
 
 [[package]]
@@ -1866,6 +2002,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
 dependencies = [
  "cpufeatures",
+]
+
+[[package]]
+name = "keccak-asm"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb8515fff80ed850aea4a1595f2e519c003e2a00a82fe168ebf5269196caf444"
+dependencies = [
+ "digest 0.10.7",
+ "sha3-asm",
 ]
 
 [[package]]
@@ -1889,26 +2035,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "libc"
 version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
-
-[[package]]
-name = "libloading"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c571b676ddfc9a8c12f1f3d3085a7b163966a8fd8098a90640953ce5f6170161"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
-]
 
 [[package]]
 name = "libm"
@@ -2417,12 +2547,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
-name = "peeking_take_while"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
-
-[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2436,6 +2560,17 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "pest"
+version = "2.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f8023d0fb78c8e03784ea1c7f3fa36e68a723138990b8d5a47d916b651e7a8"
+dependencies = [
+ "memchr",
+ "thiserror",
+ "ucd-trie",
+]
 
 [[package]]
 name = "phf"
@@ -2553,16 +2688,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
-name = "prettyplease"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a41cf62165e97c7f814d2221421dbb9afcbcdb0a88068e5ea206e19951c2cbb5"
-dependencies = [
- "proc-macro2",
- "syn 2.0.48",
-]
-
-[[package]]
 name = "primitive-types"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2625,6 +2750,8 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b476131c3c86cb68032fdc5cb6d5a1045e3e42d96b69fa599fd77701e1f5bf"
 dependencies = [
+ "bit-set",
+ "bit-vec",
  "bitflags 2.4.2",
  "lazy_static",
  "num-traits",
@@ -2632,6 +2759,8 @@ dependencies = [
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax 0.8.2",
+ "rusty-fork",
+ "tempfile",
  "unarray",
 ]
 
@@ -2650,6 +2779,12 @@ dependencies = [
  "web-sys",
  "winapi",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -2809,33 +2944,38 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "3.5.0"
+version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f4ca8ae0345104523b4af1a8a7ea97cfa1865cdb7a7c25d23c1a18d9b48598"
+checksum = "217d21144d329f21d5245b8e6a46e0d6d0a527d9917d7a087f225b161e529169"
 dependencies = [
  "auto_impl",
+ "cfg-if",
+ "dyn-clone",
  "revm-interpreter",
  "revm-precompile",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
 name = "revm-interpreter"
-version = "1.3.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f959cafdf64a7f89b014fa73dc2325001cf654b3d9400260b212d19a2ebe3da0"
+checksum = "776848391ed76d5103ca1aa1632cd21b521e2870afb30b63723da862d69efd0f"
 dependencies = [
  "revm-primitives",
+ "serde",
 ]
 
 [[package]]
 name = "revm-precompile"
-version = "2.2.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d360a88223d85709d2e95d4609eb1e19c649c47e28954bfabae5e92bb37e83e"
+checksum = "e3fd1856a7cb09197a02669d779e1afb5a627b0888a24814ba2b6a1ad4c3ff8d"
 dependencies = [
+ "aurora-engine-modexp",
  "c-kzg",
  "k256",
- "num",
  "once_cell",
  "revm-primitives",
  "ripemd",
@@ -2846,20 +2986,23 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
-version = "1.3.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51187b852d9e458816a2e19c81f1dd6c924077e1a8fccd16e4f044f865f299d7"
+checksum = "2a4d7d3e793e907dc0797a9d3b43abfdf5226d133855214db9bd27d4cee33ebd"
 dependencies = [
  "alloy-primitives",
- "alloy-rlp",
  "auto_impl",
  "bitflags 2.4.2",
  "bitvec",
  "c-kzg",
+ "cfg-if",
+ "derive_more",
+ "dyn-clone",
  "enumn",
  "hashbrown 0.14.3",
  "hex",
  "once_cell",
+ "serde",
 ]
 
 [[package]]
@@ -2950,8 +3093,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "608a5726529f2f0ef81b8fde9873c4bb829d6b5b5ca6be4d97345ddf0749c825"
 dependencies = [
  "alloy-rlp",
+ "ark-ff 0.3.0",
+ "ark-ff 0.4.2",
+ "bytes",
+ "fastrlp",
+ "num-bigint",
+ "num-traits",
+ "parity-scale-codec",
+ "primitive-types",
  "proptest",
  "rand",
+ "rlp",
  "ruint-macro",
  "serde",
  "valuable",
@@ -2984,11 +3136,20 @@ checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustc_version"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
+dependencies = [
+ "semver 0.11.0",
+]
+
+[[package]]
+name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver",
+ "semver 1.0.21",
 ]
 
 [[package]]
@@ -3108,6 +3269,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3178,18 +3351,18 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.27.0"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
+checksum = "d24b59d129cdadea20aea4fb2352fa053712e5d713eee47d700cd4b2bc002f10"
 dependencies = [
  "secp256k1-sys",
 ]
 
 [[package]]
 name = "secp256k1-sys"
-version = "0.8.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a129b9e9efbfb223753b9163c4ab3b13cff7fd9c7f010fbac25ab4099fa07e"
+checksum = "e5d1746aae42c19d583c3c1a8c646bfad910498e2051c551a7f2e3c0c9fbb7eb"
 dependencies = [
  "cc",
 ]
@@ -3219,9 +3392,27 @@ dependencies = [
 
 [[package]]
 name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
+
+[[package]]
+name = "semver-parser"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
+dependencies = [
+ "pest",
+]
 
 [[package]]
 name = "send_wrapper"
@@ -3255,6 +3446,7 @@ version = "1.0.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
 dependencies = [
+ "indexmap 2.2.5",
  "itoa",
  "ryu",
  "serde",
@@ -3394,6 +3586,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha3-asm"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bac61da6b35ad76b195eb4771210f947734321a8d81d7738e1580d953bc7a15e"
+dependencies = [
+ "cc",
+ "cfg-if",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3401,12 +3603,6 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
-
-[[package]]
-name = "shlex"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signature"
@@ -3502,7 +3698,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce81b7bd7c4493975347ef60d8c7e8b742d4694f4c49f93e0a12ea263938176c"
 dependencies = [
- "itertools",
+ "itertools 0.12.1",
  "nom",
  "unicode_categories",
 ]
@@ -3741,7 +3937,7 @@ dependencies = [
  "glob",
  "hex-literal",
  "indexmap 2.2.5",
- "itertools",
+ "itertools 0.12.1",
  "jsonrpsee",
  "keccak-hasher",
  "metrics",
@@ -4276,6 +4472,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
+name = "ucd-trie"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
+
+[[package]]
 name = "uint"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4380,6 +4582,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4477,18 +4688,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3de34ae270483955a94f4b21bdaaeb83d508bb84a01435f393818edb0012009"
 dependencies = [
  "rustls-pki-types",
-]
-
-[[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ ethereum-types = "0.14.1"
 ethers-core = "2.0.11"
 keccak-hasher = "0.15.0" # this version must be compatible with triehash
 rlp = "0.5.2"
-revm = "3.5.0"
+revm = "7.1.0"
 triehash = "0.8.4"
 
 # network

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,12 +5,13 @@ use std::fmt::Debug;
 use std::net::SocketAddr;
 use std::str::FromStr;
 use std::sync::Arc;
+use std::thread;
 use std::time::Duration;
 
 use anyhow::anyhow;
 use clap::Parser;
-use nonempty::NonEmpty;
 use tokio::runtime::Builder;
+use tokio::runtime::Handle;
 use tokio::runtime::Runtime;
 
 use crate::eth::evm::revm::Revm;
@@ -28,6 +29,7 @@ use crate::eth::storage::PermanentStorage;
 use crate::eth::storage::StratusStorage;
 use crate::eth::BlockMiner;
 use crate::eth::EthExecutor;
+use crate::eth::EvmTask;
 #[cfg(feature = "dev")]
 use crate::ext::not;
 use crate::infra::postgres::Postgres;
@@ -265,17 +267,39 @@ impl CommonConfig {
         Ok(storage)
     }
 
-    /// Initializes EthExecutor.
+    /// Initializes EthExecutor. Should be called inside an async runtime.
     pub fn init_executor(&self, storage: Arc<StratusStorage>) -> EthExecutor {
         let num_evms = max(self.num_evms, 1);
-        tracing::info!(evms = %num_evms, "starting executor");
+        tracing::info!(evms = %num_evms, "starting executor and evms");
 
-        let mut evms: Vec<Box<dyn Evm>> = Vec::with_capacity(num_evms);
+        // spawn evm in background using native threads
+        let (evm_tx, evm_rx) = crossbeam_channel::unbounded::<EvmTask>();
         for _ in 1..=num_evms {
-            evms.push(Box::new(Revm::new(Arc::clone(&storage))));
+            // create evm resources
+            let evm_storage = Arc::clone(&storage);
+            let evm_tokio = Handle::current();
+            let evm_rx = evm_rx.clone();
+
+            // spawn thread that will run evm
+            let t = thread::Builder::new().name("evm".into());
+            t.spawn(move || {
+                let _tokio_guard = evm_tokio.enter();
+                let mut evm = Revm::new(evm_storage);
+
+                // keep executing transactions until the channel is closed
+                while let Ok((input, tx)) = evm_rx.recv() {
+                    let result = evm.execute(input);
+                    if let Err(e) = tx.send(result) {
+                        tracing::error!(reason = ?e, "failed to send evm execution result");
+                    };
+                }
+                tracing::warn!("stopping evm thread because task channel was closed");
+            })
+            .expect("spawning evm threads should not fail");
         }
 
-        EthExecutor::new(NonEmpty::from_vec(evms).unwrap(), Arc::clone(&storage))
+        // creates an executor that can communicate with background evms
+        EthExecutor::new(evm_tx, Arc::clone(&storage))
     }
 
     /// Initializes Tokio runtime.

--- a/src/eth/evm/evm.rs
+++ b/src/eth/evm/evm.rs
@@ -27,13 +27,13 @@ use crate::if_else;
 pub type EvmExecutionResult = (Execution, ExecutionMetrics);
 
 /// EVM operations.
-pub trait Evm: Send + Sync + 'static {
+pub trait Evm {
     /// Execute a transaction that deploys a contract or call a contract function.
     fn execute(&mut self, input: EvmInput) -> anyhow::Result<EvmExecutionResult>;
 }
 
 /// EVM input data. Usually derived from a transaction or call.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct EvmInput {
     /// Operation party address.
     ///

--- a/src/eth/evm/revm.rs
+++ b/src/eth/evm/revm.rs
@@ -23,7 +23,8 @@ use revm::primitives::TransactTo;
 use revm::primitives::B256;
 use revm::primitives::U256;
 use revm::Database;
-use revm::EVM;
+use revm::Evm as RevmEvm;
+use revm::Handler;
 use tokio::runtime::Handle;
 
 use crate::eth::evm::evm::EvmExecutionResult;
@@ -49,24 +50,29 @@ use crate::infra::metrics;
 
 /// Implementation of EVM using [`revm`](https://crates.io/crates/revm).
 pub struct Revm {
-    evm: EVM<RevmDatabaseSession>,
-    storage: Arc<StratusStorage>,
+    evm: RevmEvm<'static, (), RevmDatabaseSession>,
 }
 
 impl Revm {
     /// Creates a new instance of the Revm ready to be used.
     pub fn new(storage: Arc<StratusStorage>) -> Self {
-        let mut evm = EVM::new();
+        let mut evm = RevmEvm::builder()
+            .with_handler(Handler::mainnet_with_spec(SpecId::LONDON))
+            .with_external_context(())
+            .with_db(RevmDatabaseSession::new(storage))
+            .build();
 
         // evm general config
-        evm.env.cfg.spec_id = SpecId::LONDON;
-        evm.env.cfg.limit_contract_code_size = Some(usize::MAX);
-        evm.env.block.coinbase = Address::COINBASE.into();
+        let cfg_env = evm.cfg_mut();
+        cfg_env.limit_contract_code_size = Some(usize::MAX);
 
-        // evm tx config
-        evm.env.tx.gas_priority_fee = None;
+        let block_env = evm.block_mut();
+        block_env.coinbase = Address::COINBASE.into();
 
-        Self { evm, storage }
+        let tx_env = evm.tx_mut();
+        tx_env.gas_priority_fee = None;
+
+        Self { evm }
     }
 }
 
@@ -76,48 +82,50 @@ impl Evm for Revm {
 
         // configure session
         let evm = &mut self.evm;
-        let session = RevmDatabaseSession::new(Arc::clone(&self.storage), input.clone());
-        evm.database(session);
+        evm.db_mut().reset(input.clone());
 
         // configure evm block
-        evm.env.block.basefee = U256::ZERO;
-        evm.env.block.timestamp = input.block_timestamp.into();
-        evm.env.block.number = input.block_number.into();
+        let block_env = evm.block_mut();
+        block_env.basefee = U256::ZERO;
+        block_env.timestamp = input.block_timestamp.into();
+        block_env.number = input.block_number.into();
 
         // configure tx params
-        let tx = &mut evm.env.tx;
-        tx.caller = input.from.into();
-        tx.transact_to = match input.to {
+        let tx_env = &mut evm.tx_mut();
+        tx_env.caller = input.from.into();
+        tx_env.transact_to = match input.to {
             Some(contract) => TransactTo::Call(contract.into()),
             None => TransactTo::Create(CreateScheme::Create),
         };
-        tx.gas_limit = input.gas_limit.into();
-        tx.gas_price = input.gas_price.into();
-        tx.nonce = input.nonce.map_into();
-        tx.data = input.data.into();
-        tx.value = input.value.into();
+        tx_env.gas_limit = input.gas_limit.into();
+        tx_env.gas_price = input.gas_price.into();
+        tx_env.nonce = input.nonce.map_into();
+        tx_env.data = input.data.into();
+        tx_env.value = input.value.into();
 
         // execute evm
         let evm_result = evm.transact();
 
         // parse result and track metrics
-        let session = evm.take_db();
-        let metrics = session.metrics;
-        let point_in_time = session.input.point_in_time.clone();
+        let session = evm.db_mut();
+        let session_input = std::mem::take(&mut session.input);
+        let session_point_in_time = std::mem::take(&mut session.input.point_in_time);
+        let session_storage_changes = std::mem::take(&mut session.storage_changes);
+        let session_metrics = std::mem::take(&mut session.metrics);
 
         let execution = match evm_result {
-            Ok(result) => Ok(parse_revm_execution(result, session.input, session.storage_changes)),
+            Ok(result) => Ok(parse_revm_execution(result, session_input, session_storage_changes)),
             Err(e) => {
                 tracing::warn!(reason = ?e, "evm execution error");
                 Err(e).context("Error executing EVM transaction.")
             }
         };
 
-        metrics::inc_evm_execution(start.elapsed(), &point_in_time, execution.is_ok());
-        metrics::inc_evm_execution_account_reads(metrics.account_reads);
-        metrics::inc_evm_execution_slot_reads(metrics.slot_reads);
+        metrics::inc_evm_execution(start.elapsed(), &session_point_in_time, execution.is_ok());
+        metrics::inc_evm_execution_account_reads(session_metrics.account_reads);
+        metrics::inc_evm_execution_slot_reads(session_metrics.slot_reads);
 
-        execution.map(|x| (x, metrics))
+        execution.map(|x| (x, session_metrics))
     }
 }
 
@@ -141,13 +149,21 @@ struct RevmDatabaseSession {
 }
 
 impl RevmDatabaseSession {
-    pub fn new(storage: Arc<StratusStorage>, input: EvmInput) -> Self {
+    /// Creates the base session to be used with REVM.
+    pub fn new(storage: Arc<StratusStorage>) -> Self {
         Self {
             storage,
-            input,
+            input: Default::default(),
             storage_changes: Default::default(),
             metrics: Default::default(),
         }
+    }
+
+    /// Resets the session to be used with a new transaction.
+    pub fn reset(&mut self, input: EvmInput) {
+        self.input = input;
+        self.storage_changes = Default::default();
+        self.metrics = Default::default();
     }
 }
 

--- a/src/eth/mod.rs
+++ b/src/eth/mod.rs
@@ -29,3 +29,4 @@ pub mod storage;
 
 pub use block_miner::BlockMiner;
 pub use executor::EthExecutor;
+pub use executor::EvmTask;

--- a/src/eth/primitives/log.rs
+++ b/src/eth/primitives/log.rs
@@ -34,8 +34,8 @@ impl From<RevmLog> for Log {
     fn from(value: RevmLog) -> Self {
         Self {
             address: value.address.into(),
-            topics: value.topics.into_iter().map_into().collect(),
-            data: value.data.into(),
+            topics: value.topics().iter().cloned().map_into().collect(),
+            data: value.data.data.into(),
         }
     }
 }

--- a/src/eth/primitives/storage_point_in_time.rs
+++ b/src/eth/primitives/storage_point_in_time.rs
@@ -10,9 +10,10 @@ use crate::eth::primitives::BlockNumber;
 use crate::infra::metrics::LabelValue;
 
 /// EVM storage point-in-time indicator.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub enum StoragePointInTime {
     /// The current state of the EVM storage.
+    #[default]
     Present,
 
     /// The state of the EVM storage at the given block number.

--- a/src/eth/primitives/unix_time.rs
+++ b/src/eth/primitives/unix_time.rs
@@ -19,7 +19,7 @@ use sqlx::database::HasValueRef;
 use sqlx::error::BoxDynError;
 use sqlx::types::BigDecimal;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct UnixTime(u64);
 
 impl UnixTime {

--- a/tests/test_execution.rs
+++ b/tests/test_execution.rs
@@ -1,54 +1,42 @@
-use std::sync::Arc;
+use ethers_core::rand::thread_rng;
+// Adjust this import to include your Revm and related structs
+use fake::{Dummy, Faker};
+use stratus::config::CommonConfig;
+use stratus::config::MetricsHistogramKind;
+use stratus::config::StorageConfig;
+use stratus::eth::primitives::test_accounts;
+use stratus::eth::primitives::TransactionInput;
+use stratus::eth::primitives::Wei;
 
-use stratus::eth::evm::revm::Revm;
+#[tokio::test]
+async fn test_execution() {
+    let storage: StorageConfig = "inmemory".parse().unwrap(); //XXX we need to use a real storage
+    let config = CommonConfig {
+        storage: storage.clone(),
+        storage_max_connections: 1usize,
+        storage_acquire_timeout: 100usize,
+        num_evms: 1usize,
+        num_async_threads: 1usize,
+        num_blocking_threads: 1usize,
+        metrics_histogram_kind: MetricsHistogramKind::Summary,
+        enable_genesis: false,
+        nocapture: false,
+    };
+    let storage = storage.init(&config).await.unwrap();
+    let mut rng = thread_rng();
+    let mut fake_transaction_input = TransactionInput::dummy_with_rng(&Faker, &mut rng);
+    fake_transaction_input.nonce = 0u64.into();
+    fake_transaction_input.gas_price = 0u64.into();
+    fake_transaction_input.gas_limit = 0u64.into();
 
-#[cfg(test)]
-mod tests {
-    use ethers_core::rand::thread_rng;
-    // Adjust this import to include your Revm and related structs
-    use fake::{Dummy, Faker};
-    use nonempty::nonempty;
-    use stratus::config::CommonConfig;
-    use stratus::config::MetricsHistogramKind;
-    use stratus::config::StorageConfig;
-    use stratus::eth::primitives::test_accounts;
-    use stratus::eth::primitives::TransactionInput;
-    use stratus::eth::primitives::Wei;
-    use stratus::eth::EthExecutor;
+    let accounts = test_accounts();
+    storage.save_accounts_to_perm(accounts.clone()).await.unwrap();
 
-    use super::*;
+    let address = accounts.last().unwrap().address.clone();
+    fake_transaction_input.from = address;
+    fake_transaction_input.value = Wei::from(0u64);
 
-    #[tokio::test]
-    async fn test_execution() {
-        let storage: StorageConfig = "inmemory".parse().unwrap(); //XXX we need to use a real storage
-        let config = CommonConfig {
-            storage: storage.clone(),
-            storage_max_connections: 1usize,
-            storage_acquire_timeout: 100usize,
-            num_evms: 1usize,
-            num_async_threads: 1usize,
-            num_blocking_threads: 1usize,
-            metrics_histogram_kind: MetricsHistogramKind::Summary,
-            enable_genesis: false,
-            nocapture: false,
-        };
-        let storage = storage.init(&config).await.unwrap();
-        let mut rng = thread_rng();
-        let mut fake_transaction_input = TransactionInput::dummy_with_rng(&Faker, &mut rng);
-        fake_transaction_input.nonce = 0u64.into();
-        fake_transaction_input.gas_price = 0u64.into();
-        fake_transaction_input.gas_limit = 0u64.into();
+    let executor = config.init_executor(storage);
 
-        let accounts = test_accounts();
-        storage.save_accounts_to_perm(accounts.clone()).await.unwrap();
-
-        let address = accounts.last().unwrap().address.clone();
-        fake_transaction_input.from = address;
-        fake_transaction_input.value = Wei::from(0u64);
-
-        let revm = Box::new(Revm::new(Arc::clone(&storage)));
-        let executor = EthExecutor::new(nonempty![revm], Arc::clone(&storage));
-
-        executor.transact(fake_transaction_input).await.unwrap();
-    }
+    executor.transact(fake_transaction_input).await.unwrap();
 }

--- a/tests/test_import_offline_snapshot.rs
+++ b/tests/test_import_offline_snapshot.rs
@@ -100,9 +100,10 @@ async fn test_import_offline_snapshot() {
 
         // get metrics and print them
         // iterate until prometheus returns something
-        let start = Instant::now();
         let url = format!("{}?query={}", docker.prometheus_api_url(), query);
-        while Instant::now() <= (start + Duration::from_secs(10)) {
+
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while Instant::now() <= deadline {
             let response = reqwest::get(&url).await.unwrap().json::<serde_json::Value>().await.unwrap();
             let results = response.get("data").unwrap().get("result").unwrap().as_array().unwrap();
             if results.is_empty() {


### PR DESCRIPTION
* Upgraded REVM to 7.1.0
  * In high-level view, REVM interaction still working the same way by mutatin the current env configurations. In a next PR we can evaluate if there are better way to interact with it.
* EVMs are now created directly in their own threads instead of being created in the main thread and moved to another threads, so they don't need to be Send + Sync anymore.