### PR TITLE
feat: improving csv exporter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,10 @@
 .tool-versions
 
 # Data
-data/*.csv
-data/*.db
-data/*.json
+data/**/*.csv
+data/**/*.db
+data/**/*.json
+data/**/*.txt
 
 # E2E (Stratus)
 e2e/artifacts

--- a/src/bin/importer_offline.rs
+++ b/src/bin/importer_offline.rs
@@ -146,8 +146,7 @@ async fn execute_external_rpc_storage_loader(
 ) -> anyhow::Result<()> {
     tracing::info!("external rpc storage loader starting");
 
-    // if active, resume from the previous
-
+    // find last block number
     let end = match rpc_storage.read_max_block_number_in_range(BlockNumber::ZERO, BlockNumber::MAX).await {
         Ok(Some(number)) => number,
         Ok(None) => BlockNumber::ZERO,

--- a/src/bin/importer_offline.rs
+++ b/src/bin/importer_offline.rs
@@ -40,7 +40,9 @@ async fn main() -> anyhow::Result<()> {
     let rpc_storage = config.rpc_storage.init().await?;
     let stratus_storage = config.init_stratus_storage().await?;
     let executor = config.init_executor(Arc::clone(&stratus_storage));
-    let mut csv = if_else!(config.export_csv, Some(CsvExporter::new()?), None);
+
+    let block_start = block_number_to_resume(&stratus_storage).await?;
+    let mut csv = if_else!(config.export_csv, Some(CsvExporter::new(block_start)?), None);
 
     // init shared data between importer and external rpc storage loader
     let (backlog_tx, backlog_rx) = mpsc::channel::<BacklogTask>(BACKLOG_SIZE);
@@ -49,16 +51,19 @@ async fn main() -> anyhow::Result<()> {
     // import genesis accounts
     let accounts = rpc_storage.read_initial_accounts().await?;
     if let Some(ref mut csv) = csv {
-        csv.export_initial_accounts(accounts.clone())?;
+        for account in accounts.iter() {
+            csv.add_account(account.clone())?;
+        }
+        csv.flush()?;
     }
     stratus_storage.save_accounts_to_perm(accounts).await?;
 
     // execute parallel tasks (external rpc storage loader and block importer)
     tokio::spawn(execute_external_rpc_storage_loader(
         rpc_storage,
-        Arc::clone(&stratus_storage),
         cancellation.clone(),
         config.paralellism,
+        block_start,
         backlog_tx,
     ));
     execute_block_importer(executor, Arc::clone(&stratus_storage), csv, cancellation, backlog_rx).await?;
@@ -102,9 +107,10 @@ async fn execute_block_importer(
                 Some(ref mut csv) => {
                     let block = executor.import_external_to_temp(block, &mut receipts).await?;
                     let number = *block.number();
-                    csv.export_block(block)?;
+                    csv.add_block(block)?;
                     if number.as_u64() % 50 == 0 {
-                        stratus_storage.flush_account_changes_to_temp().await?;
+                        csv.flush()?;
+                        stratus_storage.flush_temp().await?;
                     }
                 }
                 // when not exporting to csv, persist the entire block to permanent immediately
@@ -127,16 +133,16 @@ async fn execute_block_importer(
 async fn execute_external_rpc_storage_loader(
     // services
     rpc_storage: Arc<dyn ExternalRpcStorage>,
-    stratus_storage: Arc<StratusStorage>,
     cancellation: CancellationToken,
     // data
     paralellism: usize,
+    mut start: BlockNumber,
     backlog: mpsc::Sender<BacklogTask>,
 ) -> anyhow::Result<()> {
     tracing::info!("external rpc storage loader starting");
 
     // if active, resume from the previous
-    let mut start = block_number_to_resume(&stratus_storage).await?;
+
     let end = match rpc_storage.read_max_block_number_in_range(BlockNumber::ZERO, BlockNumber::MAX).await {
         Ok(Some(number)) => number,
         Ok(None) => BlockNumber::ZERO,

--- a/src/eth/storage/csv/csv_exporter.rs
+++ b/src/eth/storage/csv/csv_exporter.rs
@@ -63,10 +63,10 @@ pub struct CsvExporter {
     staged_accounts: Vec<Account>,
     staged_blocks: Vec<Block>,
 
-    accounts: csv::Writer<File>,
+    accounts_csv: csv::Writer<File>,
     accounts_id: usize,
 
-    transactions: csv::Writer<File>,
+    transactions_csv: csv::Writer<File>,
     transactions_id: usize,
 }
 
@@ -77,10 +77,10 @@ impl CsvExporter {
             staged_blocks: Vec::new(),
             staged_accounts: Vec::new(),
 
-            accounts: csv_writer(ACCOUNT_FILE, BlockNumber::ZERO, &ACCOUNTS_HEADERS)?,
+            accounts_csv: csv_writer(ACCOUNT_FILE, BlockNumber::ZERO, &ACCOUNTS_HEADERS)?,
             accounts_id: 0,
 
-            transactions: csv_writer(TRANSACTIONS_FILE, number, &TRANSACTIONS_HEADERS)?,
+            transactions_csv: csv_writer(TRANSACTIONS_FILE, number, &TRANSACTIONS_HEADERS)?,
             transactions_id: read_csv_last_id(TRANSACTIONS_FILE)?,
         })
     }
@@ -134,7 +134,7 @@ impl CsvExporter {
                 now(),                                                       // created_at
                 now(),                                                       // updated_at
             ];
-            self.accounts.write_record(row).context("failed to write csv transaction")?;
+            self.accounts_csv.write_record(row).context("failed to write csv transaction")?;
         }
 
         Ok(())
@@ -165,8 +165,9 @@ impl CsvExporter {
                 now(),                                                  // created_at
                 now(),                                                  // updated_at
             ];
-            self.transactions.write_record(row).context("failed to write csv transaction")?;
+            self.transactions_csv.write_record(row).context("failed to write csv transaction")?;
         }
+        self.transactions_csv.flush()?;
         write_csv_last_id(TRANSACTIONS_FILE, self.transactions_id)?;
         Ok(())
     }

--- a/src/eth/storage/inmemory/inmemory_temporary.rs
+++ b/src/eth/storage/inmemory/inmemory_temporary.rs
@@ -140,7 +140,7 @@ impl TemporaryStorage for InMemoryTemporaryStorage {
         Ok(())
     }
 
-    async fn flush_account_changes(&self) -> anyhow::Result<()> {
+    async fn flush(&self) -> anyhow::Result<()> {
         Ok(())
     }
 

--- a/src/eth/storage/sled/sled_temporary.rs
+++ b/src/eth/storage/sled/sled_temporary.rs
@@ -100,7 +100,7 @@ impl TemporaryStorage for SledTemporary {
         Ok(())
     }
 
-    async fn flush_account_changes(&self) -> anyhow::Result<()> {
+    async fn flush(&self) -> anyhow::Result<()> {
         // read before lock
         let Some(number) = self.read_active_block_number().await? else {
             return log_and_err!("no active block number when flushing sled data");

--- a/src/eth/storage/stratus_storage.rs
+++ b/src/eth/storage/stratus_storage.rs
@@ -184,10 +184,11 @@ impl StratusStorage {
         result
     }
 
-    pub async fn flush_account_changes_to_temp(&self) -> anyhow::Result<()> {
+    /// If necessary, flushes temporary state to durable storage.
+    pub async fn flush_temp(&self) -> anyhow::Result<()> {
         let start = Instant::now();
-        let result = self.temp.flush_account_changes().await;
-        metrics::inc_storage_flush_account_changes(start.elapsed(), result.is_ok());
+        let result = self.temp.flush().await;
+        metrics::inc_storage_flush_temp(start.elapsed(), result.is_ok());
         result
     }
 

--- a/src/eth/storage/temporary_storage.rs
+++ b/src/eth/storage/temporary_storage.rs
@@ -25,9 +25,9 @@ pub trait TemporaryStorage: Send + Sync {
     /// Temporarily stores account changes during block production.
     async fn save_account_changes(&self, changes: Vec<ExecutionAccountChanges>) -> anyhow::Result<()>;
 
-    /// If necessary, flushes account changes to durable storage. Usually called after all transactions from a block were processed.
-    async fn flush_account_changes(&self) -> anyhow::Result<()>;
+    /// If necessary, flushes temporary state to durable storage.
+    async fn flush(&self) -> anyhow::Result<()>;
 
-    /// Resets all state
+    /// Resets to default empty state.
     async fn reset(&self) -> anyhow::Result<()>;
 }

--- a/src/infra/metrics.rs
+++ b/src/infra/metrics.rs
@@ -118,8 +118,8 @@ metrics! {
     "Time to execute storage save_account_changes operation."
     histogram_duration storage_save_account_changes{success} [],
 
-    "Time to execute storage flush_account_changes operation."
-    histogram_duration storage_flush_account_changes{success} [],
+    "Time to execute storage flush_temp operation."
+    histogram_duration storage_flush_temp{success} [],
 
     "Time to execute storage save_block operation."
     histogram_duration storage_save_block{success} [],


### PR DESCRIPTION
When resuming the importer after a stop:
* Creates a new CSV from the current block instead of overwriting the previous file.
* Resume from the last used ID instead of restarting at 0.

Also sinchronizes CSV flushes and temporary storage flushes.