### PR TITLE
feat: add transaction metric

### DIFF
--- a/src/bin/run_with_importer.rs
+++ b/src/bin/run_with_importer.rs
@@ -5,8 +5,6 @@ use std::sync::Arc;
 use importer_online::run_importer_online;
 use stratus::config::RunWithImporterConfig;
 use stratus::eth::rpc::serve_rpc;
-#[cfg(feature = "metrics")]
-use stratus::infra::metrics;
 use stratus::init_global_services;
 use tokio::try_join;
 

--- a/src/eth/storage/stratus_storage.rs
+++ b/src/eth/storage/stratus_storage.rs
@@ -283,6 +283,8 @@ impl StratusStorage {
         let label_size_by_tx = block.label_size_by_transactions();
         #[cfg(feature = "metrics")]
         let label_size_by_gas = block.label_size_by_gas();
+        #[cfg(feature = "metrics")]
+        let tx_count = block.transactions.len();
 
         // save block to permanent storage and clears temporary storage
         let next_number = block.number().next();
@@ -293,6 +295,8 @@ impl StratusStorage {
 
         #[cfg(feature = "metrics")]
         metrics::inc_storage_commit(start.elapsed(), label_size_by_tx, label_size_by_gas, result.is_ok());
+        #[cfg(feature = "metrics")]
+        metrics::inc_n_storage_transaction_count(tx_count as u64);
 
         result
     }

--- a/src/infra/metrics.rs
+++ b/src/infra/metrics.rs
@@ -135,7 +135,10 @@ metrics! {
     histogram_duration storage_reset{kind, success} [],
 
     "Time to execute storage commit operation."
-    histogram_duration storage_commit{size_by_tx, size_by_gas, success} []
+    histogram_duration storage_commit{size_by_tx, size_by_gas, success} [],
+
+    "Number of transactions requests that were commited"
+    counter   storage_transaction_count{} []
 }
 
 // Importer offline metrics.
@@ -296,14 +299,29 @@ macro_rules! metrics {
 macro_rules! metrics_impl_fn_inc {
     (counter $name:ident $group:ident $($label:ident)*) => {
         paste! {
-            #[doc = "Add 1 to `" $name "` counter."]
-            pub fn [<inc_ $name>]($( $label: impl Into<LabelValue> ),+) {
+            #[doc = "Add n to `" $name "` counter."]
+            pub fn [<inc_n_ $name>](n: u64, $( $label: impl Into<LabelValue> ),*) {
                 let labels = into_labels(
                     vec![
                         ("group", stringify!($group).into()),
                         $(
                             (stringify!($label), $label.into()),
-                        )+
+                        )*
+                    ]
+                );
+                counter!(stringify!([<stratus_$name>]), n, labels);
+            }
+        }
+
+        paste! {
+            #[doc = "Add 1 to `" $name "` counter."]
+            pub fn [<inc_ $name>]($( $label: impl Into<LabelValue> ),*) {
+                let labels = into_labels(
+                    vec![
+                        ("group", stringify!($group).into()),
+                        $(
+                            (stringify!($label), $label.into()),
+                        )*
                     ]
                 );
                 counter!(stringify!([<stratus_$name>]), 1, labels);


### PR DESCRIPTION
With this we can get the current tps for instance using `increase(stratus_storage_transactions[1s])`, or get a graph of the average tps over time with `increase(stratus_storage_transactions[30s])/30`.