### PR TITLE
feat: base csv writer and storage/postgres configurations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -779,6 +779,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac574ff4d437a7b5ad237ef331c17ccca63c46479e5b5453eb8e10bb99a759fe"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "darling"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3926,6 +3947,7 @@ dependencies = [
  "const-hex",
  "const_format",
  "crossbeam-channel",
+ "csv",
  "derive-new",
  "derive_more",
  "ethabi",
@@ -3969,6 +3991,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "triehash",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ chrono = "0.4.31"
 clap = { version = "4.4.18", features = ["derive", "env"] }
 const_format = "0.2.32"
 const-hex = "1.10.0"
+csv = "1.3.0"
 derive_more = "0.99.17"
 derive-new = "0.6.0"
 hex-literal = "0.4.1"
@@ -30,6 +31,7 @@ quote = "1.0.33"
 rand = "0.8.5"
 strum = "0.25.0"
 thiserror = "1.0.56"
+url = "2.5.0"
 
 # async
 tokio = { version = "1.35.1", features = ["rt-multi-thread", "macros"] }

--- a/src/bin/importer_offline.rs
+++ b/src/bin/importer_offline.rs
@@ -2,6 +2,7 @@ mod helpers;
 
 use std::cmp::min;
 use std::sync::Arc;
+use std::time::Duration;
 use std::time::Instant;
 
 use anyhow::anyhow;
@@ -14,11 +15,13 @@ use stratus::eth::primitives::Account;
 use stratus::eth::primitives::BlockNumber;
 use stratus::eth::primitives::BlockSelection;
 use stratus::eth::primitives::ExternalReceipts;
+use stratus::eth::storage::CsvExporter;
 use stratus::eth::storage::StratusStorage;
 use stratus::eth::EthExecutor;
 use stratus::ext::not;
 use stratus::infra::metrics;
 use stratus::infra::postgres::Postgres;
+use stratus::infra::postgres::PostgresClientConfig;
 use stratus::init_global_services;
 use stratus::log_and_err;
 use tokio::sync::mpsc;
