### PR TITLE
fix: column order of 'chain_id' field in transactions

### DIFF
--- a/static/schema/001-init.sql
+++ b/static/schema/001-init.sql
@@ -421,9 +421,9 @@ CREATE TABLE public.transactions (
     s bytea NOT NULL,
     value numeric NOT NULL,
     result text NOT NULL,
-    chain_id numeric DEFAULT NULL,
     created_at timestamp(6) without time zone DEFAULT now() NOT NULL,
-    updated_at timestamp(6) without time zone DEFAULT now() NOT NULL
+    updated_at timestamp(6) without time zone DEFAULT now() NOT NULL,
+    chain_id numeric DEFAULT NULL
 );
 
 


### PR DESCRIPTION
Inconsistency in column ordering was causing problems in CSV exportation.

This PR makes it consistent throughout the project.