### PR TITLE
feat: apply_receipt

### DIFF
--- a/src/eth/evm/revm.rs
+++ b/src/eth/evm/revm.rs
@@ -321,7 +321,7 @@ fn parse_revm_execution(revm_result: RevmResultAndState, input: EvmInput, execut
     tracing::info!(?result, %gas, output_len = %output.len(), %output, "evm executed");
     EvmExecution {
         block_timestamp: input.block_timestamp,
-        execution_costs_applied: false,
+        receipt_applied: false,
         result,
         output,
         logs,

--- a/src/eth/primitives/wei.rs
+++ b/src/eth/primitives/wei.rs
@@ -26,7 +26,7 @@ use sqlx::Decode;
 use crate::gen_newtype_from;
 
 /// Native token amount in wei.
-#[derive(Debug, Clone, Copy, Default, Eq, PartialEq, derive_more::Add, derive_more::Sub, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialOrd, Ord, PartialEq, Eq, derive_more::Add, derive_more::Sub, serde::Serialize, serde::Deserialize)]
 pub struct Wei(U256);
 
 impl Wei {

--- a/src/eth/storage/postgres_permanent/types.rs
+++ b/src/eth/storage/postgres_permanent/types.rs
@@ -61,7 +61,7 @@ impl PostgresTransaction {
             logs: inner_logs,
             // TODO: do this correctly
             changes: HashMap::new(),
-            execution_costs_applied: true,
+            receipt_applied: true,
             deployed_contract_address: self.contract_address,
         };
         let input = TransactionInput {

--- a/src/eth/storage/rocks/types.rs
+++ b/src/eth/storage/rocks/types.rs
@@ -556,7 +556,7 @@ impl From<EvmExecution> for ExecutionRocksdb {
     fn from(item: EvmExecution) -> Self {
         Self {
             block_timestamp: UnixTimeRocksdb::from(item.block_timestamp),
-            execution_costs_applied: item.execution_costs_applied,
+            execution_costs_applied: item.receipt_applied,
             result: item.result.into(),
             output: BytesRocksdb::from(item.output),
             logs: item.logs.into_iter().map(LogRocksdb::from).collect(),
@@ -570,7 +570,7 @@ impl From<ExecutionRocksdb> for EvmExecution {
     fn from(item: ExecutionRocksdb) -> Self {
         Self {
             block_timestamp: item.block_timestamp.into(),
-            execution_costs_applied: item.execution_costs_applied,
+            receipt_applied: item.execution_costs_applied,
             result: item.result.into(),
             output: item.output.into(),
             logs: item.logs.into_iter().map(Log::from).collect(),


### PR DESCRIPTION
Centralizes all executions fixes based on the external receipt in a function `apply_receipt`.