### PR TITLE
feat: do not reexecute external transactions that failed

### DIFF
--- a/src/eth/evm/revm.rs
+++ b/src/eth/evm/revm.rs
@@ -236,11 +236,12 @@ fn parse_revm_execution(revm_result: RevmResultAndState, input: EvmInput, execut
 
     tracing::info!(?result, %gas, output_len = %output.len(), %output, "evm executed");
     Execution {
+        block_timestamp: input.block_timestamp,
+        execution_costs_applied: false,
         result,
         output,
         logs,
         gas,
-        block_timestamp: input.block_timestamp,
         changes: execution_changes.into_values().collect(),
     }
 }

--- a/src/eth/primitives/nonce.rs
+++ b/src/eth/primitives/nonce.rs
@@ -34,6 +34,11 @@ impl Nonce {
     pub fn is_zero(&self) -> bool {
         self == &Self::ZERO
     }
+
+    /// Returns the next nonce.
+    pub fn next(&self) -> Self {
+        Self(self.0 + 1)
+    }
 }
 
 impl Display for Nonce {

--- a/src/eth/storage/postgres_permanent/types.rs
+++ b/src/eth/storage/postgres_permanent/types.rs
@@ -63,6 +63,7 @@ impl PostgresTransaction {
             logs: inner_logs,
             // TODO: do this correctly
             changes: vec![],
+            execution_costs_applied: true,
         };
         let input = TransactionInput {
             chain_id: ChainId::default(),


### PR DESCRIPTION
When importing external transactions, do not reexecute transactions that failed.
Instead manually increment the sender nonce and generate a fake execution for the failed transaction.