### PR TITLE
chore: deploy postgres with importer-online instead run-with-importer

### DIFF
--- a/config/production.yaml
+++ b/config/production.yaml
@@ -74,7 +74,7 @@ kubernetes:
     # EVM api postgres storage
     # --------------------------------------------------------------------------
     - name: stratus-api-postgres
-      dockerfile: ./docker/Dockerfile.run_with_importer_postgres
+      dockerfile: ./docker/Dockerfile.importer_online_postgres
       secretsManager:
         enabled: true
         provider: gcpsm

--- a/docker/Dockerfile.importer_online_postgres
+++ b/docker/Dockerfile.importer_online_postgres
@@ -1,0 +1,22 @@
+# Build
+FROM rust:1.75 as builder
+
+WORKDIR /app
+COPY src /app/src
+COPY static /app/static
+COPY .sqlx /app/.sqlx
+COPY build.rs /app/build.rs
+COPY Cargo.toml /app/Cargo.toml
+COPY Cargo.lock /app/Cargo.lock
+
+RUN apt update
+RUN apt-get install -y libclang-dev cmake
+
+RUN cargo build --release --bin importer-online --features metrics
+
+# Runtime
+FROM rust:1.75 as runtime
+WORKDIR /app
+COPY --from=builder /app/target/release/importer-online /app/importer-online
+
+CMD ["sh", "-c", "/app/importer-online"]


### PR DESCRIPTION
To serve RPC we can just create a pod running regular stratus