### PR TITLE
test: skip broken hybrid

### DIFF
--- a/.github/workflows/e2e-contracts-hybrid.yml
+++ b/.github/workflows/e2e-contracts-hybrid.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   contract_test_hybrid:
+    if: github.event_name != 'pull_request'
     name: Contracts E2E Hybrid Tests
     runs-on: ubuntu-latest
     timeout-minutes: 40

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -28,6 +28,7 @@ jobs:
       cancel-in-progress: true
 
   e2e-stratus-hybrid:
+    if: github.event_name != 'pull_request'
     name: E2E Stratus Hybrid
     uses: ./.github/workflows/_setup-e2e.yml
     with:


### PR DESCRIPTION
The #392 was merged without being ready. To avoid the annoying CI failing on every pull request, I'm skipping it until the code is fixed to pass them.

To run the hybrid test, manually dispatch the run in the Actions tab for your branch. 