### PR TITLE
deps(follow-redirects): bump from 1.15.5 to 1.15.6

### DIFF
--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -4108,7 +4108,9 @@
             }
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.5",
+            "version": "1.15.6",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+            "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
             "dev": true,
             "funding": [
                 {
@@ -4116,7 +4118,6 @@
                     "url": "https://github.com/sponsors/RubenVerborgh"
                 }
             ],
-            "license": "MIT",
             "engines": {
                 "node": ">=4.0"
             },


### PR DESCRIPTION
fixes https://github.com/cloudwalk/stratus/security/dependabot/13