### PR TITLE
feat: `--block-start` and `--block-end` args for importer-offline

### DIFF
--- a/src/bin/importer_offline.rs
+++ b/src/bin/importer_offline.rs
@@ -43,11 +43,11 @@ async fn main() -> anyhow::Result<()> {
     let executor = config.init_executor(Arc::clone(&stratus_storage));
 
     let block_start = match config.block_start {
-        Some(start) => start,
+        Some(start) => BlockNumber::from(start),
         None => block_number_to_start(&stratus_storage).await?,
     };
     let block_end = match config.block_end {
-        Some(end) => end,
+        Some(end) => BlockNumber::from(end),
         None => block_number_to_stop(&rpc_storage).await?,
     };
 

--- a/src/bin/importer_offline.rs
+++ b/src/bin/importer_offline.rs
@@ -154,9 +154,7 @@ async fn execute_external_rpc_storage_loader(
     end: BlockNumber,
     backlog: mpsc::Sender<BacklogTask>,
 ) -> anyhow::Result<()> {
-    tracing::info!("external rpc storage loader starting");
-
-    tracing::info!(%start, %end, "block limits");
+    tracing::info!(%start, %end, "external rpc storage loader starting");
 
     // prepare loads to be executed in parallel
     let mut tasks = Vec::new();

--- a/src/bin/importer_offline.rs
+++ b/src/bin/importer_offline.rs
@@ -42,11 +42,11 @@ async fn main() -> anyhow::Result<()> {
     let stratus_storage = config.init_stratus_storage().await?;
     let executor = config.init_executor(Arc::clone(&stratus_storage));
 
-    let block_start = match config.start {
+    let block_start = match config.block_start {
         Some(start) => start,
         None => block_number_to_start(&stratus_storage).await?,
     };
-    let block_end = match config.end {
+    let block_end = match config.block_end {
         Some(end) => end,
         None => block_number_to_stop(&rpc_storage).await?,
     };

--- a/src/bin/importer_offline.rs
+++ b/src/bin/importer_offline.rs
@@ -42,7 +42,15 @@ async fn main() -> anyhow::Result<()> {
     let stratus_storage = config.init_stratus_storage().await?;
     let executor = config.init_executor(Arc::clone(&stratus_storage));
 
-    let block_start = block_number_to_resume(&stratus_storage).await?;
+    let block_start = match config.start {
+        Some(start) => start,
+        None => block_number_to_start(&stratus_storage).await?,
+    };
+    let block_end = match config.end {
+        Some(end) => end,
+        None => block_number_to_stop(&rpc_storage).await?,
+    };
+
     let mut csv = if_else!(config.export_csv, Some(CsvExporter::new(block_start)?), None);
 
     // init shared data between importer and external rpc storage loader
@@ -65,6 +73,7 @@ async fn main() -> anyhow::Result<()> {
         cancellation.clone(),
         config.paralellism,
         block_start,
+        block_end,
         backlog_tx,
     ));
     execute_block_importer(executor, Arc::clone(&stratus_storage), csv, cancellation, backlog_rx).await?;
@@ -142,19 +151,11 @@ async fn execute_external_rpc_storage_loader(
     // data
     paralellism: usize,
     mut start: BlockNumber,
+    end: BlockNumber,
     backlog: mpsc::Sender<BacklogTask>,
 ) -> anyhow::Result<()> {
     tracing::info!("external rpc storage loader starting");
 
-    // find last block number
-    let end = match rpc_storage.read_max_block_number_in_range(BlockNumber::ZERO, BlockNumber::MAX).await {
-        Ok(Some(number)) => number,
-        Ok(None) => BlockNumber::ZERO,
-        Err(e) => {
-            cancellation.cancel();
-            return Err(e);
-        }
-    };
     tracing::info!(%start, %end, "block limits");
 
     // prepare loads to be executed in parallel
@@ -213,8 +214,8 @@ async fn load_blocks_and_receipts(
     try_join!(blocks_task, receipts_task)
 }
 
-// Finds the block number to resume the import job.
-async fn block_number_to_resume(stratus_storage: &StratusStorage) -> anyhow::Result<BlockNumber> {
+// Finds the block number to start the import job.
+async fn block_number_to_start(stratus_storage: &StratusStorage) -> anyhow::Result<BlockNumber> {
     // when has an active number, resume from it because it was not imported yet.
     let active_number = stratus_storage.read_active_block_number().await?;
     if let Some(active_number) = active_number {
@@ -230,4 +231,13 @@ async fn block_number_to_resume(stratus_storage: &StratusStorage) -> anyhow::Res
         mined_number = mined_number.next();
     }
     Ok(mined_number)
+}
+
+// Finds the block number to stop the import job.
+async fn block_number_to_stop(rpc_storage: &Arc<dyn ExternalRpcStorage>) -> anyhow::Result<BlockNumber> {
+    match rpc_storage.read_max_block_number_in_range(BlockNumber::ZERO, BlockNumber::MAX).await {
+        Ok(Some(number)) => Ok(number),
+        Ok(None) => Ok(BlockNumber::ZERO),
+        Err(e) => Err(e),
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -111,6 +111,14 @@ pub struct ImporterOfflineConfig {
     #[clap(flatten)]
     pub rpc_storage: ExternalRpcStorageConfig,
 
+    /// Initial block number to be imported.
+    #[arg(long = "start", env = "START")]
+    pub start: Option<BlockNumber>,
+
+    /// Final block number to be imported.
+    #[arg(long = "end", env = "END")]
+    pub end: Option<BlockNumber>,
+
     /// Number of parallel database fetches.
     #[arg(short = 'p', long = "paralellism", env = "PARALELLISM", default_value = "1")]
     pub paralellism: usize,

--- a/src/config.rs
+++ b/src/config.rs
@@ -112,12 +112,12 @@ pub struct ImporterOfflineConfig {
     pub rpc_storage: ExternalRpcStorageConfig,
 
     /// Initial block number to be imported.
-    #[arg(long = "start", env = "START")]
-    pub start: Option<BlockNumber>,
+    #[arg(long = "block-start", env = "BLOCK_START")]
+    pub block_start: Option<BlockNumber>,
 
     /// Final block number to be imported.
-    #[arg(long = "end", env = "END")]
-    pub end: Option<BlockNumber>,
+    #[arg(long = "block-end", env = "BLOCK_END")]
+    pub block_end: Option<BlockNumber>,
 
     /// Number of parallel database fetches.
     #[arg(short = 'p', long = "paralellism", env = "PARALELLISM", default_value = "1")]

--- a/src/config.rs
+++ b/src/config.rs
@@ -113,11 +113,11 @@ pub struct ImporterOfflineConfig {
 
     /// Initial block number to be imported.
     #[arg(long = "block-start", env = "BLOCK_START")]
-    pub block_start: Option<BlockNumber>,
+    pub block_start: Option<u64>,
 
     /// Final block number to be imported.
     #[arg(long = "block-end", env = "BLOCK_END")]
-    pub block_end: Option<BlockNumber>,
+    pub block_end: Option<u64>,
 
     /// Number of parallel database fetches.
     #[arg(short = 'p', long = "paralellism", env = "PARALELLISM", default_value = "1")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+use std::fmt::Debug;
+
 use crate::config::WithCommonConfig;
 
 pub mod config;
@@ -8,10 +10,11 @@ pub mod infra;
 /// Executes global services initialization.
 pub fn init_global_services<T>() -> T
 where
-    T: clap::Parser + WithCommonConfig,
+    T: clap::Parser + WithCommonConfig + Debug,
 {
     let config = T::parse();
     infra::init_tracing();
     infra::init_metrics(config.common().metrics_histogram_kind);
+    tracing::info!(?config);
     config
 }


### PR DESCRIPTION
Allow to manually specify the starting and ending block of the importer-offline job.