### PR TITLE
feat: total gas metric

### DIFF
--- a/src/eth/storage/stratus_storage.rs
+++ b/src/eth/storage/stratus_storage.rs
@@ -284,7 +284,7 @@ impl StratusStorage {
         #[cfg(feature = "metrics")]
         let label_size_by_gas = block.label_size_by_gas();
         #[cfg(feature = "metrics")]
-        let tx_count = block.transactions.len();
+        let gas_used = block.header.gas_used.as_u64();
 
         // save block to permanent storage and clears temporary storage
         let next_number = block.number().next();
@@ -296,7 +296,7 @@ impl StratusStorage {
         #[cfg(feature = "metrics")]
         metrics::inc_storage_commit(start.elapsed(), label_size_by_tx, label_size_by_gas, result.is_ok());
         #[cfg(feature = "metrics")]
-        metrics::inc_n_storage_transaction_count(tx_count as u64);
+        metrics::inc_n_storage_gas_total(gas_used);
 
         result
     }

--- a/src/infra/metrics.rs
+++ b/src/infra/metrics.rs
@@ -137,8 +137,8 @@ metrics! {
     "Time to execute storage commit operation."
     histogram_duration storage_commit{size_by_tx, size_by_gas, success} [],
 
-    "Number of transactions requests that were commited"
-    counter   storage_transaction_count{} []
+    "Ammount of gas in the commited transactions"
+    counter   storage_gas_total{} []
 }
 
 // Importer offline metrics.


### PR DESCRIPTION
Removed the the `storage_transaction_count` added in #567 since we can already get this data using `stratus_executor_external_transaction_count` for the importer and `executor_transact_count` for `eth_sendRawTransaction`.