### PR TITLE
Reduce Log Level For Leader Behind Follower Case

### DIFF
--- a/src/eth/consensus/mod.rs
+++ b/src/eth/consensus/mod.rs
@@ -775,7 +775,7 @@ impl AppendEntryService for AppendEntryServiceImpl {
                 metrics::set_append_entries_block_number_diff(diff);
             }
         } else {
-            tracing::error!(
+            tracing::warn!(
                 "leader is behind follower: arrived_block: {}, header_block: {}",
                 last_last_arrived_block_number,
                 header.number


### PR DESCRIPTION
Reducing the Log Level from ERROR to WARN for the Leader is Behind follower message. As it is now, the current implementation makes the follower nodes pull the blocks from Substrate instead of the Leader node. This will log the message very frequently and will only be reduced in a future enhancement when the follower nodes start receiving the entries from the leader node directly.