@@ -38,7 +41,15 @@ type BacklogTask = (Vec<BlockRow>, Vec<ReceiptRow>);
 async fn main() -> anyhow::Result<()> {
     // init services
     let config: ImporterOfflineConfig = init_global_services();
-    let pg = Arc::new(Postgres::new(&config.postgres_url, 400usize, 20usize).await?);
+    let mut csv = CsvExporter::default();
+    let pg = Arc::new(
+        Postgres::new(PostgresClientConfig {
+            url: config.pg.pg_url.to_string(),
+            connections: config.pg.pg_connections,
+            acquire_timeout: Duration::from_millis(config.pg.pg_timeout_millis),
+        })
+        .await?,
+    );
     let storage = config.init_storage().await?;
     let executor = config.init_executor(Arc::clone(&storage));
 
@@ -52,11 +63,11 @@ async fn main() -> anyhow::Result<()> {
         .into_iter()
         .map(|row| Account::new_with_balance(row.address, row.balance))
         .collect_vec();
-    storage.save_accounts_to_perm(accounts).await?;
+    csv.export_accounts(accounts).await?;
 
     // execute parallel tasks (postgres loader and block importer)
     tokio::spawn(execute_postgres_loader(pg, storage, cancellation.clone(), config.paralellism, backlog_tx));
-    execute_block_importer(executor, cancellation, backlog_rx).await?;
+    execute_block_importer(executor, csv, cancellation, backlog_rx).await?;
 
     Ok(())
 }
@@ -67,6 +78,7 @@ async fn main() -> anyhow::Result<()> {
 async fn execute_block_importer(
     // services
     executor: EthExecutor,
+    mut csv: CsvExporter,
     cancellation: CancellationToken,
     // data
     mut backlog_rx: mpsc::Receiver<BacklogTask>,
@@ -89,7 +101,10 @@ async fn execute_block_importer(
         tracing::info!(%block_start, %block_end, receipts = %receipts.len(), "importing blocks");
         for block in blocks {
             let start = Instant::now();
-            executor.import_external(block.payload, &mut receipts).await?;
+
+            let block = executor.import_external(block.payload, &mut receipts).await?;
+            csv.export_block(block).await?;
+
             metrics::inc_import_offline(start.elapsed());
         }
     };

--- a/src/bin/importer_online.rs
+++ b/src/bin/importer_online.rs
@@ -44,7 +44,7 @@ async fn main() -> anyhow::Result<()> {
 
         // import block
         let mut receipts: ExternalReceipts = receipts.into();
-        executor.import_external(block, &mut receipts).await?;
+        executor.import_external_and_commit(block, &mut receipts).await?;
         metrics::inc_import_online(start.elapsed());
     }
 }

--- a/src/eth/primitives/account.rs
+++ b/src/eth/primitives/account.rs
@@ -19,7 +19,7 @@ use crate::eth::primitives::Wei;
 use crate::ext::OptionExt;
 
 /// Ethereum account (wallet or contract).
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct Account {
     /// Immutable address of the account.
     pub address: Address,

--- a/src/eth/storage/csv/csv_exporter.rs
+++ b/src/eth/storage/csv/csv_exporter.rs
@@ -1,0 +1,55 @@
+use std::fs::File;
+
+use anyhow::Context;
+
+use crate::eth::primitives::Account;
+use crate::eth::primitives::Block;
+use crate::eth::storage::StorageError;
+
+/// Export primitives to CSV files.
+pub struct CsvExporter {
+    accounts: csv::Writer<File>,
+    transactions: csv::Writer<File>,
+}
+
+impl Default for CsvExporter {
+    fn default() -> Self {
+        Self {
+            accounts: csv_writer("data/accounts.csv"),
+            transactions: csv_writer("data/transactions.csv"),
+        }
+    }
+}
+
+fn csv_writer(path: &'static str) -> csv::Writer<File> {
+    csv::WriterBuilder::new()
+        .has_headers(true)
+        .delimiter(b'\t')
+        .quote_style(csv::QuoteStyle::NonNumeric)
+        .from_path(path)
+        .unwrap()
+}
+
+impl CsvExporter {
+    pub async fn export_block(&mut self, block: Block) -> anyhow::Result<(), StorageError> {
+        for tx in block.transactions {
+            let row = [
+                tx.input.hash.to_string(),
+                tx.input.nonce.to_string(),
+                tx.input.from.to_string(),
+                tx.input.to.map(|x| x.to_string()).unwrap_or_default(),
+                tx.input.value.to_string(),
+            ];
+            self.transactions.write_record(row).context("failed to write csv transaction")?;
+        }
+
+        Ok(())
+    }
+
+    pub async fn export_accounts(&mut self, accounts: Vec<Account>) -> anyhow::Result<()> {
+        for account in accounts {
+            self.accounts.serialize(account).context("failed to write account")?;
+        }
+        Ok(())
+    }
+}

--- a/src/eth/storage/csv/mod.rs
+++ b/src/eth/storage/csv/mod.rs
@@ -1,0 +1,3 @@
+mod csv_exporter;
+
+pub use csv_exporter::CsvExporter;

--- a/src/eth/storage/mod.rs
+++ b/src/eth/storage/mod.rs
@@ -1,5 +1,6 @@
 //! Ethereum / EVM storage.
 
+mod csv;
 mod inmemory;
 mod permanent_storage;
 mod postgres;
@@ -7,6 +8,7 @@ mod storage_error;
 mod stratus_storage;
 mod temporary_storage;
 
+pub use csv::CsvExporter;
 pub use inmemory::InMemoryPermanentStorage;
 pub use inmemory::InMemoryPermanentStorageState;
 pub use inmemory::InMemoryTemporaryStorage;

--- a/src/eth/storage/permanent_storage.rs
+++ b/src/eth/storage/permanent_storage.rs
@@ -53,5 +53,6 @@ pub trait PermanentStorage: Send + Sync {
     /// Resets all state to a specific block number.
     async fn reset_at(&self, number: BlockNumber) -> anyhow::Result<()>;
 
+    /// TODO: document it.
     async fn read_slots_sample(&self, start: BlockNumber, end: BlockNumber, max_samples: u64, seed: u64) -> anyhow::Result<Vec<SlotSample>>;
 }

--- a/src/infra/postgres.rs
+++ b/src/infra/postgres.rs
@@ -29,18 +29,25 @@ pub struct Postgres {
     pub sload_cache: SloadCache,
 }
 
+#[derive(Debug)]
+pub struct PostgresClientConfig {
+    pub url: String,
+    pub connections: u32,
+    pub acquire_timeout: Duration,
+}
+
 impl Postgres {
-    pub async fn new(url: &str, max_connections: usize, acquire_timeout: usize) -> anyhow::Result<Self> {
-        tracing::info!(%url, "starting postgres client");
+    pub async fn new(config: PostgresClientConfig) -> anyhow::Result<Self> {
+        tracing::info!(?config, "starting postgres client");
 
         let connection_pool = PgPoolOptions::new()
-            .min_connections(1)
-            .max_connections(max_connections.try_into().unwrap_or(100))
-            .acquire_timeout(Duration::from_secs(acquire_timeout.try_into().unwrap_or(2)))
-            .connect(url)
+            .min_connections(config.connections)
+            .max_connections(config.connections)
+            .acquire_timeout(config.acquire_timeout)
+            .connect(&config.url)
             .await
             .map_err(|e| {
-                tracing::error!(reason = ?e, %url, "failed to start postgres client");
+                tracing::error!(reason = ?e, ?config, "failed to start postgres client");
                 anyhow!("failed to start postgres client")
             })?;
 
@@ -77,6 +84,8 @@ impl Postgres {
     }
 
     async fn new_sload_cache(connection_pool: PgPool) -> anyhow::Result<HashMap<(Address, SlotIndex), (SlotValue, BlockNumber)>> {
+        tracing::info!("loading sload cache");
+
         let raw_sload = sqlx::query_file_as!(SlotCache, "src/eth/storage/postgres/queries/select_slot_cache.sql", BigDecimal::from(0))
             .fetch_all(&connection_pool)
             .await?;

--- a/tests/test_execution.rs
+++ b/tests/test_execution.rs
@@ -3,18 +3,21 @@ use ethers_core::rand::thread_rng;
 use fake::{Dummy, Faker};
 use stratus::config::CommonConfig;
 use stratus::config::MetricsHistogramKind;
-use stratus::config::StorageConfig;
+use stratus::config::PermanentStorageConfig;
+use stratus::config::StorageKind;
 use stratus::eth::primitives::test_accounts;
 use stratus::eth::primitives::TransactionInput;
 use stratus::eth::primitives::Wei;
 
 #[tokio::test]
 async fn test_execution() {
-    let storage: StorageConfig = "inmemory".parse().unwrap(); //XXX we need to use a real storage
     let config = CommonConfig {
-        storage: storage.clone(),
-        storage_max_connections: 1usize,
-        storage_acquire_timeout: 100usize,
+        perm: PermanentStorageConfig {
+            perm_kind: StorageKind::InMemory,
+            perm_connections: 1,
+            perm_timeout_millis: 1000,
+            perm_proxy_csv: false,
+        },
         num_evms: 1usize,
         num_async_threads: 1usize,
         num_blocking_threads: 1usize,
@@ -22,7 +25,7 @@ async fn test_execution() {
         enable_genesis: false,
         nocapture: false,
     };
-    let storage = storage.init(&config).await.unwrap();
+    let storage = config.init_storage().await.unwrap();
     let mut rng = thread_rng();
     let mut fake_transaction_input = TransactionInput::dummy_with_rng(&Faker, &mut rng);
     fake_transaction_input.nonce = 0u64.into();

--- a/tests/test_import_offline_snapshot.rs
+++ b/tests/test_import_offline_snapshot.rs
@@ -85,8 +85,8 @@ async fn test_import_offline_snapshot() {
     let snapshot: InMemoryPermanentStorageState = serde_json::from_str(snapshot_json).unwrap();
     let pg = Postgres::new(PostgresClientConfig {
         url: docker.postgres_connection_url().to_owned(),
-        connections: 1,
-        acquire_timeout: Duration::from_secs(2),
+        connections: 5,
+        acquire_timeout: Duration::from_secs(10),
     })
     .await
     .unwrap();


### PR DESCRIPTION
* Postgres receives a `PostgresClientConfig` so it is easier to understand each parameter when reading code instead of relying on positional parameters.
* Number of connections and timeout is always configurable in all jobs. They were hardcoded in several places with huge values.
* Assume small values for connections instead of huge values that only makes sense in production.
* Very initial version of CSV exporter, it will be implemented in a next PR.