### PR TITLE
build: use cargo outdated

### DIFF
--- a/.github/workflows/outdated.yml
+++ b/.github/workflows/outdated.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
     outdated:
         runs-on: ubuntu-latest
-
+        timeout-minutes: 10
         steps:
             - name: Checkout code
               uses: actions/checkout@v2

--- a/.justfile_helpers
+++ b/.justfile_helpers
@@ -3,7 +3,7 @@ _lint version="" fmt-flag="" clippy-flag="":
     cargo +nightly{{version}} clippy --all-targets -- {{clippy-flag}}
 
 [unix]
-_outdated:
+_outdated_minors_only:
     #!/bin/bash
     mkdir -p .outdated_tmp
     cp -p Cargo.lock .outdated_tmp/Cargo.lock
@@ -18,3 +18,9 @@ _outdated:
         echo "Outdated dependencies, quiting with error code $result"
     fi
     exit $result
+
+_outdated:
+    #!/bin/bash
+    command -v cargo-outdated >/dev/null 2>&1 || { cargo install cargo-outdated; }
+    cargo outdated --root-deps-only --ignore-external-rel --exit-code=1
+    exit $?

--- a/justfile
+++ b/justfile
@@ -70,7 +70,7 @@ lint:
 lint-check nightly-version="":
     @just _lint "{{nightly-version}}" --check "-D warnings"
 
-# Stratus: Check for outdated crates
+# Stratus: Check for dependencies major updates
 outdated:
     @just _outdated
 


### PR DESCRIPTION
Change `just outdated` to use `cargo outdated` instead of a custom script.
It will start notifying about major updates.
closes #344 

[Example run](https://github.com/cloudwalk/stratus/actions/runs/8379006727/job/22944918923)