### PR TITLE
fix: only update account databases when actually needed

### DIFF
--- a/src/eth/primitives/execution_account_changes.rs
+++ b/src/eth/primitives/execution_account_changes.rs
@@ -113,4 +113,9 @@ impl ExecutionAccountChanges {
     pub fn is_account_update(&self) -> bool {
         not(self.new_account)
     }
+
+    /// Checks if the Nonce, Balance or Bytecode are modified
+    pub fn is_account_change(&self) -> bool {
+        self.nonce.is_modified() || self.balance.is_modified() || self.bytecode.is_modified()
+    }
 }

--- a/src/eth/storage/rocks/rocks_state.rs
+++ b/src/eth/storage/rocks/rocks_state.rs
@@ -398,20 +398,22 @@ impl RocksStorageState {
 
         let account_changes_future = tokio::task::spawn_blocking(move || {
             for change in changes_clone_for_accounts {
-                let address: AddressRocksdb = change.address.into();
-                let mut account_info_entry = accounts.entry_or_insert_with(address, AccountRocksdb::default);
-                if let Some(nonce) = change.nonce.clone().take_modified() {
-                    account_info_entry.nonce = nonce.into();
-                }
-                if let Some(balance) = change.balance.clone().take_modified() {
-                    account_info_entry.balance = balance.into();
-                }
-                if let Some(bytecode) = change.bytecode.clone().take_modified() {
-                    account_info_entry.bytecode = bytecode.map_into();
-                }
+                if change.is_account_change() {
+                    let address: AddressRocksdb = change.address.into();
+                    let mut account_info_entry = accounts.entry_or_insert_with(address, AccountRocksdb::default);
+                    if let Some(nonce) = change.nonce.clone().take_modified() {
+                        account_info_entry.nonce = nonce.into();
+                    }
+                    if let Some(balance) = change.balance.clone().take_modified() {
+                        account_info_entry.balance = balance.into();
+                    }
+                    if let Some(bytecode) = change.bytecode.clone().take_modified() {
+                        account_info_entry.bytecode = bytecode.map_into();
+                    }
 
-                account_changes.push((address, account_info_entry.clone()));
-                account_history_changes.push(((address, block_number.into()), account_info_entry));
+                    account_changes.push((address, account_info_entry.clone()));
+                    account_history_changes.push(((address, block_number.into()), account_info_entry));
+                }
             }
 
             accounts.insert_batch(account_changes, Some(block_number.into()));


### PR DESCRIPTION
Simple fix to only update the account databases in case an `ExecutionAccountChange` actually changes the account. Previously we were inserting a new entry in `accounts_histry.rocksdb` for every `ExecutionAccountChange` (even if for instance it only updated a single slot). In the future it might make sense to refactor `ExecutionAccountChange` to contain two structures, one for every change on the values of the account (bytecode, nonce, balance) and one only for the slots (and have them be `Option<>`)