### PR TITLE
chore: importer-offline: lower log level

### DIFF
--- a/src/eth/evm/revm.rs
+++ b/src/eth/evm/revm.rs
@@ -318,7 +318,7 @@ fn parse_revm_execution(revm_result: RevmResultAndState, input: EvmInput, execut
     let (result, output, logs, gas) = parse_revm_result(revm_result.result);
     let changes = parse_revm_state(revm_result.state, execution_changes);
 
-    tracing::info!(?result, %gas, output_len = %output.len(), %output, "evm executed");
+    tracing::debug!(?result, %gas, output_len = %output.len(), %output, "evm executed");
     EvmExecution {
         block_timestamp: input.block_timestamp,
         execution_costs_applied: false,

--- a/src/eth/executor.rs
+++ b/src/eth/executor.rs
@@ -84,7 +84,7 @@ impl Executor {
         #[cfg(feature = "metrics")]
         let (start, mut block_metrics) = (metrics::now(), ExecutionMetrics::default());
 
-        tracing::info!(number = %block.number(), "re-executing external block");
+        tracing::debug!(number = %block.number(), "re-executing external block");
 
         let storage = &self.storage;
 


### PR DESCRIPTION

importer-offline goes through ~66 million blocks, and so it outputs 66 million lines, which makes it unreadable for a human.

this PR lowers the log level for that specific log