### PR TITLE
optimize relayer e2e test duration

### DIFF
--- a/e2e-contracts/integration/test/relayer.test.ts
+++ b/e2e-contracts/integration/test/relayer.test.ts
@@ -30,9 +30,9 @@ describe("Relayer integration test", function () {
 
     describe("Long duration transaction tests", function () {
         const parameters = [
-            { name: "Few wallets, sufficient balance", wallets: 3, duration: 15, tps: 5, baseBalance: 2000 },
-            { name: "Few wallets, insufficient balance", wallets: 2, duration: 15, tps: 1, baseBalance: 5 },
-            { name: "Many wallets, sufficient balance", wallets: 20, duration: 15, tps: 30, baseBalance: 2000 },
+            { name: "Few wallets, sufficient balance", wallets: 3, duration: 10, tps: 5, baseBalance: 2000 },
+            { name: "Few wallets, insufficient balance", wallets: 2, duration: 10, tps: 1, baseBalance: 5 },
+            { name: "Many wallets, sufficient balance", wallets: 20, duration: 10, tps: 30, baseBalance: 2000 },
         ];
         parameters.forEach((params, index) => {
             const wallets: any[] = [];
@@ -81,7 +81,7 @@ describe("Relayer integration test", function () {
     
                     await new Promise(resolve => setTimeout(resolve, transactionInterval));
                 }
-                await new Promise(resolve => setTimeout(resolve, 2000));
+                await new Promise(resolve => setTimeout(resolve, 1000));
             });
     
             it(`${params.name}: Validate transaction mined delay between Stratus and Hardhat`, async function () {
@@ -185,7 +185,7 @@ describe("Relayer integration test", function () {
 
                 nonces[i % 2]++;
             }
-            await new Promise(resolve => setTimeout(resolve, 2000));
+            await new Promise(resolve => setTimeout(resolve, 1000));
         });
 
         it("Validate no mismatched transactions were generated", async function () {

--- a/e2e-contracts/integration/test/relayer.test.ts
+++ b/e2e-contracts/integration/test/relayer.test.ts
@@ -30,9 +30,9 @@ describe("Relayer integration test", function () {
 
     describe("Long duration transaction tests", function () {
         const parameters = [
-            { name: "Few wallets, sufficient balance", wallets: 3, duration: 10, tps: 5, baseBalance: 2000 },
-            { name: "Few wallets, insufficient balance", wallets: 2, duration: 10, tps: 1, baseBalance: 5 },
-            { name: "Many wallets, sufficient balance", wallets: 20, duration: 10, tps: 30, baseBalance: 2000 },
+            { name: "Few wallets, sufficient balance", wallets: 3, duration: 15, tps: 5, baseBalance: 2000 },
+            { name: "Few wallets, insufficient balance", wallets: 2, duration: 15, tps: 1, baseBalance: 5 },
+            { name: "Many wallets, sufficient balance", wallets: 20, duration: 15, tps: 30, baseBalance: 2000 },
         ];
         parameters.forEach((params, index) => {
             const wallets: any[] = [];
@@ -81,7 +81,7 @@ describe("Relayer integration test", function () {
     
                     await new Promise(resolve => setTimeout(resolve, transactionInterval));
                 }
-                await new Promise(resolve => setTimeout(resolve, 1000));
+                await new Promise(resolve => setTimeout(resolve, 2000));
             });
     
             it(`${params.name}: Validate transaction mined delay between Stratus and Hardhat`, async function () {
@@ -185,7 +185,7 @@ describe("Relayer integration test", function () {
 
                 nonces[i % 2]++;
             }
-            await new Promise(resolve => setTimeout(resolve, 1000));
+            await new Promise(resolve => setTimeout(resolve, 2000));
         });
 
         it("Validate no mismatched transactions were generated", async function () {

--- a/justfile
+++ b/justfile
@@ -370,9 +370,9 @@ e2e-relayer-external-up:
 
     # Build Stratus and Relayer binaries
     echo "Building Stratus binary"
-    cargo build --release --bin stratus --features dev
+    cargo build --release --bin stratus --features dev &
     echo "Building Stratus binary"
-    cargo build --release --bin relayer --features dev
+    cargo build --release --bin relayer --features dev &
 
     mkdir e2e_logs
 
@@ -382,6 +382,9 @@ e2e-relayer-external-up:
     # Wait for Postgres to start
     wait-service --tcp 0.0.0.0:5432 -t {{ wait_service_timeout }} -- echo
     sleep 5
+
+    # Wait for build to finish
+    wait
 
     # Start Stratus binary
     cargo run --release --bin stratus --features dev -- --block-mode 1s --perm-storage=rocks --relayer-db-url "postgres://postgres:123@0.0.0.0:5432/stratus" --relayer-db-connections 5 --relayer-db-timeout 1s -a 0.0.0.0:3000 > e2e_logs/stratus.log &

--- a/justfile
+++ b/justfile
@@ -381,9 +381,8 @@ e2e-relayer-external-up:
 
     # Wait for Postgres to start
     wait-service --tcp 0.0.0.0:5432 -t {{ wait_service_timeout }} -- echo
-    sleep 5
 
-    # Wait for build to finish
+    # Wait for builds to finish
     wait
 
     # Start Stratus binary


### PR DESCRIPTION
Executing Stratus and Relayer builds + docker compose up in parallel to reduce test duration.
This enhancement subtracted ~3min if cache hits.