### PR TITLE
fix: do not panic on evm thread because of tracing

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -13,7 +13,6 @@ use display_json::DebugAsJson;
 use tokio::runtime::Builder;
 use tokio::runtime::Handle;
 use tokio::runtime::Runtime;
-use tracing::info_span;
 
 use crate::eth::evm::revm::Revm;
 use crate::eth::evm::Evm;
@@ -233,11 +232,8 @@ impl ExecutorConfig {
                         return;
                     }
 
-                    // enter span from another thread
-                    let span = task.span_id.map(|id| info_span!(parent: id, "executor::evm"));
-                    let _span_enter = span.as_ref().map(|span| span.enter());
-
                     // execute
+                    let _span_enter = task.span.enter();
                     let result = evm.execute(task.input);
                     if let Err(e) = task.response_tx.send(result) {
                         tracing::error!(reason = ?e, "failed to send evm execution result");


### PR DESCRIPTION
Instead of passing the span ID and creating a new span in the EVM thread, we create the span in the client thread and only enter it inside the EVM thread.