### PR TITLE
feat: always returns owned values for hash and number

### DIFF
--- a/src/bin/importer_offline.rs
+++ b/src/bin/importer_offline.rs
@@ -185,7 +185,7 @@ async fn execute_block_importer(
             let mined_block = miner.mine_external().await?;
 
             // export snapshot for tests
-            if blocks_to_export_snapshot.contains(mined_block.number()) {
+            if blocks_to_export_snapshot.contains(&mined_block.number()) {
                 export_snapshot(&block, &receipts, &mined_block)?;
             }
 
@@ -329,12 +329,12 @@ async fn import_external_to_csv(
     block_last_index: usize,
 ) -> anyhow::Result<()> {
     // export block to csv
-    let number = *block.number();
+    let block_number = block.number();
     csv.add_block(block)?;
 
     let is_last_block = block_index == block_last_index;
-    let is_chunk_interval_end = number.as_u64() % CSV_CHUNKING_BLOCKS_INTERVAL == 0;
-    let is_flush_interval_end = number.as_u64() % FLUSH_INTERVAL_IN_BLOCKS == 0;
+    let is_chunk_interval_end = block_number.as_u64() % CSV_CHUNKING_BLOCKS_INTERVAL == 0;
+    let is_flush_interval_end = block_number.as_u64() % FLUSH_INTERVAL_IN_BLOCKS == 0;
 
     // check if should flush
     let should_chunk_csv_files = is_chunk_interval_end;
@@ -348,8 +348,8 @@ async fn import_external_to_csv(
 
     // chunk
     if should_chunk_csv_files {
-        tracing::info!("Chunk ended at block number {number}, starting next CSV chunks for the next block");
-        csv.finish_current_chunks(number)?;
+        tracing::info!("Chunk ended at block number {block_number}, starting next CSV chunks for the next block");
+        csv.finish_current_chunks(block_number)?;
     }
 
     Ok(())

--- a/src/eth/block_miner.rs
+++ b/src/eth/block_miner.rs
@@ -149,7 +149,7 @@ impl BlockMiner {
         let block = block_from_external(external_block, mined_txs);
 
         block.map(|block| {
-            Span::with(|s| s.rec("number", block.number()));
+            Span::with(|s| s.rec("number", &block.number()));
             block
         })
     }
@@ -187,7 +187,7 @@ impl BlockMiner {
             block.push_execution(tx.input, tx.result);
         }
 
-        Span::with(|s| s.rec("number", block.number()));
+        Span::with(|s| s.rec("number", &block.number()));
 
         Ok(block)
     }
@@ -220,7 +220,7 @@ impl BlockMiner {
         };
 
         block.map(|block| {
-            Span::with(|s| s.rec("number", block.number()));
+            Span::with(|s| s.rec("number", &block.number()));
             block
         })
     }
@@ -234,12 +234,12 @@ impl BlockMiner {
     /// Persists a mined block to permanent storage and prepares new block.
     #[tracing::instrument(name = "miner::commit", skip_all, fields(number))]
     pub async fn commit(&self, block: Block) -> anyhow::Result<()> {
-        Span::with(|s| s.rec("number", block.number()));
+        Span::with(|s| s.rec("number", &block.number()));
 
         tracing::info!(number = %block.number(), transactions_len = %block.transactions.len(), "commiting block");
 
         // extract fields to use in notifications
-        let block_number = *block.number();
+        let block_number = block.number();
         let block_header = block.header.clone();
         let block_logs: Vec<LogMined> = block.transactions.iter().flat_map(|tx| &tx.logs).cloned().collect();
 

--- a/src/eth/primitives/block.rs
+++ b/src/eth/primitives/block.rs
@@ -125,13 +125,13 @@ impl Block {
     }
 
     /// Returns the block number.
-    pub fn number(&self) -> &BlockNumber {
-        &self.header.number
+    pub fn number(&self) -> BlockNumber {
+        self.header.number
     }
 
     /// Returns the block hash.
-    pub fn hash(&self) -> &Hash {
-        &self.header.hash
+    pub fn hash(&self) -> Hash {
+        self.header.hash
     }
 
     /// Compact accounts changes removing intermediate values, keeping only the last modified nonce, balance, bytecode and slots.

--- a/src/eth/storage/csv/csv_exporter.rs
+++ b/src/eth/storage/csv/csv_exporter.rs
@@ -215,7 +215,7 @@ impl CsvExporter {
         let blocks: Vec<Block> = self.staged_blocks.drain(..).collect();
         for block in blocks {
             let now = now();
-            self.export_account_changes(now.clone(), *block.number(), block.compact_account_changes())?;
+            self.export_account_changes(now.clone(), block.number(), block.compact_account_changes())?;
             self.export_block(now.clone(), block.header)?;
             self.export_transactions(now.clone(), block.transactions)?;
         }

--- a/src/eth/storage/stratus_storage.rs
+++ b/src/eth/storage/stratus_storage.rs
@@ -396,7 +396,7 @@ impl StratusStorage {
 
     #[tracing::instrument(name = "storage::save_block", skip_all, fields(number))]
     pub async fn save_block(&self, block: Block) -> anyhow::Result<()> {
-        Span::with(|s| s.rec("number", block.number()));
+        Span::with(|s| s.rec("number", &block.number()));
 
         #[cfg(feature = "metrics")]
         {


### PR DESCRIPTION
Ensure consistency of `hash` and `number` functions.
They should always returns owned values.