### PR TITLE
reduce clock test duration

### DIFF
--- a/utils/block-time-check.sh
+++ b/utils/block-time-check.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-sleep_interval=180
+sleep_interval=120
 error_margin=0.05
 
 echo -n "-> Waiting for blocks to generate... "


### PR DESCRIPTION
Reducing duration from 180 to 120 seconds