### PR TITLE
test: add linters to E2E tests

### DIFF
--- a/e2e/.prettierignore
+++ b/e2e/.prettierignore
@@ -1,0 +1,4 @@
+# Files and folders that Prettier must ignore
+artifacts/**
+cache/**
+typechain-types/**

--- a/e2e/.prettierrc.js
+++ b/e2e/.prettierrc.js
@@ -1,5 +1,5 @@
 module.exports = {
-    plugins: ["@trivago/prettier-plugin-sort-imports"],
+    plugins: ["@trivago/prettier-plugin-sort-imports", "prettier-plugin-solidity"],
     // lines
     printWidth: 120,
     tabWidth: 4,
@@ -14,4 +14,19 @@ module.exports = {
     importOrder: ["<THIRD_PARTY_MODULES>", "^[./]"],
     importOrderSeparation: true,
     importOrderSortSpecifiers: true,
+
+    overrides: [
+        // Solidity
+        {
+            files: "*.sol",
+            options: {
+                parser: "solidity-parse",
+                printWidth: 120,
+                tabWidth: 4,
+                useTabs: false,
+                singleQuote: false,
+                bracketSpacing: true,
+            },
+        },
+    ],
 };

--- a/e2e/.solhint.json
+++ b/e2e/.solhint.json
@@ -1,0 +1,6 @@
+{
+    "extends": "solhint:recommended",
+    "rules": {
+        "gas-custom-errors": "off"
+    }
+}

--- a/e2e/contracts/TestContractBalances.sol
+++ b/e2e/contracts/TestContractBalances.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.0;
 
 contract TestContractBalances {
-
     mapping(address => uint256) public balances;
 
     event Add(address indexed account, uint amount);

--- a/e2e/contracts/TestContractBalances.sol
+++ b/e2e/contracts/TestContractBalances.sol
@@ -4,9 +4,9 @@ pragma solidity ^0.8.0;
 contract TestContractBalances {
     mapping(address => uint256) public balances;
 
-    event Add(address indexed account, uint amount);
-    event Sub(address indexed account, uint amount);
-    event Set(address indexed account, uint amount);
+    event Add(address indexed account, uint256 amount);
+    event Sub(address indexed account, uint256 amount);
+    event Set(address indexed account, uint256 amount);
 
     /// @dev Add amount to the balance of an account.
     /// @return The new balance.

--- a/e2e/contracts/TestContractCounter.sol
+++ b/e2e/contracts/TestContractCounter.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.0;
 
 contract TestContractCounter {
-
     uint256 counter;
     uint256 doubleCounter;
 

--- a/e2e/contracts/TestContractCounter.sol
+++ b/e2e/contracts/TestContractCounter.sol
@@ -2,8 +2,8 @@
 pragma solidity ^0.8.0;
 
 contract TestContractCounter {
-    uint256 counter;
-    uint256 doubleCounter;
+    uint256 internal counter;
+    uint256 internal doubleCounter;
 
     function inc() public {
         counter += 1;

--- a/e2e/contracts/TestContractDenseStorage.sol
+++ b/e2e/contracts/TestContractDenseStorage.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.0;
 
 contract TestContractDenseStorage {
-
     struct Record {
         uint16 field16;
         uint16 reserve;

--- a/e2e/eslint.config.js
+++ b/e2e/eslint.config.js
@@ -1,0 +1,111 @@
+const globals = require("globals");
+const pluginJs = require("@eslint/js");
+const tseslint = require("typescript-eslint");
+const stylistic = require("@stylistic/eslint-plugin");
+const sort = require("eslint-plugin-sort");
+
+const MAX_LINE_LENGTH = 120;
+const INDENT_SIZE = 4;
+
+function changeErrorToWarn(configObj) {
+    for (const key in configObj) {
+        if (configObj[key] === "error") {
+            configObj[key] = "warn";
+        } else if (typeof configObj[key] === "object") {
+            const nestedConfigObj = configObj[key];
+            for (const key in nestedConfigObj) {
+                if (nestedConfigObj[key] === "error") {
+                    nestedConfigObj[key] = "warn";
+                }
+            }
+        }
+    }
+    return configObj;
+}
+
+const stylisticRecommendedConfig = stylistic.configs.customize({
+    indent: INDENT_SIZE,
+    quotes: "double",
+    semi: true,
+    jsx: false,
+    arrowParens: true,
+    commaDangle: "always-multiline",
+});
+changeErrorToWarn(stylisticRecommendedConfig.rules);
+
+module.exports = [
+    // --------- JavaScript and TypeScript files config ----------- //
+
+    // Common ignored files (except the 'node_modules' folder that is ignored by default)
+    {
+        ignores: ["cache/**", "artifacts/**", "typechain-types/**"],
+    },
+
+    // Common recommended config
+    {
+        name: "common",
+        files: ["**/*.js", "**/*.ts", "**/*.mjs", "**/*.mts", "**/*.cjs", "**/*.cts"],
+        languageOptions: { globals: globals.node },
+        ...pluginJs.configs.recommended,
+    },
+
+    // Stylistic recommended config
+    {
+        name: "script-stylistic",
+        files: ["**/*.js", "**/*.ts", "**/*.mjs", "**/*.mts", "**/*.cjs", "**/*.cts"],
+        ...stylisticRecommendedConfig,
+    },
+
+    // Sorting recommended config
+    {
+        plugins: sort.configs["flat/recommended"].plugins,
+    },
+
+    // ----------------- TypeScript only files config ------------------ //
+
+    // TypeScript recommended config
+    ...tseslint.configs.recommended.map((config) => ({
+        ...config,
+        files: ["**/*.ts", "**/*.mts", "**/*.cts"],
+    })),
+
+    // Typescript special rules
+    {
+        name: "type-script-base-special-rules",
+        files: ["**/*.ts", "**/*.mts", "**/*.cts"],
+        rules: {
+            "@typescript-eslint/no-explicit-any": "off", // Allow to use `any`
+            "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_" }],
+        },
+    },
+
+    // ----------------- Special rules ------------------ //
+
+    {
+        name: "special",
+        files: ["**/*.js", "**/*.ts", "**/*.mjs", "**/*.mts", "**/*.cjs", "**/*.cts"],
+        rules: {
+            // Common rules
+            "no-constant-condition": ["error", { checkLoops: false }],
+
+            // Stylistic rules
+            "@stylistic/brace-style": ["warn", "1tbs", { allowSingleLine: true }],
+            "@stylistic/max-len": ["warn", { code: MAX_LINE_LENGTH }],
+            "@stylistic/operator-linebreak": ["warn", "after", { overrides: { "?": "before", ":": "before" } }],
+
+            // Sorting rules
+            "sort/imports": [
+                "warn",
+                {
+                    groups: [
+                        { type: "dependency", order: 10 },
+                        { type: "other", order: 20 },
+                    ],
+                    separator: "\n",
+                    caseSensitive: true,
+                },
+            ],
+            "sort/import-members": ["warn", { caseSensitive: true }],
+        },
+    },
+];

--- a/e2e/hardhat.config.ts
+++ b/e2e/hardhat.config.ts
@@ -1,5 +1,5 @@
-import { HardhatUserConfig } from "hardhat/config";
 import "@nomicfoundation/hardhat-toolbox";
+import { HardhatUserConfig } from "hardhat/config";
 
 const ACCOUNTS_MNEMONIC = "test test test test test test test test test test test junk";
 const MINING_INTERVAL_PATTERN = /^(\d+)s$/;

--- a/e2e/hardhat.config.ts
+++ b/e2e/hardhat.config.ts
@@ -1,6 +1,5 @@
 import { HardhatUserConfig } from "hardhat/config";
 import "@nomicfoundation/hardhat-toolbox";
-import "@openzeppelin/hardhat-upgrades";
 
 const ACCOUNTS_MNEMONIC = "test test test test test test test test test test test junk";
 const MINING_INTERVAL_PATTERN = /^(\d+)s$/;
@@ -34,7 +33,7 @@ const config: HardhatUserConfig = {
             initialBaseFeePerGas: 0,
             mining: {
                 auto: process.env.BLOCK_MODE === "automine",
-                interval: defineBlockMiningIntervalInMs(process.env.BLOCK_MODE)
+                interval: defineBlockMiningIntervalInMs(process.env.BLOCK_MODE),
             },
             accounts: {
                 mnemonic: ACCOUNTS_MNEMONIC,

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -7,9 +7,15 @@
             "name": "hardhat-project",
             "devDependencies": {
                 "@nomicfoundation/hardhat-toolbox": "^5.0.0",
+                "@stylistic/eslint-plugin": "^1.8.1",
                 "@trivago/prettier-plugin-sort-imports": "^4.3.0",
+                "@typescript-eslint/eslint-plugin": "^7.12.0",
+                "@typescript-eslint/parser": "^7.12.0",
                 "axios": "^1.7.2",
+                "eslint": "^8.57.0",
+                "eslint-plugin-sort": "^3.0.2",
                 "prettier": "^3.3.1",
+                "typescript-eslint": "^7.12.0",
                 "web3-types": "^1.6.0",
                 "ws": "^8.17.0"
             }
@@ -381,6 +387,111 @@
             },
             "engines": {
                 "node": ">=12"
+            }
+        },
+        "node_modules/@eslint-community/eslint-utils": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+            "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+            "dev": true,
+            "dependencies": {
+                "eslint-visitor-keys": "^3.3.0"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "peerDependencies": {
+                "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+            }
+        },
+        "node_modules/@eslint-community/regexpp": {
+            "version": "4.10.1",
+            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.1.tgz",
+            "integrity": "sha512-Zm2NGpWELsQAD1xsJzGQpYfvICSsFkEpU0jxBjfdC6uNEWXcHnfs9hScFWtXVDVl+rBQJGrl4g1vcKIejpH9dA==",
+            "dev": true,
+            "engines": {
+                "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+            }
+        },
+        "node_modules/@eslint/eslintrc": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+            "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+            "dev": true,
+            "dependencies": {
+                "ajv": "^6.12.4",
+                "debug": "^4.3.2",
+                "espree": "^9.6.0",
+                "globals": "^13.19.0",
+                "ignore": "^5.2.0",
+                "import-fresh": "^3.2.1",
+                "js-yaml": "^4.1.0",
+                "minimatch": "^3.1.2",
+                "strip-json-comments": "^3.1.1"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/@eslint/eslintrc/node_modules/ajv": {
+            "version": "6.12.6",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "dev": true,
+            "dependencies": {
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/@eslint/eslintrc/node_modules/globals": {
+            "version": "13.24.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+            "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+            "dev": true,
+            "dependencies": {
+                "type-fest": "^0.20.2"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "dev": true
+        },
+        "node_modules/@eslint/eslintrc/node_modules/type-fest": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+            "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@eslint/js": {
+            "version": "8.57.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
+            "integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
+            "dev": true,
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             }
         },
         "node_modules/@ethereumjs/rlp": {
@@ -1220,6 +1331,41 @@
                 "node": ">=14"
             }
         },
+        "node_modules/@humanwhocodes/config-array": {
+            "version": "0.11.14",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
+            "integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
+            "deprecated": "Use @eslint/config-array instead",
+            "dev": true,
+            "dependencies": {
+                "@humanwhocodes/object-schema": "^2.0.2",
+                "debug": "^4.3.1",
+                "minimatch": "^3.0.5"
+            },
+            "engines": {
+                "node": ">=10.10.0"
+            }
+        },
+        "node_modules/@humanwhocodes/module-importer": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+            "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+            "dev": true,
+            "engines": {
+                "node": ">=12.22"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/nzakas"
+            }
+        },
+        "node_modules/@humanwhocodes/object-schema": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+            "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
+            "deprecated": "Use @eslint/object-schema instead",
+            "dev": true
+        },
         "node_modules/@jridgewell/gen-mapping": {
             "version": "0.3.5",
             "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
@@ -1373,7 +1519,6 @@
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
             "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@nodelib/fs.stat": "2.0.5",
                 "run-parallel": "^1.1.9"
@@ -1387,7 +1532,6 @@
             "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
             "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">= 8"
             }
@@ -1397,7 +1541,6 @@
             "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
             "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@nodelib/fs.scandir": "2.1.5",
                 "fastq": "^1.6.0"
@@ -2262,6 +2405,113 @@
                 "antlr4ts": "^0.5.0-alpha.4"
             }
         },
+        "node_modules/@stylistic/eslint-plugin": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-1.8.1.tgz",
+            "integrity": "sha512-64My6I7uCcmSQ//427Pfg2vjSf9SDzfsGIWohNFgISMLYdC5BzJqDo647iDDJzSxINh3WTC0Ql46ifiKuOoTyA==",
+            "dev": true,
+            "dependencies": {
+                "@stylistic/eslint-plugin-js": "1.8.1",
+                "@stylistic/eslint-plugin-jsx": "1.8.1",
+                "@stylistic/eslint-plugin-plus": "1.8.1",
+                "@stylistic/eslint-plugin-ts": "1.8.1",
+                "@types/eslint": "^8.56.10"
+            },
+            "engines": {
+                "node": "^16.0.0 || >=18.0.0"
+            },
+            "peerDependencies": {
+                "eslint": ">=8.40.0"
+            }
+        },
+        "node_modules/@stylistic/eslint-plugin-js": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-js/-/eslint-plugin-js-1.8.1.tgz",
+            "integrity": "sha512-c5c2C8Mos5tTQd+NWpqwEu7VT6SSRooAguFPMj1cp2RkTYl1ynKoXo8MWy3k4rkbzoeYHrqC2UlUzsroAN7wtQ==",
+            "dev": true,
+            "dependencies": {
+                "@types/eslint": "^8.56.10",
+                "acorn": "^8.11.3",
+                "escape-string-regexp": "^4.0.0",
+                "eslint-visitor-keys": "^3.4.3",
+                "espree": "^9.6.1"
+            },
+            "engines": {
+                "node": "^16.0.0 || >=18.0.0"
+            },
+            "peerDependencies": {
+                "eslint": ">=8.40.0"
+            }
+        },
+        "node_modules/@stylistic/eslint-plugin-jsx": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-jsx/-/eslint-plugin-jsx-1.8.1.tgz",
+            "integrity": "sha512-k1Eb6rcjMP+mmjvj+vd9y5KUdWn1OBkkPLHXhsrHt5lCDFZxJEs0aVQzE5lpYrtVZVkpc5esTtss/cPJux0lfA==",
+            "dev": true,
+            "dependencies": {
+                "@stylistic/eslint-plugin-js": "^1.8.1",
+                "@types/eslint": "^8.56.10",
+                "estraverse": "^5.3.0",
+                "picomatch": "^4.0.2"
+            },
+            "engines": {
+                "node": "^16.0.0 || >=18.0.0"
+            },
+            "peerDependencies": {
+                "eslint": ">=8.40.0"
+            }
+        },
+        "node_modules/@stylistic/eslint-plugin-jsx/node_modules/estraverse": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+            "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+            "dev": true,
+            "engines": {
+                "node": ">=4.0"
+            }
+        },
+        "node_modules/@stylistic/eslint-plugin-jsx/node_modules/picomatch": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+            "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/@stylistic/eslint-plugin-plus": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-plus/-/eslint-plugin-plus-1.8.1.tgz",
+            "integrity": "sha512-4+40H3lHYTN8OWz+US8CamVkO+2hxNLp9+CAjorI7top/lHqemhpJvKA1LD9Uh+WMY9DYWiWpL2+SZ2wAXY9fQ==",
+            "dev": true,
+            "dependencies": {
+                "@types/eslint": "^8.56.10",
+                "@typescript-eslint/utils": "^6.21.0"
+            },
+            "peerDependencies": {
+                "eslint": "*"
+            }
+        },
+        "node_modules/@stylistic/eslint-plugin-ts": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-ts/-/eslint-plugin-ts-1.8.1.tgz",
+            "integrity": "sha512-/q1m+ZuO1JHfiSF16EATFzv7XSJkc5W6DocfvH5o9oB6WWYFMF77fVoBWnKT3wGptPOc2hkRupRKhmeFROdfWA==",
+            "dev": true,
+            "dependencies": {
+                "@stylistic/eslint-plugin-js": "1.8.1",
+                "@types/eslint": "^8.56.10",
+                "@typescript-eslint/utils": "^6.21.0"
+            },
+            "engines": {
+                "node": "^16.0.0 || >=18.0.0"
+            },
+            "peerDependencies": {
+                "eslint": ">=8.40.0"
+            }
+        },
         "node_modules/@trivago/prettier-plugin-sort-imports": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/@trivago/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-4.3.0.tgz",
@@ -2398,6 +2648,22 @@
                 "@types/node": "*"
             }
         },
+        "node_modules/@types/eslint": {
+            "version": "8.56.10",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.10.tgz",
+            "integrity": "sha512-Shavhk87gCtY2fhXDctcfS3e6FdxWkCx1iUZ9eEUbh7rTqlZT0/IzOkCOVt0fCjcFuZ9FPYfuezTBImfHCDBGQ==",
+            "dev": true,
+            "dependencies": {
+                "@types/estree": "*",
+                "@types/json-schema": "*"
+            }
+        },
+        "node_modules/@types/estree": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+            "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+            "dev": true
+        },
         "node_modules/@types/form-data": {
             "version": "0.0.33",
             "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-0.0.33.tgz",
@@ -2418,6 +2684,12 @@
                 "@types/minimatch": "*",
                 "@types/node": "*"
             }
+        },
+        "node_modules/@types/json-schema": {
+            "version": "7.0.15",
+            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+            "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+            "dev": true
         },
         "node_modules/@types/lru-cache": {
             "version": "5.1.1",
@@ -2484,6 +2756,610 @@
                 "@types/node": "*"
             }
         },
+        "node_modules/@types/semver": {
+            "version": "7.5.8",
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
+            "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
+            "dev": true
+        },
+        "node_modules/@typescript-eslint/eslint-plugin": {
+            "version": "7.13.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.13.0.tgz",
+            "integrity": "sha512-FX1X6AF0w8MdVFLSdqwqN/me2hyhuQg4ykN6ZpVhh1ij/80pTvDKclX1sZB9iqex8SjQfVhwMKs3JtnnMLzG9w==",
+            "dev": true,
+            "dependencies": {
+                "@eslint-community/regexpp": "^4.10.0",
+                "@typescript-eslint/scope-manager": "7.13.0",
+                "@typescript-eslint/type-utils": "7.13.0",
+                "@typescript-eslint/utils": "7.13.0",
+                "@typescript-eslint/visitor-keys": "7.13.0",
+                "graphemer": "^1.4.0",
+                "ignore": "^5.3.1",
+                "natural-compare": "^1.4.0",
+                "ts-api-utils": "^1.3.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || >=20.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "@typescript-eslint/parser": "^7.0.0",
+                "eslint": "^8.56.0"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/utils": {
+            "version": "7.13.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.13.0.tgz",
+            "integrity": "sha512-jceD8RgdKORVnB4Y6BqasfIkFhl4pajB1wVxrF4akxD2QPM8GNYjgGwEzYS+437ewlqqrg7Dw+6dhdpjMpeBFQ==",
+            "dev": true,
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.4.0",
+                "@typescript-eslint/scope-manager": "7.13.0",
+                "@typescript-eslint/types": "7.13.0",
+                "@typescript-eslint/typescript-estree": "7.13.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || >=20.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.56.0"
+            }
+        },
+        "node_modules/@typescript-eslint/experimental-utils": {
+            "version": "5.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.62.0.tgz",
+            "integrity": "sha512-RTXpeB3eMkpoclG3ZHft6vG/Z30azNHuqY6wKPBHlVMZFuEvrtlEDe8gMqDb+SO+9hjC/pLekeSCryf9vMZlCw==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/utils": "5.62.0"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            }
+        },
+        "node_modules/@typescript-eslint/experimental-utils/node_modules/@typescript-eslint/scope-manager": {
+            "version": "5.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
+            "integrity": "sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "5.62.0",
+                "@typescript-eslint/visitor-keys": "5.62.0"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/experimental-utils/node_modules/@typescript-eslint/types": {
+            "version": "5.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
+            "integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==",
+            "dev": true,
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/experimental-utils/node_modules/@typescript-eslint/typescript-estree": {
+            "version": "5.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
+            "integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "5.62.0",
+                "@typescript-eslint/visitor-keys": "5.62.0",
+                "debug": "^4.3.4",
+                "globby": "^11.1.0",
+                "is-glob": "^4.0.3",
+                "semver": "^7.3.7",
+                "tsutils": "^3.21.0"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@typescript-eslint/experimental-utils/node_modules/@typescript-eslint/utils": {
+            "version": "5.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.62.0.tgz",
+            "integrity": "sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==",
+            "dev": true,
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.2.0",
+                "@types/json-schema": "^7.0.9",
+                "@types/semver": "^7.3.12",
+                "@typescript-eslint/scope-manager": "5.62.0",
+                "@typescript-eslint/types": "5.62.0",
+                "@typescript-eslint/typescript-estree": "5.62.0",
+                "eslint-scope": "^5.1.1",
+                "semver": "^7.3.7"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            }
+        },
+        "node_modules/@typescript-eslint/experimental-utils/node_modules/@typescript-eslint/visitor-keys": {
+            "version": "5.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
+            "integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "5.62.0",
+                "eslint-visitor-keys": "^3.3.0"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/experimental-utils/node_modules/eslint-scope": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+            "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+            "dev": true,
+            "dependencies": {
+                "esrecurse": "^4.3.0",
+                "estraverse": "^4.1.1"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/@typescript-eslint/experimental-utils/node_modules/estraverse": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+            "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+            "dev": true,
+            "engines": {
+                "node": ">=4.0"
+            }
+        },
+        "node_modules/@typescript-eslint/experimental-utils/node_modules/globby": {
+            "version": "11.1.0",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+            "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+            "dev": true,
+            "dependencies": {
+                "array-union": "^2.1.0",
+                "dir-glob": "^3.0.1",
+                "fast-glob": "^3.2.9",
+                "ignore": "^5.2.0",
+                "merge2": "^1.4.1",
+                "slash": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@typescript-eslint/experimental-utils/node_modules/semver": {
+            "version": "7.6.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+            "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+            "dev": true,
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@typescript-eslint/parser": {
+            "version": "7.13.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.13.0.tgz",
+            "integrity": "sha512-EjMfl69KOS9awXXe83iRN7oIEXy9yYdqWfqdrFAYAAr6syP8eLEFI7ZE4939antx2mNgPRW/o1ybm2SFYkbTVA==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/scope-manager": "7.13.0",
+                "@typescript-eslint/types": "7.13.0",
+                "@typescript-eslint/typescript-estree": "7.13.0",
+                "@typescript-eslint/visitor-keys": "7.13.0",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": "^18.18.0 || >=20.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.56.0"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@typescript-eslint/scope-manager": {
+            "version": "7.13.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.13.0.tgz",
+            "integrity": "sha512-ZrMCe1R6a01T94ilV13egvcnvVJ1pxShkE0+NDjDzH4nvG1wXpwsVI5bZCvE7AEDH1mXEx5tJSVR68bLgG7Dng==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "7.13.0",
+                "@typescript-eslint/visitor-keys": "7.13.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || >=20.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/type-utils": {
+            "version": "7.13.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.13.0.tgz",
+            "integrity": "sha512-xMEtMzxq9eRkZy48XuxlBFzpVMDurUAfDu5Rz16GouAtXm0TaAoTFzqWUFPPuQYXI/CDaH/Bgx/fk/84t/Bc9A==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/typescript-estree": "7.13.0",
+                "@typescript-eslint/utils": "7.13.0",
+                "debug": "^4.3.4",
+                "ts-api-utils": "^1.3.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || >=20.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.56.0"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/utils": {
+            "version": "7.13.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.13.0.tgz",
+            "integrity": "sha512-jceD8RgdKORVnB4Y6BqasfIkFhl4pajB1wVxrF4akxD2QPM8GNYjgGwEzYS+437ewlqqrg7Dw+6dhdpjMpeBFQ==",
+            "dev": true,
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.4.0",
+                "@typescript-eslint/scope-manager": "7.13.0",
+                "@typescript-eslint/types": "7.13.0",
+                "@typescript-eslint/typescript-estree": "7.13.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || >=20.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.56.0"
+            }
+        },
+        "node_modules/@typescript-eslint/types": {
+            "version": "7.13.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.13.0.tgz",
+            "integrity": "sha512-QWuwm9wcGMAuTsxP+qz6LBBd3Uq8I5Nv8xb0mk54jmNoCyDspnMvVsOxI6IsMmway5d1S9Su2+sCKv1st2l6eA==",
+            "dev": true,
+            "engines": {
+                "node": "^18.18.0 || >=20.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/typescript-estree": {
+            "version": "7.13.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.13.0.tgz",
+            "integrity": "sha512-cAvBvUoobaoIcoqox1YatXOnSl3gx92rCZoMRPzMNisDiM12siGilSM4+dJAekuuHTibI2hVC2fYK79iSFvWjw==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "7.13.0",
+                "@typescript-eslint/visitor-keys": "7.13.0",
+                "debug": "^4.3.4",
+                "globby": "^11.1.0",
+                "is-glob": "^4.0.3",
+                "minimatch": "^9.0.4",
+                "semver": "^7.6.0",
+                "ts-api-utils": "^1.3.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || >=20.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "dev": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/@typescript-eslint/typescript-estree/node_modules/globby": {
+            "version": "11.1.0",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+            "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+            "dev": true,
+            "dependencies": {
+                "array-union": "^2.1.0",
+                "dir-glob": "^3.0.1",
+                "fast-glob": "^3.2.9",
+                "ignore": "^5.2.0",
+                "merge2": "^1.4.1",
+                "slash": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+            "version": "9.0.4",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
+            "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+            "version": "7.6.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+            "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+            "dev": true,
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@typescript-eslint/utils": {
+            "version": "6.21.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.21.0.tgz",
+            "integrity": "sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==",
+            "dev": true,
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.4.0",
+                "@types/json-schema": "^7.0.12",
+                "@types/semver": "^7.5.0",
+                "@typescript-eslint/scope-manager": "6.21.0",
+                "@typescript-eslint/types": "6.21.0",
+                "@typescript-eslint/typescript-estree": "6.21.0",
+                "semver": "^7.5.4"
+            },
+            "engines": {
+                "node": "^16.0.0 || >=18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^7.0.0 || ^8.0.0"
+            }
+        },
+        "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/scope-manager": {
+            "version": "6.21.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
+            "integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "6.21.0",
+                "@typescript-eslint/visitor-keys": "6.21.0"
+            },
+            "engines": {
+                "node": "^16.0.0 || >=18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/types": {
+            "version": "6.21.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
+            "integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
+            "dev": true,
+            "engines": {
+                "node": "^16.0.0 || >=18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree": {
+            "version": "6.21.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
+            "integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "6.21.0",
+                "@typescript-eslint/visitor-keys": "6.21.0",
+                "debug": "^4.3.4",
+                "globby": "^11.1.0",
+                "is-glob": "^4.0.3",
+                "minimatch": "9.0.3",
+                "semver": "^7.5.4",
+                "ts-api-utils": "^1.0.1"
+            },
+            "engines": {
+                "node": "^16.0.0 || >=18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/visitor-keys": {
+            "version": "6.21.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
+            "integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "6.21.0",
+                "eslint-visitor-keys": "^3.4.1"
+            },
+            "engines": {
+                "node": "^16.0.0 || >=18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/utils/node_modules/brace-expansion": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "dev": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/@typescript-eslint/utils/node_modules/globby": {
+            "version": "11.1.0",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+            "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+            "dev": true,
+            "dependencies": {
+                "array-union": "^2.1.0",
+                "dir-glob": "^3.0.1",
+                "fast-glob": "^3.2.9",
+                "ignore": "^5.2.0",
+                "merge2": "^1.4.1",
+                "slash": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@typescript-eslint/utils/node_modules/minimatch": {
+            "version": "9.0.3",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+            "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@typescript-eslint/utils/node_modules/semver": {
+            "version": "7.6.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+            "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+            "dev": true,
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@typescript-eslint/visitor-keys": {
+            "version": "7.13.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.13.0.tgz",
+            "integrity": "sha512-nxn+dozQx+MK61nn/JP+M4eCkHDSxSLDpgE3WcQo0+fkjEolnaB5jswvIKC4K56By8MMgIho7f1PVxERHEo8rw==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "7.13.0",
+                "eslint-visitor-keys": "^3.4.3"
+            },
+            "engines": {
+                "node": "^18.18.0 || >=20.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@ungap/structured-clone": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
+            "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
+            "dev": true
+        },
         "node_modules/abbrev": {
             "version": "1.0.9",
             "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
@@ -2496,12 +3372,20 @@
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
             "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
             "dev": true,
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
             "engines": {
                 "node": ">=0.4.0"
+            }
+        },
+        "node_modules/acorn-jsx": {
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+            "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+            "dev": true,
+            "peerDependencies": {
+                "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
             }
         },
         "node_modules/acorn-walk": {
@@ -2627,7 +3511,6 @@
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
             "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -2637,7 +3520,6 @@
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
             "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "color-convert": "^2.0.1"
             },
@@ -2680,8 +3562,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/array-back": {
             "version": "3.1.0",
@@ -2698,7 +3579,6 @@
             "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
             "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -2778,8 +3658,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/base-x": {
             "version": "3.0.9",
@@ -2866,7 +3745,6 @@
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -2877,7 +3755,6 @@
             "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
             "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "fill-range": "^7.1.1"
             },
@@ -2980,6 +3857,15 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/callsites": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+            "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/camelcase": {
             "version": "6.3.0",
             "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
@@ -3050,7 +3936,6 @@
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
             "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -3232,7 +4117,6 @@
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
             "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "color-name": "~1.1.4"
             },
@@ -3244,8 +4128,7 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/colors": {
             "version": "1.4.0",
@@ -3417,8 +4300,7 @@
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/concat-stream": {
             "version": "1.6.2",
@@ -3522,6 +4404,35 @@
             "dev": true,
             "peer": true
         },
+        "node_modules/cross-spawn": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+            "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+            "dev": true,
+            "dependencies": {
+                "path-key": "^3.1.0",
+                "shebang-command": "^2.0.0",
+                "which": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/cross-spawn/node_modules/which": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+            "dev": true,
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "node-which": "bin/node-which"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
         "node_modules/crypt": {
             "version": "0.0.2",
             "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
@@ -3596,8 +4507,7 @@
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
             "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/define-data-property": {
             "version": "1.1.4",
@@ -3664,12 +4574,23 @@
             "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
             "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "path-type": "^4.0.0"
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/doctrine": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+            "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+            "dev": true,
+            "dependencies": {
+                "esutils": "^2.0.2"
+            },
+            "engines": {
+                "node": ">=6.0.0"
             }
         },
         "node_modules/elliptic": {
@@ -3764,7 +4685,6 @@
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
             "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -3809,6 +4729,311 @@
                 "node": ">=0.8.0"
             }
         },
+        "node_modules/eslint": {
+            "version": "8.57.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
+            "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
+            "dev": true,
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.2.0",
+                "@eslint-community/regexpp": "^4.6.1",
+                "@eslint/eslintrc": "^2.1.4",
+                "@eslint/js": "8.57.0",
+                "@humanwhocodes/config-array": "^0.11.14",
+                "@humanwhocodes/module-importer": "^1.0.1",
+                "@nodelib/fs.walk": "^1.2.8",
+                "@ungap/structured-clone": "^1.2.0",
+                "ajv": "^6.12.4",
+                "chalk": "^4.0.0",
+                "cross-spawn": "^7.0.2",
+                "debug": "^4.3.2",
+                "doctrine": "^3.0.0",
+                "escape-string-regexp": "^4.0.0",
+                "eslint-scope": "^7.2.2",
+                "eslint-visitor-keys": "^3.4.3",
+                "espree": "^9.6.1",
+                "esquery": "^1.4.2",
+                "esutils": "^2.0.2",
+                "fast-deep-equal": "^3.1.3",
+                "file-entry-cache": "^6.0.1",
+                "find-up": "^5.0.0",
+                "glob-parent": "^6.0.2",
+                "globals": "^13.19.0",
+                "graphemer": "^1.4.0",
+                "ignore": "^5.2.0",
+                "imurmurhash": "^0.1.4",
+                "is-glob": "^4.0.0",
+                "is-path-inside": "^3.0.3",
+                "js-yaml": "^4.1.0",
+                "json-stable-stringify-without-jsonify": "^1.0.1",
+                "levn": "^0.4.1",
+                "lodash.merge": "^4.6.2",
+                "minimatch": "^3.1.2",
+                "natural-compare": "^1.4.0",
+                "optionator": "^0.9.3",
+                "strip-ansi": "^6.0.1",
+                "text-table": "^0.2.0"
+            },
+            "bin": {
+                "eslint": "bin/eslint.js"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/eslint-plugin-sort": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-sort/-/eslint-plugin-sort-3.0.2.tgz",
+            "integrity": "sha512-l1eARITmR3sSdqCTekEY7q5CiEzZdST/QGDCVUCgqAdrATGtw7/lDDXmIxdMeXe570P5dgV0RKbtTvvxODJS8w==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/experimental-utils": "^5.54.1",
+                "isomorphic-resolve": "^1.0.0",
+                "natural-compare": "^1.4.0"
+            },
+            "peerDependencies": {
+                "eslint": ">=8"
+            }
+        },
+        "node_modules/eslint-scope": {
+            "version": "7.2.2",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+            "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+            "dev": true,
+            "dependencies": {
+                "esrecurse": "^4.3.0",
+                "estraverse": "^5.2.0"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/eslint-scope/node_modules/estraverse": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+            "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+            "dev": true,
+            "engines": {
+                "node": ">=4.0"
+            }
+        },
+        "node_modules/eslint-visitor-keys": {
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+            "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+            "dev": true,
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/eslint/node_modules/ajv": {
+            "version": "6.12.6",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "dev": true,
+            "dependencies": {
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/eslint/node_modules/find-up": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+            "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+            "dev": true,
+            "dependencies": {
+                "locate-path": "^6.0.0",
+                "path-exists": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/eslint/node_modules/glob-parent": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+            "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+            "dev": true,
+            "dependencies": {
+                "is-glob": "^4.0.3"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            }
+        },
+        "node_modules/eslint/node_modules/globals": {
+            "version": "13.24.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+            "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+            "dev": true,
+            "dependencies": {
+                "type-fest": "^0.20.2"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/eslint/node_modules/json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "dev": true
+        },
+        "node_modules/eslint/node_modules/levn": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+            "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+            "dev": true,
+            "dependencies": {
+                "prelude-ls": "^1.2.1",
+                "type-check": "~0.4.0"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/eslint/node_modules/locate-path": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+            "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+            "dev": true,
+            "dependencies": {
+                "p-locate": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/eslint/node_modules/optionator": {
+            "version": "0.9.4",
+            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+            "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+            "dev": true,
+            "dependencies": {
+                "deep-is": "^0.1.3",
+                "fast-levenshtein": "^2.0.6",
+                "levn": "^0.4.1",
+                "prelude-ls": "^1.2.1",
+                "type-check": "^0.4.0",
+                "word-wrap": "^1.2.5"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/eslint/node_modules/p-limit": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+            "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+            "dev": true,
+            "dependencies": {
+                "yocto-queue": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/eslint/node_modules/p-locate": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+            "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+            "dev": true,
+            "dependencies": {
+                "p-limit": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/eslint/node_modules/path-exists": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+            "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/eslint/node_modules/prelude-ls": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+            "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/eslint/node_modules/type-check": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+            "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+            "dev": true,
+            "dependencies": {
+                "prelude-ls": "^1.2.1"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/eslint/node_modules/type-fest": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+            "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/espree": {
+            "version": "9.6.1",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+            "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+            "dev": true,
+            "dependencies": {
+                "acorn": "^8.9.0",
+                "acorn-jsx": "^5.3.2",
+                "eslint-visitor-keys": "^3.4.1"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
         "node_modules/esprima": {
             "version": "2.7.3",
             "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
@@ -3821,6 +5046,48 @@
             },
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/esquery": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
+            "integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
+            "dev": true,
+            "dependencies": {
+                "estraverse": "^5.1.0"
+            },
+            "engines": {
+                "node": ">=0.10"
+            }
+        },
+        "node_modules/esquery/node_modules/estraverse": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+            "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+            "dev": true,
+            "engines": {
+                "node": ">=4.0"
+            }
+        },
+        "node_modules/esrecurse": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+            "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+            "dev": true,
+            "dependencies": {
+                "estraverse": "^5.2.0"
+            },
+            "engines": {
+                "node": ">=4.0"
+            }
+        },
+        "node_modules/esrecurse/node_modules/estraverse": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+            "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+            "dev": true,
+            "engines": {
+                "node": ">=4.0"
             }
         },
         "node_modules/estraverse": {
@@ -3838,7 +5105,6 @@
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
             "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -4201,15 +5467,13 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/fast-glob": {
             "version": "3.3.2",
             "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
             "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@nodelib/fs.stat": "^2.0.2",
                 "@nodelib/fs.walk": "^1.2.3",
@@ -4221,21 +5485,37 @@
                 "node": ">=8.6.0"
             }
         },
+        "node_modules/fast-json-stable-stringify": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+            "dev": true
+        },
         "node_modules/fast-levenshtein": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/fastq": {
             "version": "1.17.1",
             "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
             "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "reusify": "^1.0.4"
+            }
+        },
+        "node_modules/file-entry-cache": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+            "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+            "dev": true,
+            "dependencies": {
+                "flat-cache": "^3.0.4"
+            },
+            "engines": {
+                "node": "^10.12.0 || >=12.0.0"
             }
         },
         "node_modules/fill-range": {
@@ -4243,7 +5523,6 @@
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
             "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "to-regex-range": "^5.0.1"
             },
@@ -4286,6 +5565,42 @@
             "bin": {
                 "flat": "cli.js"
             }
+        },
+        "node_modules/flat-cache": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
+            "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
+            "dev": true,
+            "dependencies": {
+                "flatted": "^3.2.9",
+                "keyv": "^4.5.3",
+                "rimraf": "^3.0.2"
+            },
+            "engines": {
+                "node": "^10.12.0 || >=12.0.0"
+            }
+        },
+        "node_modules/flat-cache/node_modules/rimraf": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+            "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+            "deprecated": "Rimraf versions prior to v4 are no longer supported",
+            "dev": true,
+            "dependencies": {
+                "glob": "^7.1.3"
+            },
+            "bin": {
+                "rimraf": "bin.js"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/flatted": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
+            "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
+            "dev": true
         },
         "node_modules/follow-redirects": {
             "version": "1.15.6",
@@ -4354,8 +5669,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
             "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/fsevents": {
             "version": "2.3.3",
@@ -4529,7 +5843,6 @@
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
             "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -4550,7 +5863,6 @@
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
             "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "is-glob": "^4.0.1"
             },
@@ -4634,6 +5946,12 @@
             "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
             "dev": true,
             "peer": true
+        },
+        "node_modules/graphemer": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+            "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+            "dev": true
         },
         "node_modules/handlebars": {
             "version": "4.7.8",
@@ -4950,7 +6268,6 @@
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
             "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -5144,7 +6461,6 @@
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
             "integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">= 4"
             }
@@ -5167,6 +6483,40 @@
             "dev": true,
             "peer": true
         },
+        "node_modules/import-fresh": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+            "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+            "dev": true,
+            "dependencies": {
+                "parent-module": "^1.0.0",
+                "resolve-from": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/import-fresh/node_modules/resolve-from": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+            "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/imurmurhash": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+            "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.8.19"
+            }
+        },
         "node_modules/indent-string": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
@@ -5182,7 +6532,6 @@
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "once": "^1.3.0",
                 "wrappy": "1"
@@ -5192,8 +6541,7 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/ini": {
             "version": "1.3.8",
@@ -5240,7 +6588,6 @@
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
             "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -5260,7 +6607,6 @@
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
             "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "is-extglob": "^2.1.1"
             },
@@ -5284,9 +6630,17 @@
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
             "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=0.12.0"
+            }
+        },
+        "node_modules/is-path-inside": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+            "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/is-plain-obj": {
@@ -5323,8 +6677,13 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-            "dev": true,
-            "peer": true
+            "dev": true
+        },
+        "node_modules/isomorphic-resolve": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isomorphic-resolve/-/isomorphic-resolve-1.0.0.tgz",
+            "integrity": "sha512-FWn6176keSYAapzv5P6ZzLdbCXj5uaG49h1y+EXRNqZm2RBztzBOYqCMmSe4Dmo+bIvk7sX/SN4pI/3QmfH3aw==",
+            "dev": true
         },
         "node_modules/javascript-natural-sort": {
             "version": "0.7.1",
@@ -5350,7 +6709,6 @@
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
             "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "argparse": "^2.0.1"
             },
@@ -5370,12 +6728,24 @@
                 "node": ">=4"
             }
         },
+        "node_modules/json-buffer": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+            "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+            "dev": true
+        },
         "node_modules/json-schema-traverse": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
             "dev": true,
             "peer": true
+        },
+        "node_modules/json-stable-stringify-without-jsonify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+            "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+            "dev": true
         },
         "node_modules/json-stringify-safe": {
             "version": "5.0.1",
@@ -5421,6 +6791,15 @@
             },
             "engines": {
                 "node": ">=10.0.0"
+            }
+        },
+        "node_modules/keyv": {
+            "version": "4.5.4",
+            "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+            "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+            "dev": true,
+            "dependencies": {
+                "json-buffer": "3.0.1"
             }
         },
         "node_modules/kind-of": {
@@ -5508,6 +6887,12 @@
             "dev": true,
             "peer": true
         },
+        "node_modules/lodash.merge": {
+            "version": "4.6.2",
+            "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+            "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+            "dev": true
+        },
         "node_modules/lodash.truncate": {
             "version": "4.4.2",
             "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
@@ -5590,7 +6975,6 @@
             "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
             "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">= 8"
             }
@@ -5607,7 +6991,6 @@
             "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
             "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "braces": "^3.0.3",
                 "picomatch": "^2.3.1"
@@ -5656,7 +7039,6 @@
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
             "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -5943,6 +7325,12 @@
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
             "dev": true
         },
+        "node_modules/natural-compare": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+            "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+            "dev": true
+        },
         "node_modules/ndjson": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ndjson/-/ndjson-2.0.0.tgz",
@@ -6086,7 +7474,6 @@
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "wrappy": "1"
             }
@@ -6178,6 +7565,18 @@
                 "node": ">=4"
             }
         },
+        "node_modules/parent-module": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+            "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+            "dev": true,
+            "dependencies": {
+                "callsites": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/parse-cache-control": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
@@ -6200,9 +7599,17 @@
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/path-key": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/path-parse": {
@@ -6217,7 +7624,6 @@
             "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
             "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -6260,7 +7666,6 @@
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
             "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=8.6"
             },
@@ -6345,7 +7750,6 @@
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
             "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -6384,8 +7788,7 @@
                     "type": "consulting",
                     "url": "https://feross.org/support"
                 }
-            ],
-            "peer": true
+            ]
         },
         "node_modules/randombytes": {
             "version": "2.1.0",
@@ -6551,7 +7954,6 @@
             "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
             "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "iojs": ">=1.0.0",
                 "node": ">=0.10.0"
@@ -6613,7 +8015,6 @@
                     "url": "https://feross.org/support"
                 }
             ],
-            "peer": true,
             "dependencies": {
                 "queue-microtask": "^1.2.2"
             }
@@ -6860,6 +8261,27 @@
                 "node": "*"
             }
         },
+        "node_modules/shebang-command": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+            "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+            "dev": true,
+            "dependencies": {
+                "shebang-regex": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/shebang-regex": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/shelljs": {
             "version": "0.8.5",
             "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
@@ -6909,7 +8331,6 @@
             "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
             "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -7274,7 +8695,6 @@
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
             "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "ansi-regex": "^5.0.1"
             },
@@ -7301,7 +8721,6 @@
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
             "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=8"
             },
@@ -7314,7 +8733,6 @@
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
             "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "has-flag": "^4.0.0"
             },
@@ -7400,6 +8818,12 @@
                 "node": ">=8"
             }
         },
+        "node_modules/text-table": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+            "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+            "dev": true
+        },
         "node_modules/then-request": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/then-request/-/then-request-6.0.2.tgz",
@@ -7482,7 +8906,6 @@
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
             "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "is-number": "^7.0.0"
             },
@@ -7498,6 +8921,18 @@
             "peer": true,
             "engines": {
                 "node": ">=0.6"
+            }
+        },
+        "node_modules/ts-api-utils": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
+            "integrity": "sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=16"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.2.0"
             }
         },
         "node_modules/ts-command-line-args": {
@@ -7593,6 +9028,27 @@
             "integrity": "sha512-Tyrf5mxF8Ofs1tNoxA13lFeZ2Zrbd6cKbuH3V+MQ5sb6DtBj5FjrXVsRWT8YvNAQTqNoz66dz1WsbigI22aEnw==",
             "dev": true,
             "peer": true
+        },
+        "node_modules/tsutils": {
+            "version": "3.21.0",
+            "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+            "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+            "dev": true,
+            "dependencies": {
+                "tslib": "^1.8.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            },
+            "peerDependencies": {
+                "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
+            }
+        },
+        "node_modules/tsutils/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "dev": true
         },
         "node_modules/tweetnacl": {
             "version": "1.0.3",
@@ -7775,6 +9231,54 @@
                 "node": ">=14.17"
             }
         },
+        "node_modules/typescript-eslint": {
+            "version": "7.13.0",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-7.13.0.tgz",
+            "integrity": "sha512-upO0AXxyBwJ4BbiC6CRgAJKtGYha2zw4m1g7TIVPSonwYEuf7vCicw3syjS1OxdDMTz96sZIXl3Jx3vWJLLKFw==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/eslint-plugin": "7.13.0",
+                "@typescript-eslint/parser": "7.13.0",
+                "@typescript-eslint/utils": "7.13.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || >=20.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.56.0"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/typescript-eslint/node_modules/@typescript-eslint/utils": {
+            "version": "7.13.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.13.0.tgz",
+            "integrity": "sha512-jceD8RgdKORVnB4Y6BqasfIkFhl4pajB1wVxrF4akxD2QPM8GNYjgGwEzYS+437ewlqqrg7Dw+6dhdpjMpeBFQ==",
+            "dev": true,
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.4.0",
+                "@typescript-eslint/scope-manager": "7.13.0",
+                "@typescript-eslint/types": "7.13.0",
+                "@typescript-eslint/typescript-estree": "7.13.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || >=20.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.56.0"
+            }
+        },
         "node_modules/typical": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
@@ -7844,7 +9348,6 @@
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
             "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "punycode": "^2.1.0"
             }
@@ -7980,7 +9483,6 @@
             "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
             "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -8045,8 +9547,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/ws": {
             "version": "8.17.0",
@@ -8139,7 +9640,6 @@
             "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
             "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=10"
             },

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -15,6 +15,7 @@
                 "eslint": "^8.57.0",
                 "eslint-plugin-sort": "^3.0.2",
                 "prettier": "^3.3.1",
+                "prettier-plugin-solidity": "^1.3.1",
                 "typescript-eslint": "^7.12.0",
                 "web3-types": "^1.6.0",
                 "ws": "^8.17.0"
@@ -7708,6 +7709,41 @@
                 "url": "https://github.com/prettier/prettier?sponsor=1"
             }
         },
+        "node_modules/prettier-plugin-solidity": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/prettier-plugin-solidity/-/prettier-plugin-solidity-1.3.1.tgz",
+            "integrity": "sha512-MN4OP5I2gHAzHZG1wcuJl0FsLS3c4Cc5494bbg+6oQWBPuEamjwDvmGfFMZ6NFzsh3Efd9UUxeT7ImgjNH4ozA==",
+            "dev": true,
+            "dependencies": {
+                "@solidity-parser/parser": "^0.17.0",
+                "semver": "^7.5.4",
+                "solidity-comments-extractor": "^0.0.8"
+            },
+            "engines": {
+                "node": ">=16"
+            },
+            "peerDependencies": {
+                "prettier": ">=2.3.0"
+            }
+        },
+        "node_modules/prettier-plugin-solidity/node_modules/@solidity-parser/parser": {
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.17.0.tgz",
+            "integrity": "sha512-Nko8R0/kUo391jsEHHxrGM07QFdnPGvlmox4rmH0kNiNAashItAilhy4Mv4pK5gQmW5f4sXAF58fwJbmlkGcVw==",
+            "dev": true
+        },
+        "node_modules/prettier-plugin-solidity/node_modules/semver": {
+            "version": "7.6.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+            "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+            "dev": true,
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/process-nextick-args": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -8410,6 +8446,12 @@
             "bin": {
                 "semver": "bin/semver"
             }
+        },
+        "node_modules/solidity-comments-extractor": {
+            "version": "0.0.8",
+            "resolved": "https://registry.npmjs.org/solidity-comments-extractor/-/solidity-comments-extractor-0.0.8.tgz",
+            "integrity": "sha512-htM7Vn6LhHreR+EglVMd2s+sZhcXAirB1Zlyrv5zBuTxieCvjfnRpd7iZk75m/u6NOlEyQ94C6TWbBn2cY7w8g==",
+            "dev": true
         },
         "node_modules/solidity-coverage": {
             "version": "0.8.12",

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -6,86 +6,28 @@
         "": {
             "name": "hardhat-project",
             "devDependencies": {
-                "@nomicfoundation/hardhat-toolbox": "^4.0.0",
-                "@openzeppelin/hardhat-upgrades": "^3.0.1",
+                "@nomicfoundation/hardhat-toolbox": "^5.0.0",
                 "@trivago/prettier-plugin-sort-imports": "^4.3.0",
-                "axios": "^1.6.7",
-                "ethers": "^6.9.0",
-                "hardhat": "^2.19.2",
-                "prettier": "^3.1.1",
-                "web3-types": "^1.3.1",
-                "ws": "^8.16.0"
+                "axios": "^1.7.2",
+                "prettier": "^3.3.1",
+                "web3-types": "^1.6.0",
+                "ws": "^8.17.0"
             }
         },
         "node_modules/@adraffy/ens-normalize": {
             "version": "1.10.1",
             "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
             "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==",
-            "dev": true
-        },
-        "node_modules/@aws-crypto/sha256-js": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.2.tgz",
-            "integrity": "sha512-Nr1QJIbW/afYYGzYvrF70LtaHrIRtd4TNAglX8BvlfxJLZ45SAmueIKYl5tWoNBPzp65ymXGFK0Bb1vZUpuc9g==",
             "dev": true,
-            "dependencies": {
-                "@aws-crypto/util": "^1.2.2",
-                "@aws-sdk/types": "^3.1.0",
-                "tslib": "^1.11.1"
-            }
-        },
-        "node_modules/@aws-crypto/util": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-1.2.2.tgz",
-            "integrity": "sha512-H8PjG5WJ4wz0UXAFXeJjWCW1vkvIJ3qUUD+rGRwJ2/hj+xT58Qle2MTql/2MGzkU+1JLAFuR6aJpLAjHwhmwwg==",
-            "dev": true,
-            "dependencies": {
-                "@aws-sdk/types": "^3.1.0",
-                "@aws-sdk/util-utf8-browser": "^3.0.0",
-                "tslib": "^1.11.1"
-            }
-        },
-        "node_modules/@aws-sdk/types": {
-            "version": "3.577.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.577.0.tgz",
-            "integrity": "sha512-FT2JZES3wBKN/alfmhlo+3ZOq/XJ0C7QOZcDNrpKjB0kqYoKjhVKZ/Hx6ArR0czkKfHzBBEs6y40ebIHx2nSmA==",
-            "dev": true,
-            "dependencies": {
-                "@smithy/types": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/types/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-            "dev": true
-        },
-        "node_modules/@aws-sdk/util-utf8-browser": {
-            "version": "3.259.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
-            "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
-            "dev": true,
-            "dependencies": {
-                "tslib": "^2.3.1"
-            }
-        },
-        "node_modules/@aws-sdk/util-utf8-browser/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-            "dev": true
+            "peer": true
         },
         "node_modules/@babel/code-frame": {
-            "version": "7.24.2",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.2.tgz",
-            "integrity": "sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
+            "integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
             "dev": true,
             "dependencies": {
-                "@babel/highlight": "^7.24.2",
+                "@babel/highlight": "^7.24.7",
                 "picocolors": "^1.0.0"
             },
             "engines": {
@@ -107,35 +49,52 @@
             }
         },
         "node_modules/@babel/helper-environment-visitor": {
-            "version": "7.22.20",
-            "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
-            "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.24.7.tgz",
+            "integrity": "sha512-DoiN84+4Gnd0ncbBOM9AZENV4a5ZiL39HYMyZJGZ/AZEykHYdJw0wW3kdcsh9/Kn+BRXHLkkklZ51ecPKmI1CQ==",
             "dev": true,
+            "dependencies": {
+                "@babel/types": "^7.24.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-environment-visitor/node_modules/@babel/types": {
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.7.tgz",
+            "integrity": "sha512-XEFXSlxiG5td2EJRe8vOmRbaXVgfcBlszKujvVmWIK/UpywWljQCfzAv3RQCGujWQ1RD4YYWEAqDXfuJiy8f5Q==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.24.7",
+                "@babel/helper-validator-identifier": "^7.24.7",
+                "to-fast-properties": "^2.0.0"
+            },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-function-name": {
-            "version": "7.23.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
-            "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.24.7.tgz",
+            "integrity": "sha512-FyoJTsj/PEUWu1/TYRiXTIHc8lbw+TDYkZuoE43opPS5TrI7MyONBE1oNvfguEXAD9yhQRrVBnXdXzSLQl9XnA==",
             "dev": true,
             "dependencies": {
-                "@babel/template": "^7.22.15",
-                "@babel/types": "^7.23.0"
+                "@babel/template": "^7.24.7",
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-function-name/node_modules/@babel/types": {
-            "version": "7.24.5",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.5.tgz",
-            "integrity": "sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.7.tgz",
+            "integrity": "sha512-XEFXSlxiG5td2EJRe8vOmRbaXVgfcBlszKujvVmWIK/UpywWljQCfzAv3RQCGujWQ1RD4YYWEAqDXfuJiy8f5Q==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-string-parser": "^7.24.1",
-                "@babel/helper-validator-identifier": "^7.24.5",
+                "@babel/helper-string-parser": "^7.24.7",
+                "@babel/helper-validator-identifier": "^7.24.7",
                 "to-fast-properties": "^2.0.0"
             },
             "engines": {
@@ -143,25 +102,25 @@
             }
         },
         "node_modules/@babel/helper-hoist-variables": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
-            "integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.24.7.tgz",
+            "integrity": "sha512-MJJwhkoGy5c4ehfoRyrJ/owKeMl19U54h27YYftT0o2teQ3FJ3nQUf/I3LlJsX4l3qlw7WRXUmiyajvHXoTubQ==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.22.5"
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-hoist-variables/node_modules/@babel/types": {
-            "version": "7.24.5",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.5.tgz",
-            "integrity": "sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.7.tgz",
+            "integrity": "sha512-XEFXSlxiG5td2EJRe8vOmRbaXVgfcBlszKujvVmWIK/UpywWljQCfzAv3RQCGujWQ1RD4YYWEAqDXfuJiy8f5Q==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-string-parser": "^7.24.1",
-                "@babel/helper-validator-identifier": "^7.24.5",
+                "@babel/helper-string-parser": "^7.24.7",
+                "@babel/helper-validator-identifier": "^7.24.7",
                 "to-fast-properties": "^2.0.0"
             },
             "engines": {
@@ -169,25 +128,25 @@
             }
         },
         "node_modules/@babel/helper-split-export-declaration": {
-            "version": "7.24.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.5.tgz",
-            "integrity": "sha512-5CHncttXohrHk8GWOFCcCl4oRD9fKosWlIRgWm4ql9VYioKm52Mk2xsmoohvm7f3JoiLSM5ZgJuRaf5QZZYd3Q==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.7.tgz",
+            "integrity": "sha512-oy5V7pD+UvfkEATUKvIjvIAH/xCzfsFVw7ygW2SI6NClZzquT+mwdTfgfdbUiceh6iQO0CHtCPsyze/MZ2YbAA==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.24.5"
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-split-export-declaration/node_modules/@babel/types": {
-            "version": "7.24.5",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.5.tgz",
-            "integrity": "sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.7.tgz",
+            "integrity": "sha512-XEFXSlxiG5td2EJRe8vOmRbaXVgfcBlszKujvVmWIK/UpywWljQCfzAv3RQCGujWQ1RD4YYWEAqDXfuJiy8f5Q==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-string-parser": "^7.24.1",
-                "@babel/helper-validator-identifier": "^7.24.5",
+                "@babel/helper-string-parser": "^7.24.7",
+                "@babel/helper-validator-identifier": "^7.24.7",
                 "to-fast-properties": "^2.0.0"
             },
             "engines": {
@@ -195,30 +154,30 @@
             }
         },
         "node_modules/@babel/helper-string-parser": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.1.tgz",
-            "integrity": "sha512-2ofRCjnnA9y+wk8b9IAREroeUP02KHp431N2mhKniy2yKIDKpbrHv9eXwm8cBeWQYcJmzv5qKCu65P47eCF7CQ==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.7.tgz",
+            "integrity": "sha512-7MbVt6xrwFQbunH2DNQsAP5sTGxfqQtErvBIvIMi6EQnbgUOuVYanvREcmFrOPhoXBrTtjhhP+lW+o5UfK+tDg==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.24.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.5.tgz",
-            "integrity": "sha512-3q93SSKX2TWCG30M2G2kwaKeTYgEUp5Snjuj8qm729SObL6nbtUldAi37qbxkD5gg3xnBio+f9nqpSepGZMvxA==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
+            "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/highlight": {
-            "version": "7.24.5",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.5.tgz",
-            "integrity": "sha512-8lLmua6AVh/8SLJRRVD6V8p73Hir9w5mJrhE+IPpILG31KKlI9iz5zmBYKcWPS59qSfgP9RaSBQSHHE81WKuEw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
+            "integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.24.5",
+                "@babel/helper-validator-identifier": "^7.24.7",
                 "chalk": "^2.4.2",
                 "js-tokens": "^4.0.0",
                 "picocolors": "^1.0.0"
@@ -227,10 +186,81 @@
                 "node": ">=6.9.0"
             }
         },
+        "node_modules/@babel/highlight/node_modules/ansi-styles": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+            "dev": true,
+            "dependencies": {
+                "color-convert": "^1.9.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/@babel/highlight/node_modules/chalk": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/@babel/highlight/node_modules/color-convert": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+            "dev": true,
+            "dependencies": {
+                "color-name": "1.1.3"
+            }
+        },
+        "node_modules/@babel/highlight/node_modules/color-name": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+            "dev": true
+        },
+        "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/@babel/highlight/node_modules/has-flag": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/@babel/highlight/node_modules/supports-color": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+            "dev": true,
+            "dependencies": {
+                "has-flag": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/@babel/parser": {
-            "version": "7.24.5",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.5.tgz",
-            "integrity": "sha512-EOv5IK8arwh3LI47dz1b0tKUb/1uhHAnHJOrjgtQMIpu1uXd9mlFrJg9IUgGUgZ41Ch0K8REPTYpO7B76b4vJg==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.7.tgz",
+            "integrity": "sha512-9uUYRm6OqQrCqQdG1iCBwBPZgN8ciDBro2nIOFaiRz1/BCxaI7CNvQbDHvsArAC7Tw9Hda/B3U+6ui9u4HWXPw==",
             "dev": true,
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -240,27 +270,27 @@
             }
         },
         "node_modules/@babel/template": {
-            "version": "7.24.0",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.0.tgz",
-            "integrity": "sha512-Bkf2q8lMB0AFpX0NFEqSbx1OkTHf0f+0j82mkw+ZpzBnkk7e9Ql0891vlfgi+kHwOk8tQjiQHpqh4LaSa0fKEA==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.7.tgz",
+            "integrity": "sha512-jYqfPrU9JTF0PmPy1tLYHW4Mp4KlgxJD9l2nP9fD6yT/ICi554DmrWBAEYpIelzjHf1msDP3PxJIRt/nFNfBig==",
             "dev": true,
             "dependencies": {
-                "@babel/code-frame": "^7.23.5",
-                "@babel/parser": "^7.24.0",
-                "@babel/types": "^7.24.0"
+                "@babel/code-frame": "^7.24.7",
+                "@babel/parser": "^7.24.7",
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/template/node_modules/@babel/types": {
-            "version": "7.24.5",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.5.tgz",
-            "integrity": "sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.7.tgz",
+            "integrity": "sha512-XEFXSlxiG5td2EJRe8vOmRbaXVgfcBlszKujvVmWIK/UpywWljQCfzAv3RQCGujWQ1RD4YYWEAqDXfuJiy8f5Q==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-string-parser": "^7.24.1",
-                "@babel/helper-validator-identifier": "^7.24.5",
+                "@babel/helper-string-parser": "^7.24.7",
+                "@babel/helper-validator-identifier": "^7.24.7",
                 "to-fast-properties": "^2.0.0"
             },
             "engines": {
@@ -289,12 +319,12 @@
             }
         },
         "node_modules/@babel/traverse/node_modules/@babel/generator": {
-            "version": "7.24.5",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.5.tgz",
-            "integrity": "sha512-x32i4hEXvr+iI0NEoEfDKzlemF8AmtOP8CcrRaEcpzysWuoEb1KknpcvMsHKPONoKZiDuItklgWhB18xEhr9PA==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.7.tgz",
+            "integrity": "sha512-oipXieGC3i45Y1A41t4tAqpnEZWgB/lC6Ehh6+rOviR5XWpTtMmLN+fGjz9vOiNRt0p6RtO6DtD0pdU3vpqdSA==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.24.5",
+                "@babel/types": "^7.24.7",
                 "@jridgewell/gen-mapping": "^0.3.5",
                 "@jridgewell/trace-mapping": "^0.3.25",
                 "jsesc": "^2.5.1"
@@ -304,13 +334,13 @@
             }
         },
         "node_modules/@babel/traverse/node_modules/@babel/types": {
-            "version": "7.24.5",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.5.tgz",
-            "integrity": "sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.7.tgz",
+            "integrity": "sha512-XEFXSlxiG5td2EJRe8vOmRbaXVgfcBlszKujvVmWIK/UpywWljQCfzAv3RQCGujWQ1RD4YYWEAqDXfuJiy8f5Q==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-string-parser": "^7.24.1",
-                "@babel/helper-validator-identifier": "^7.24.5",
+                "@babel/helper-string-parser": "^7.24.7",
+                "@babel/helper-validator-identifier": "^7.24.7",
                 "to-fast-properties": "^2.0.0"
             },
             "engines": {
@@ -382,22 +412,22 @@
             }
         },
         "node_modules/@ethereumjs/util/node_modules/@noble/curves": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.3.0.tgz",
-            "integrity": "sha512-t01iSXPuN+Eqzb4eBX0S5oubSqXbK/xXa1Ne18Hj8f9pStxztHCE2gfboSp/dZRLSqfuLpRK2nDXDK+W9puocA==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.0.tgz",
+            "integrity": "sha512-p+4cb332SFCrReJkCYe8Xzm0OWi4Jji5jVdIZRL/PmacmDkFNw6MrrV+gGpiPxLHbV+zKFRywUWbaseT+tZRXg==",
             "dev": true,
             "peer": true,
             "dependencies": {
-                "@noble/hashes": "1.3.3"
+                "@noble/hashes": "1.4.0"
             },
             "funding": {
                 "url": "https://paulmillr.com/funding/"
             }
         },
         "node_modules/@ethereumjs/util/node_modules/@noble/hashes": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.3.tgz",
-            "integrity": "sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+            "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
             "dev": true,
             "peer": true,
             "engines": {
@@ -408,16 +438,16 @@
             }
         },
         "node_modules/@ethereumjs/util/node_modules/ethereum-cryptography": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-2.1.3.tgz",
-            "integrity": "sha512-BlwbIL7/P45W8FGW2r7LGuvoEZ+7PWsniMvQ4p5s2xCyw9tmaDlpfsN9HjAucbF+t/qpVHwZUisgfK24TCW8aA==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-2.2.0.tgz",
+            "integrity": "sha512-hsm9JhfytIf8QME/3B7j4bc8V+VdTU+Vas1aJlvIS96ffoNAosudXvGoEvWmc7QZYdkC8mrMJz9r0fcbw7GyCA==",
             "dev": true,
             "peer": true,
             "dependencies": {
-                "@noble/curves": "1.3.0",
-                "@noble/hashes": "1.3.3",
-                "@scure/bip32": "1.3.3",
-                "@scure/bip39": "1.2.2"
+                "@noble/curves": "1.4.0",
+                "@noble/hashes": "1.4.0",
+                "@scure/bip32": "1.4.0",
+                "@scure/bip39": "1.3.0"
             }
         },
         "node_modules/@ethersproject/abi": {
@@ -435,6 +465,7 @@
                     "url": "https://www.buymeacoffee.com/ricmoo"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "@ethersproject/address": "^5.7.0",
                 "@ethersproject/bignumber": "^5.7.0",
@@ -462,6 +493,7 @@
                     "url": "https://www.buymeacoffee.com/ricmoo"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "@ethersproject/bignumber": "^5.7.0",
                 "@ethersproject/bytes": "^5.7.0",
@@ -487,6 +519,7 @@
                     "url": "https://www.buymeacoffee.com/ricmoo"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "@ethersproject/abstract-provider": "^5.7.0",
                 "@ethersproject/bignumber": "^5.7.0",
@@ -510,6 +543,7 @@
                     "url": "https://www.buymeacoffee.com/ricmoo"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "@ethersproject/bignumber": "^5.7.0",
                 "@ethersproject/bytes": "^5.7.0",
@@ -533,6 +567,7 @@
                     "url": "https://www.buymeacoffee.com/ricmoo"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "@ethersproject/bytes": "^5.7.0"
             }
@@ -552,6 +587,7 @@
                     "url": "https://www.buymeacoffee.com/ricmoo"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "@ethersproject/bytes": "^5.7.0",
                 "@ethersproject/properties": "^5.7.0"
@@ -572,6 +608,7 @@
                     "url": "https://www.buymeacoffee.com/ricmoo"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "@ethersproject/bytes": "^5.7.0",
                 "@ethersproject/logger": "^5.7.0",
@@ -593,6 +630,7 @@
                     "url": "https://www.buymeacoffee.com/ricmoo"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "@ethersproject/logger": "^5.7.0"
             }
@@ -612,6 +650,7 @@
                     "url": "https://www.buymeacoffee.com/ricmoo"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "@ethersproject/bignumber": "^5.7.0"
             }
@@ -631,6 +670,7 @@
                     "url": "https://www.buymeacoffee.com/ricmoo"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "@ethersproject/abi": "^5.7.0",
                 "@ethersproject/abstract-provider": "^5.7.0",
@@ -659,6 +699,7 @@
                     "url": "https://www.buymeacoffee.com/ricmoo"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "@ethersproject/abstract-signer": "^5.7.0",
                 "@ethersproject/address": "^5.7.0",
@@ -686,6 +727,7 @@
                     "url": "https://www.buymeacoffee.com/ricmoo"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "@ethersproject/abstract-signer": "^5.7.0",
                 "@ethersproject/basex": "^5.7.0",
@@ -716,6 +758,7 @@
                     "url": "https://www.buymeacoffee.com/ricmoo"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "@ethersproject/abstract-signer": "^5.7.0",
                 "@ethersproject/address": "^5.7.0",
@@ -736,7 +779,8 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
             "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/@ethersproject/keccak256": {
             "version": "5.7.0",
@@ -753,6 +797,7 @@
                     "url": "https://www.buymeacoffee.com/ricmoo"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "@ethersproject/bytes": "^5.7.0",
                 "js-sha3": "0.8.0"
@@ -772,7 +817,8 @@
                     "type": "individual",
                     "url": "https://www.buymeacoffee.com/ricmoo"
                 }
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@ethersproject/networks": {
             "version": "5.7.1",
@@ -789,6 +835,7 @@
                     "url": "https://www.buymeacoffee.com/ricmoo"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "@ethersproject/logger": "^5.7.0"
             }
@@ -808,6 +855,7 @@
                     "url": "https://www.buymeacoffee.com/ricmoo"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "@ethersproject/bytes": "^5.7.0",
                 "@ethersproject/sha2": "^5.7.0"
@@ -828,6 +876,7 @@
                     "url": "https://www.buymeacoffee.com/ricmoo"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "@ethersproject/logger": "^5.7.0"
             }
@@ -847,6 +896,7 @@
                     "url": "https://www.buymeacoffee.com/ricmoo"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "@ethersproject/abstract-provider": "^5.7.0",
                 "@ethersproject/abstract-signer": "^5.7.0",
@@ -875,6 +925,7 @@
             "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
             "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=8.3.0"
             },
@@ -906,6 +957,7 @@
                     "url": "https://www.buymeacoffee.com/ricmoo"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "@ethersproject/bytes": "^5.7.0",
                 "@ethersproject/logger": "^5.7.0"
@@ -926,6 +978,7 @@
                     "url": "https://www.buymeacoffee.com/ricmoo"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "@ethersproject/bytes": "^5.7.0",
                 "@ethersproject/logger": "^5.7.0"
@@ -946,6 +999,7 @@
                     "url": "https://www.buymeacoffee.com/ricmoo"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "@ethersproject/bytes": "^5.7.0",
                 "@ethersproject/logger": "^5.7.0",
@@ -967,6 +1021,7 @@
                     "url": "https://www.buymeacoffee.com/ricmoo"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "@ethersproject/bytes": "^5.7.0",
                 "@ethersproject/logger": "^5.7.0",
@@ -991,6 +1046,7 @@
                     "url": "https://www.buymeacoffee.com/ricmoo"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "@ethersproject/bignumber": "^5.7.0",
                 "@ethersproject/bytes": "^5.7.0",
@@ -1015,6 +1071,7 @@
                     "url": "https://www.buymeacoffee.com/ricmoo"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "@ethersproject/bytes": "^5.7.0",
                 "@ethersproject/constants": "^5.7.0",
@@ -1036,6 +1093,7 @@
                     "url": "https://www.buymeacoffee.com/ricmoo"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "@ethersproject/address": "^5.7.0",
                 "@ethersproject/bignumber": "^5.7.0",
@@ -1063,6 +1121,7 @@
                     "url": "https://www.buymeacoffee.com/ricmoo"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "@ethersproject/bignumber": "^5.7.0",
                 "@ethersproject/constants": "^5.7.0",
@@ -1084,6 +1143,7 @@
                     "url": "https://www.buymeacoffee.com/ricmoo"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "@ethersproject/abstract-provider": "^5.7.0",
                 "@ethersproject/abstract-signer": "^5.7.0",
@@ -1117,6 +1177,7 @@
                     "url": "https://www.buymeacoffee.com/ricmoo"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "@ethersproject/base64": "^5.7.0",
                 "@ethersproject/bytes": "^5.7.0",
@@ -1140,6 +1201,7 @@
                     "url": "https://www.buymeacoffee.com/ricmoo"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "@ethersproject/bytes": "^5.7.0",
                 "@ethersproject/hash": "^5.7.0",
@@ -1153,6 +1215,7 @@
             "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
             "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=14"
             }
@@ -1221,6 +1284,7 @@
             "resolved": "https://registry.npmjs.org/@metamask/eth-sig-util/-/eth-sig-util-4.0.1.tgz",
             "integrity": "sha512-tghyZKLHZjcdlDqCA3gNZmLeR0XvOE9U1qoQO9ohyAZT6Pya+H9vkBPcsyXytmYLNgVoin7CKCmweo/R43V+tQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "ethereumjs-abi": "^0.6.8",
                 "ethereumjs-util": "^6.2.1",
@@ -1237,6 +1301,7 @@
             "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
             "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/node": "*"
             }
@@ -1245,13 +1310,15 @@
             "version": "4.12.0",
             "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
             "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/@metamask/eth-sig-util/node_modules/ethereumjs-util": {
             "version": "6.2.1",
             "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
             "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/bn.js": "^4.11.3",
                 "bn.js": "^4.11.0",
@@ -1267,6 +1334,7 @@
             "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
             "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@noble/hashes": "1.3.2"
             },
@@ -1279,6 +1347,7 @@
             "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
             "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">= 16"
             },
@@ -1296,7 +1365,8 @@
                     "type": "individual",
                     "url": "https://paulmillr.com/funding/"
                 }
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
@@ -1337,82 +1407,90 @@
             }
         },
         "node_modules/@nomicfoundation/edr": {
-            "version": "0.3.8",
-            "resolved": "https://registry.npmjs.org/@nomicfoundation/edr/-/edr-0.3.8.tgz",
-            "integrity": "sha512-u2UJ5QpznSHVkZRh6ePWoeVb6kmPrrqh08gCnZ9FHlJV9CITqlrTQHJkacd+INH31jx88pTAJnxePE4XAiH5qg==",
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@nomicfoundation/edr/-/edr-0.4.0.tgz",
+            "integrity": "sha512-T96DMSogO8TCdbKKctvxfsDljbhFOUKWc9fHJhSeUh71EEho2qR4951LKQF7t7UWEzguVYh/idQr5L/E3QeaMw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
-                "@nomicfoundation/edr-darwin-arm64": "0.3.8",
-                "@nomicfoundation/edr-darwin-x64": "0.3.8",
-                "@nomicfoundation/edr-linux-arm64-gnu": "0.3.8",
-                "@nomicfoundation/edr-linux-arm64-musl": "0.3.8",
-                "@nomicfoundation/edr-linux-x64-gnu": "0.3.8",
-                "@nomicfoundation/edr-linux-x64-musl": "0.3.8",
-                "@nomicfoundation/edr-win32-x64-msvc": "0.3.8"
+                "@nomicfoundation/edr-darwin-arm64": "0.4.0",
+                "@nomicfoundation/edr-darwin-x64": "0.4.0",
+                "@nomicfoundation/edr-linux-arm64-gnu": "0.4.0",
+                "@nomicfoundation/edr-linux-arm64-musl": "0.4.0",
+                "@nomicfoundation/edr-linux-x64-gnu": "0.4.0",
+                "@nomicfoundation/edr-linux-x64-musl": "0.4.0",
+                "@nomicfoundation/edr-win32-x64-msvc": "0.4.0"
             },
             "engines": {
                 "node": ">= 18"
             }
         },
         "node_modules/@nomicfoundation/edr-darwin-arm64": {
-            "version": "0.3.8",
-            "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-arm64/-/edr-darwin-arm64-0.3.8.tgz",
-            "integrity": "sha512-eB0leCexS8sQEmfyD72cdvLj9djkBzQGP4wSQw6SNf2I4Sw4Cnzb3d45caG2FqFFjbvfqL0t+badUUIceqQuMw==",
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-arm64/-/edr-darwin-arm64-0.4.0.tgz",
+            "integrity": "sha512-7+rraFk9tCqvfemv9Ita5vTlSBAeO/S5aDKOgGRgYt0JEKZlrX161nDW6UfzMPxWl9GOLEDUzCEaYuNmXseUlg==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">= 18"
             }
         },
         "node_modules/@nomicfoundation/edr-darwin-x64": {
-            "version": "0.3.8",
-            "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-x64/-/edr-darwin-x64-0.3.8.tgz",
-            "integrity": "sha512-JksVCS1N5ClwVF14EvO25HCQ+Laljh/KRfHERMVAC9ZwPbTuAd/9BtKvToCBi29uCHWqsXMI4lxCApYQv2nznw==",
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-x64/-/edr-darwin-x64-0.4.0.tgz",
+            "integrity": "sha512-+Hrc0mP9L6vhICJSfyGo/2taOToy1AIzVZawO3lU8Lf7oDQXfhQ4UkZnkWAs9SVu1eUwHUGGGE0qB8644piYgg==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">= 18"
             }
         },
         "node_modules/@nomicfoundation/edr-linux-arm64-gnu": {
-            "version": "0.3.8",
-            "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-gnu/-/edr-linux-arm64-gnu-0.3.8.tgz",
-            "integrity": "sha512-raCE+fOeNXhVBLUo87cgsHSGvYYRB6arih4eG6B9KGACWK5Veebtm9xtKeiD8YCsdUlUfat6F7ibpeNm91fpsA==",
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-gnu/-/edr-linux-arm64-gnu-0.4.0.tgz",
+            "integrity": "sha512-4HUDMchNClQrVRfVTqBeSX92hM/3khCgpZkXP52qrnJPqgbdCxosOehlQYZ65wu0b/kaaZSyvACgvCLSQ5oSzQ==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">= 18"
             }
         },
         "node_modules/@nomicfoundation/edr-linux-arm64-musl": {
-            "version": "0.3.8",
-            "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-musl/-/edr-linux-arm64-musl-0.3.8.tgz",
-            "integrity": "sha512-PwiDp4wBZWMCIy29eKkv8moTKRrpiSDlrc+GQMSZLhOAm8T33JKKXPwD/2EbplbhCygJDGXZdtEKl9x9PaH66A==",
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-musl/-/edr-linux-arm64-musl-0.4.0.tgz",
+            "integrity": "sha512-D4J935ZRL8xfnP3zIFlCI9jXInJ0loDUkCTLeCEbOf2uuDumWDghKNQlF1itUS+EHaR1pFVBbuwqq8hVK0dASg==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">= 18"
             }
         },
         "node_modules/@nomicfoundation/edr-linux-x64-gnu": {
-            "version": "0.3.8",
-            "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-gnu/-/edr-linux-x64-gnu-0.3.8.tgz",
-            "integrity": "sha512-6AcvA/XKoipGap5jJmQ9Y6yT7Uf39D9lu2hBcDCXnXbMcXaDGw4mn1/L4R63D+9VGZyu1PqlcJixCUZlGGIWlg==",
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-gnu/-/edr-linux-x64-gnu-0.4.0.tgz",
+            "integrity": "sha512-6x7HPy+uN5Cb9N77e2XMmT6+QSJ+7mRbHnhkGJ8jm4cZvWuj2Io7npOaeHQ3YHK+TiQpTnlbkjoOIpEwpY3XZA==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">= 18"
             }
         },
         "node_modules/@nomicfoundation/edr-linux-x64-musl": {
-            "version": "0.3.8",
-            "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-musl/-/edr-linux-x64-musl-0.3.8.tgz",
-            "integrity": "sha512-cxb0sEmZjlwhYWO28sPsV64VDx31ekskhC1IsDXU1p9ntjHSJRmW4KEIqJ2O3QwJap/kLKfMS6TckvY10gjc6w==",
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-musl/-/edr-linux-x64-musl-0.4.0.tgz",
+            "integrity": "sha512-3HFIJSXgyubOiaN4MWGXx2xhTnhwlJk0PiSYNf9+L/fjBtcRkb2nM910ZJHTvqCb6OT98cUnaKuAYdXIW2amgw==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">= 18"
             }
         },
         "node_modules/@nomicfoundation/edr-win32-x64-msvc": {
-            "version": "0.3.8",
-            "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-win32-x64-msvc/-/edr-win32-x64-msvc-0.3.8.tgz",
-            "integrity": "sha512-yVuVPqRRNLZk7TbBMkKw7lzCvI8XO8fNTPTYxymGadjr9rEGRuNTU1yBXjfJ59I1jJU/X2TSkRk1OFX0P5tpZQ==",
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-win32-x64-msvc/-/edr-win32-x64-msvc-0.4.0.tgz",
+            "integrity": "sha512-CP4GsllEfXEz+lidcGYxKe5rDJ60TM5/blB5z/04ELVvw6/CK9eLcYeku7HV0jvV7VE6dADYKSdQyUkvd0El+A==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">= 18"
             }
@@ -1422,6 +1500,7 @@
             "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-common/-/ethereumjs-common-4.0.4.tgz",
             "integrity": "sha512-9Rgb658lcWsjiicr5GzNCjI1llow/7r0k50dLL95OJ+6iZJcVbi15r3Y0xh2cIO+zgX0WIHcbzIu6FeQf9KPrg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@nomicfoundation/ethereumjs-util": "9.0.4"
             }
@@ -1431,6 +1510,7 @@
             "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-rlp/-/ethereumjs-rlp-5.0.4.tgz",
             "integrity": "sha512-8H1S3s8F6QueOc/X92SdrA4RDenpiAEqMg5vJH99kcQaCy/a3Q6fgseo75mgWlbanGJXSlAPtnCeG9jvfTYXlw==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "rlp": "bin/rlp.cjs"
             },
@@ -1443,6 +1523,7 @@
             "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-tx/-/ethereumjs-tx-5.0.4.tgz",
             "integrity": "sha512-Xjv8wAKJGMrP1f0n2PeyfFCCojHd7iS3s/Ab7qzF1S64kxZ8Z22LCMynArYsVqiFx6rzYy548HNVEyI+AYN/kw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@nomicfoundation/ethereumjs-common": "4.0.4",
                 "@nomicfoundation/ethereumjs-rlp": "5.0.4",
@@ -1466,6 +1547,7 @@
             "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-util/-/ethereumjs-util-9.0.4.tgz",
             "integrity": "sha512-sLOzjnSrlx9Bb9EFNtHzK/FJFsfg2re6bsGqinFinH1gCqVfz9YYlXiMWwDM4C/L4ywuHFCYwfKTVr/QHQcU0Q==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@nomicfoundation/ethereumjs-rlp": "5.0.4",
                 "ethereum-cryptography": "0.1.3"
@@ -1483,9 +1565,9 @@
             }
         },
         "node_modules/@nomicfoundation/hardhat-chai-matchers": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-chai-matchers/-/hardhat-chai-matchers-2.0.6.tgz",
-            "integrity": "sha512-Te1Uyo9oJcTCF0Jy9dztaLpshmlpjLf2yPtWXlXuLjMt3RRSmJLm/+rKVTW6gfadAEs12U/it6D0ZRnnRGiICQ==",
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-chai-matchers/-/hardhat-chai-matchers-2.0.7.tgz",
+            "integrity": "sha512-RQfsiTwdf0SP+DtuNYvm4921X6VirCQq0Xyh+mnuGlTwEFSPZ/o27oQC+l+3Y/l48DDU7+ZcYBR+Fp+Rp94LfQ==",
             "dev": true,
             "peer": true,
             "dependencies": {
@@ -1516,10 +1598,43 @@
                 "hardhat": "^2.0.0"
             }
         },
+        "node_modules/@nomicfoundation/hardhat-ignition": {
+            "version": "0.15.4",
+            "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-ignition/-/hardhat-ignition-0.15.4.tgz",
+            "integrity": "sha512-x1lhLN9ZRSJ9eiNY9AoinMdeQeU4LDQSQOIw90W9DiZIG/g9YUzcTEIY58QTi2TZOF8YFiF6vJqLSePCpi8R1Q==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "@nomicfoundation/ignition-core": "^0.15.4",
+                "@nomicfoundation/ignition-ui": "^0.15.4",
+                "chalk": "^4.0.0",
+                "debug": "^4.3.2",
+                "fs-extra": "^10.0.0",
+                "prompts": "^2.4.2"
+            },
+            "peerDependencies": {
+                "@nomicfoundation/hardhat-verify": "^2.0.1",
+                "hardhat": "^2.18.0"
+            }
+        },
+        "node_modules/@nomicfoundation/hardhat-ignition-ethers": {
+            "version": "0.15.4",
+            "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-ignition-ethers/-/hardhat-ignition-ethers-0.15.4.tgz",
+            "integrity": "sha512-vY30V4b788GSziW/nOd0L/4IPw6mwpluahLs4+gPUUKWaHHGMA8OIeHaYpRRljM1i0M/Kg1yIozrDM/aeRebkg==",
+            "dev": true,
+            "peer": true,
+            "peerDependencies": {
+                "@nomicfoundation/hardhat-ethers": "^3.0.4",
+                "@nomicfoundation/hardhat-ignition": "^0.15.4",
+                "@nomicfoundation/ignition-core": "^0.15.4",
+                "ethers": "^6.7.0",
+                "hardhat": "^2.18.0"
+            }
+        },
         "node_modules/@nomicfoundation/hardhat-network-helpers": {
-            "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-network-helpers/-/hardhat-network-helpers-1.0.10.tgz",
-            "integrity": "sha512-R35/BMBlx7tWN5V6d/8/19QCwEmIdbnA4ZrsuXgvs8i2qFx5i7h6mH5pBS4Pwi4WigLH+upl6faYusrNPuzMrQ==",
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-network-helpers/-/hardhat-network-helpers-1.0.11.tgz",
+            "integrity": "sha512-uGPL7QSKvxrHRU69dx8jzoBvuztlLCtyFsbgfXIwIjnO3dqZRz2GNMHJoO3C3dIiUNM6jdNF4AUnoQKDscdYrA==",
             "dev": true,
             "peer": true,
             "dependencies": {
@@ -1530,20 +1645,21 @@
             }
         },
         "node_modules/@nomicfoundation/hardhat-toolbox": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-toolbox/-/hardhat-toolbox-4.0.0.tgz",
-            "integrity": "sha512-jhcWHp0aHaL0aDYj8IJl80v4SZXWMS1A2XxXa1CA6pBiFfJKuZinCkO6wb+POAt0LIfXB3gA3AgdcOccrcwBwA==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-toolbox/-/hardhat-toolbox-5.0.0.tgz",
+            "integrity": "sha512-FnUtUC5PsakCbwiVNsqlXVIWG5JIb5CEZoSXbJUsEBun22Bivx2jhF1/q9iQbzuaGpJKFQyOhemPB2+XlEE6pQ==",
             "dev": true,
             "peerDependencies": {
                 "@nomicfoundation/hardhat-chai-matchers": "^2.0.0",
                 "@nomicfoundation/hardhat-ethers": "^3.0.0",
+                "@nomicfoundation/hardhat-ignition-ethers": "^0.15.0",
                 "@nomicfoundation/hardhat-network-helpers": "^1.0.0",
                 "@nomicfoundation/hardhat-verify": "^2.0.0",
                 "@typechain/ethers-v6": "^0.5.0",
                 "@typechain/hardhat": "^9.0.0",
                 "@types/chai": "^4.2.0",
                 "@types/mocha": ">=9.1.0",
-                "@types/node": ">=16.0.0",
+                "@types/node": ">=18.0.0",
                 "chai": "^4.2.0",
                 "ethers": "^6.4.0",
                 "hardhat": "^2.11.0",
@@ -1555,9 +1671,9 @@
             }
         },
         "node_modules/@nomicfoundation/hardhat-verify": {
-            "version": "2.0.7",
-            "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-verify/-/hardhat-verify-2.0.7.tgz",
-            "integrity": "sha512-jiYHBX+K6bBN0YhwFHQ5SWWc3dQZliM3pdgpH33C7tnsVACsX1ubZn6gZ9hfwlzG0tyjFM72XQhpaXQ56cE6Ew==",
+            "version": "2.0.8",
+            "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-verify/-/hardhat-verify-2.0.8.tgz",
+            "integrity": "sha512-x/OYya7A2Kcz+3W/J78dyDHxr0ezU23DKTrRKfy5wDPCnePqnr79vm8EXqX3gYps6IjPBYyGPZ9K6E5BnrWx5Q==",
             "dev": true,
             "peer": true,
             "dependencies": {
@@ -1575,11 +1691,152 @@
                 "hardhat": "^2.0.4"
             }
         },
+        "node_modules/@nomicfoundation/hardhat-verify/node_modules/ansi-styles": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "color-convert": "^1.9.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/@nomicfoundation/hardhat-verify/node_modules/chalk": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/@nomicfoundation/hardhat-verify/node_modules/color-convert": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "color-name": "1.1.3"
+            }
+        },
+        "node_modules/@nomicfoundation/hardhat-verify/node_modules/color-name": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+            "dev": true,
+            "peer": true
+        },
+        "node_modules/@nomicfoundation/hardhat-verify/node_modules/escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+            "dev": true,
+            "peer": true,
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/@nomicfoundation/hardhat-verify/node_modules/has-flag": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+            "dev": true,
+            "peer": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/@nomicfoundation/hardhat-verify/node_modules/supports-color": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "has-flag": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/@nomicfoundation/ignition-core": {
+            "version": "0.15.4",
+            "resolved": "https://registry.npmjs.org/@nomicfoundation/ignition-core/-/ignition-core-0.15.4.tgz",
+            "integrity": "sha512-i379lH+xOLFdaDv0KiNma550ZXCHc5ZkmKYhM44xyLMKBlvX6skUVFkgUjjN1gvprgOIxc17GVQXlR1R5FhGZA==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "@ethersproject/address": "5.6.1",
+                "@nomicfoundation/solidity-analyzer": "^0.1.1",
+                "cbor": "^9.0.0",
+                "debug": "^4.3.2",
+                "ethers": "^6.7.0",
+                "fs-extra": "^10.0.0",
+                "immer": "10.0.2",
+                "lodash": "4.17.21",
+                "ndjson": "2.0.0"
+            }
+        },
+        "node_modules/@nomicfoundation/ignition-core/node_modules/@ethersproject/address": {
+            "version": "5.6.1",
+            "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.6.1.tgz",
+            "integrity": "sha512-uOgF0kS5MJv9ZvCz7x6T2EXJSzotiybApn4XlOgoTX0xdtyVIJ7pF+6cGPxiEq/dpBiTfMiw7Yc81JcwhSYA0Q==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "peer": true,
+            "dependencies": {
+                "@ethersproject/bignumber": "^5.6.2",
+                "@ethersproject/bytes": "^5.6.1",
+                "@ethersproject/keccak256": "^5.6.1",
+                "@ethersproject/logger": "^5.6.0",
+                "@ethersproject/rlp": "^5.6.1"
+            }
+        },
+        "node_modules/@nomicfoundation/ignition-core/node_modules/cbor": {
+            "version": "9.0.2",
+            "resolved": "https://registry.npmjs.org/cbor/-/cbor-9.0.2.tgz",
+            "integrity": "sha512-JPypkxsB10s9QOWwa6zwPzqE1Md3vqpPc+cai4sAecuCsRyAtAl/pMyhPlMbT/xtPnm2dznJZYRLui57qiRhaQ==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "nofilter": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "node_modules/@nomicfoundation/ignition-ui": {
+            "version": "0.15.4",
+            "resolved": "https://registry.npmjs.org/@nomicfoundation/ignition-ui/-/ignition-ui-0.15.4.tgz",
+            "integrity": "sha512-cHbmuxmhso5n2zdIaaIW4p8NNzrFj0mrnv8ufhAZfM3s3IFrRoGc1zo8hI/n1CiOTPuqUbdZcB79d+2tCKtCNw==",
+            "dev": true,
+            "peer": true
+        },
         "node_modules/@nomicfoundation/solidity-analyzer": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer/-/solidity-analyzer-0.1.1.tgz",
             "integrity": "sha512-1LMtXj1puAxyFusBgUIy5pZk3073cNXYnXUpuNKFghHbIit/xZgbk0AokpUADbNm3gyD6bFWl3LRFh3dhVdREg==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">= 12"
             },
@@ -1608,6 +1865,7 @@
             "os": [
                 "darwin"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 10"
             }
@@ -1624,6 +1882,7 @@
             "os": [
                 "darwin"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 10"
             }
@@ -1640,6 +1899,7 @@
             "os": [
                 "freebsd"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 10"
             }
@@ -1656,6 +1916,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 10"
             }
@@ -1672,6 +1933,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 10"
             }
@@ -1688,6 +1950,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 10"
             }
@@ -1704,6 +1967,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 10"
             }
@@ -1720,6 +1984,7 @@
             "os": [
                 "win32"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 10"
             }
@@ -1736,6 +2001,7 @@
             "os": [
                 "win32"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 10"
             }
@@ -1752,327 +2018,9 @@
             "os": [
                 "win32"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 10"
-            }
-        },
-        "node_modules/@openzeppelin/defender-admin-client": {
-            "version": "1.54.4",
-            "resolved": "https://registry.npmjs.org/@openzeppelin/defender-admin-client/-/defender-admin-client-1.54.4.tgz",
-            "integrity": "sha512-WbHevtyrTTYIoCNO0jjdIZdQ1lAXZBIXXM4dhk/vqn3B7PnY+dvwjaR9YYEpZ/kjEQCcDUSm++njBJ/h7tTnhw==",
-            "dev": true,
-            "dependencies": {
-                "@openzeppelin/defender-base-client": "1.54.4",
-                "axios": "^1.4.0",
-                "ethers": "^5.7.2",
-                "lodash": "^4.17.19",
-                "node-fetch": "^2.6.0"
-            }
-        },
-        "node_modules/@openzeppelin/defender-admin-client/node_modules/ethers": {
-            "version": "5.7.2",
-            "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
-            "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-                },
-                {
-                    "type": "individual",
-                    "url": "https://www.buymeacoffee.com/ricmoo"
-                }
-            ],
-            "dependencies": {
-                "@ethersproject/abi": "5.7.0",
-                "@ethersproject/abstract-provider": "5.7.0",
-                "@ethersproject/abstract-signer": "5.7.0",
-                "@ethersproject/address": "5.7.0",
-                "@ethersproject/base64": "5.7.0",
-                "@ethersproject/basex": "5.7.0",
-                "@ethersproject/bignumber": "5.7.0",
-                "@ethersproject/bytes": "5.7.0",
-                "@ethersproject/constants": "5.7.0",
-                "@ethersproject/contracts": "5.7.0",
-                "@ethersproject/hash": "5.7.0",
-                "@ethersproject/hdnode": "5.7.0",
-                "@ethersproject/json-wallets": "5.7.0",
-                "@ethersproject/keccak256": "5.7.0",
-                "@ethersproject/logger": "5.7.0",
-                "@ethersproject/networks": "5.7.1",
-                "@ethersproject/pbkdf2": "5.7.0",
-                "@ethersproject/properties": "5.7.0",
-                "@ethersproject/providers": "5.7.2",
-                "@ethersproject/random": "5.7.0",
-                "@ethersproject/rlp": "5.7.0",
-                "@ethersproject/sha2": "5.7.0",
-                "@ethersproject/signing-key": "5.7.0",
-                "@ethersproject/solidity": "5.7.0",
-                "@ethersproject/strings": "5.7.0",
-                "@ethersproject/transactions": "5.7.0",
-                "@ethersproject/units": "5.7.0",
-                "@ethersproject/wallet": "5.7.0",
-                "@ethersproject/web": "5.7.1",
-                "@ethersproject/wordlists": "5.7.0"
-            }
-        },
-        "node_modules/@openzeppelin/defender-base-client": {
-            "version": "1.54.4",
-            "resolved": "https://registry.npmjs.org/@openzeppelin/defender-base-client/-/defender-base-client-1.54.4.tgz",
-            "integrity": "sha512-LEDiHFI8BavbjVjR/H8IJSyw0Dlr2NTiutTwMIJk6QKtQ1ZlTuUktl+tBzl3Fe3SpLiaBZvqYx4/3tN0byeE4Q==",
-            "dev": true,
-            "dependencies": {
-                "amazon-cognito-identity-js": "^6.0.1",
-                "async-retry": "^1.3.3",
-                "axios": "^1.4.0",
-                "lodash": "^4.17.19",
-                "node-fetch": "^2.6.0"
-            }
-        },
-        "node_modules/@openzeppelin/defender-sdk-base-client": {
-            "version": "1.13.1",
-            "resolved": "https://registry.npmjs.org/@openzeppelin/defender-sdk-base-client/-/defender-sdk-base-client-1.13.1.tgz",
-            "integrity": "sha512-FI7YdfgDf0px+cXbXyDkS0mpqzyySHeLkKj90ymzAy1/sGYKHNC03vyzMnMfIRuxa4bF15wdL4MCpA60PSWGpQ==",
-            "dev": true,
-            "dependencies": {
-                "amazon-cognito-identity-js": "^6.3.6",
-                "async-retry": "^1.3.3"
-            }
-        },
-        "node_modules/@openzeppelin/defender-sdk-deploy-client": {
-            "version": "1.13.1",
-            "resolved": "https://registry.npmjs.org/@openzeppelin/defender-sdk-deploy-client/-/defender-sdk-deploy-client-1.13.1.tgz",
-            "integrity": "sha512-zQEoURBRMknrOXLDNzK3gXiHfQbDImLKtEVPBOybya/MYqququBdNkRmPpSkJ45LHVbuxWyqRkkGFQp8+l/UQg==",
-            "dev": true,
-            "dependencies": {
-                "@openzeppelin/defender-sdk-base-client": "^1.13.1",
-                "axios": "^1.6.7",
-                "lodash": "^4.17.21"
-            }
-        },
-        "node_modules/@openzeppelin/defender-sdk-network-client": {
-            "version": "1.13.1",
-            "resolved": "https://registry.npmjs.org/@openzeppelin/defender-sdk-network-client/-/defender-sdk-network-client-1.13.1.tgz",
-            "integrity": "sha512-QR9dTZ6MuJ5o+GwAKH4Hxy+xuElI0iCwpVqN/ntHG0Ar7neHoq/f7jPtk04/DgEmrwTUMLzTKpZWmUO1fxiEMA==",
-            "dev": true,
-            "dependencies": {
-                "@openzeppelin/defender-sdk-base-client": "^1.13.1",
-                "axios": "^1.6.7",
-                "lodash": "^4.17.21"
-            }
-        },
-        "node_modules/@openzeppelin/hardhat-upgrades": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@openzeppelin/hardhat-upgrades/-/hardhat-upgrades-3.1.0.tgz",
-            "integrity": "sha512-CQ5Cg2kE8WeW6qajUTacBsmkntiAwJd7f6p+BUtd1fEvEv7si4H2lmAqvjOjkFc9ihIEQxMBy50IsBXSZGktmg==",
-            "dev": true,
-            "dependencies": {
-                "@openzeppelin/defender-admin-client": "^1.52.0",
-                "@openzeppelin/defender-base-client": "^1.52.0",
-                "@openzeppelin/defender-sdk-base-client": "^1.10.0",
-                "@openzeppelin/defender-sdk-deploy-client": "^1.10.0",
-                "@openzeppelin/defender-sdk-network-client": "^1.10.0",
-                "@openzeppelin/upgrades-core": "^1.32.0",
-                "chalk": "^4.1.0",
-                "debug": "^4.1.1",
-                "ethereumjs-util": "^7.1.5",
-                "proper-lockfile": "^4.1.1",
-                "undici": "^6.11.1"
-            },
-            "bin": {
-                "migrate-oz-cli-project": "dist/scripts/migrate-oz-cli-project.js"
-            },
-            "peerDependencies": {
-                "@nomicfoundation/hardhat-ethers": "^3.0.0",
-                "@nomicfoundation/hardhat-verify": "^2.0.0",
-                "ethers": "^6.6.0",
-                "hardhat": "^2.0.2"
-            },
-            "peerDependenciesMeta": {
-                "@nomicfoundation/hardhat-verify": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@openzeppelin/hardhat-upgrades/node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dev": true,
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/@openzeppelin/hardhat-upgrades/node_modules/chalk": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-            "dev": true,
-            "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "node_modules/@openzeppelin/hardhat-upgrades/node_modules/color-convert": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dev": true,
-            "dependencies": {
-                "color-name": "~1.1.4"
-            },
-            "engines": {
-                "node": ">=7.0.0"
-            }
-        },
-        "node_modules/@openzeppelin/hardhat-upgrades/node_modules/color-name": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true
-        },
-        "node_modules/@openzeppelin/hardhat-upgrades/node_modules/has-flag": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@openzeppelin/hardhat-upgrades/node_modules/supports-color": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "dev": true,
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@openzeppelin/hardhat-upgrades/node_modules/undici": {
-            "version": "6.18.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-6.18.0.tgz",
-            "integrity": "sha512-nT8jjv/fE9Et1ilR6QoW8ingRTY2Pp4l2RUrdzV5Yz35RJDrtPc1DXvuNqcpsJSGIRHFdt3YKKktTzJA6r0fTA==",
-            "dev": true,
-            "engines": {
-                "node": ">=18.17"
-            }
-        },
-        "node_modules/@openzeppelin/upgrades-core": {
-            "version": "1.33.1",
-            "resolved": "https://registry.npmjs.org/@openzeppelin/upgrades-core/-/upgrades-core-1.33.1.tgz",
-            "integrity": "sha512-YRxIRhTY1b+j7+NUUu8Uuem5ugxKexEMVd8dBRWNgWeoN1gS1OCrhgUg0ytL+54vzQ+SGWZDfNnzjVuI1Cj1Zw==",
-            "dev": true,
-            "dependencies": {
-                "cbor": "^9.0.0",
-                "chalk": "^4.1.0",
-                "compare-versions": "^6.0.0",
-                "debug": "^4.1.1",
-                "ethereumjs-util": "^7.0.3",
-                "minimist": "^1.2.7",
-                "proper-lockfile": "^4.1.1",
-                "solidity-ast": "^0.4.51"
-            },
-            "bin": {
-                "openzeppelin-upgrades-core": "dist/cli/cli.js"
-            }
-        },
-        "node_modules/@openzeppelin/upgrades-core/node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dev": true,
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/@openzeppelin/upgrades-core/node_modules/cbor": {
-            "version": "9.0.2",
-            "resolved": "https://registry.npmjs.org/cbor/-/cbor-9.0.2.tgz",
-            "integrity": "sha512-JPypkxsB10s9QOWwa6zwPzqE1Md3vqpPc+cai4sAecuCsRyAtAl/pMyhPlMbT/xtPnm2dznJZYRLui57qiRhaQ==",
-            "dev": true,
-            "dependencies": {
-                "nofilter": "^3.1.0"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/@openzeppelin/upgrades-core/node_modules/chalk": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-            "dev": true,
-            "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "node_modules/@openzeppelin/upgrades-core/node_modules/color-convert": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dev": true,
-            "dependencies": {
-                "color-name": "~1.1.4"
-            },
-            "engines": {
-                "node": ">=7.0.0"
-            }
-        },
-        "node_modules/@openzeppelin/upgrades-core/node_modules/color-name": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true
-        },
-        "node_modules/@openzeppelin/upgrades-core/node_modules/has-flag": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@openzeppelin/upgrades-core/node_modules/supports-color": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "dev": true,
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/@scure/base": {
@@ -2080,42 +2028,43 @@
             "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.6.tgz",
             "integrity": "sha512-ok9AWwhcgYuGG3Zfhyqg+zwl+Wn5uE+dwC0NV/2qQkx4dABbb/bx96vWu8NSj+BNjjSjno+JRYRjle1jV08k3g==",
             "dev": true,
+            "peer": true,
             "funding": {
                 "url": "https://paulmillr.com/funding/"
             }
         },
         "node_modules/@scure/bip32": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.3.3.tgz",
-            "integrity": "sha512-LJaN3HwRbfQK0X1xFSi0Q9amqOgzQnnDngIt+ZlsBC3Bm7/nE7K0kwshZHyaru79yIVRv/e1mQAjZyuZG6jOFQ==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.4.0.tgz",
+            "integrity": "sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==",
             "dev": true,
             "peer": true,
             "dependencies": {
-                "@noble/curves": "~1.3.0",
-                "@noble/hashes": "~1.3.2",
-                "@scure/base": "~1.1.4"
+                "@noble/curves": "~1.4.0",
+                "@noble/hashes": "~1.4.0",
+                "@scure/base": "~1.1.6"
             },
             "funding": {
                 "url": "https://paulmillr.com/funding/"
             }
         },
         "node_modules/@scure/bip32/node_modules/@noble/curves": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.3.0.tgz",
-            "integrity": "sha512-t01iSXPuN+Eqzb4eBX0S5oubSqXbK/xXa1Ne18Hj8f9pStxztHCE2gfboSp/dZRLSqfuLpRK2nDXDK+W9puocA==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.0.tgz",
+            "integrity": "sha512-p+4cb332SFCrReJkCYe8Xzm0OWi4Jji5jVdIZRL/PmacmDkFNw6MrrV+gGpiPxLHbV+zKFRywUWbaseT+tZRXg==",
             "dev": true,
             "peer": true,
             "dependencies": {
-                "@noble/hashes": "1.3.3"
+                "@noble/hashes": "1.4.0"
             },
             "funding": {
                 "url": "https://paulmillr.com/funding/"
             }
         },
         "node_modules/@scure/bip32/node_modules/@noble/hashes": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.3.tgz",
-            "integrity": "sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+            "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
             "dev": true,
             "peer": true,
             "engines": {
@@ -2126,14 +2075,27 @@
             }
         },
         "node_modules/@scure/bip39": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.2.2.tgz",
-            "integrity": "sha512-HYf9TUXG80beW+hGAt3TRM8wU6pQoYur9iNypTROm42dorCGmLnFe3eWjz3gOq6G62H2WRh0FCzAR1PI+29zIA==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.3.0.tgz",
+            "integrity": "sha512-disdg7gHuTDZtY+ZdkmLpPCk7fxZSu3gBiEGuoC1XYxv9cGx3Z6cpTggCgW6odSOOIXCiDjuGejW+aJKCY/pIQ==",
             "dev": true,
             "peer": true,
             "dependencies": {
-                "@noble/hashes": "~1.3.2",
-                "@scure/base": "~1.1.4"
+                "@noble/hashes": "~1.4.0",
+                "@scure/base": "~1.1.6"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/@scure/bip39/node_modules/@noble/hashes": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+            "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+            "dev": true,
+            "peer": true,
+            "engines": {
+                "node": ">= 16"
             },
             "funding": {
                 "url": "https://paulmillr.com/funding/"
@@ -2144,6 +2106,7 @@
             "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.30.0.tgz",
             "integrity": "sha512-TmfrII8w1PQZSZgPpUESqjB+jC6MvZJZdLtE/0hZ+SrnKhW3x5WlYLvTXZpcWePYBku7rl2wn1RZu6uT0qCTeg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@sentry/hub": "5.30.0",
                 "@sentry/minimal": "5.30.0",
@@ -2155,11 +2118,19 @@
                 "node": ">=6"
             }
         },
+        "node_modules/@sentry/core/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "dev": true,
+            "peer": true
+        },
         "node_modules/@sentry/hub": {
             "version": "5.30.0",
             "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.30.0.tgz",
             "integrity": "sha512-2tYrGnzb1gKz2EkMDQcfLrDTvmGcQPuWxLnJKXJvYTQDGLlEvi2tWz1VIHjunmOvJrB5aIQLhm+dcMRwFZDCqQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@sentry/types": "5.30.0",
                 "@sentry/utils": "5.30.0",
@@ -2169,11 +2140,19 @@
                 "node": ">=6"
             }
         },
+        "node_modules/@sentry/hub/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "dev": true,
+            "peer": true
+        },
         "node_modules/@sentry/minimal": {
             "version": "5.30.0",
             "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.30.0.tgz",
             "integrity": "sha512-BwWb/owZKtkDX+Sc4zCSTNcvZUq7YcH3uAVlmh/gtR9rmUvbzAA3ewLuB3myi4wWRAMEtny6+J/FN/x+2wn9Xw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@sentry/hub": "5.30.0",
                 "@sentry/types": "5.30.0",
@@ -2183,11 +2162,19 @@
                 "node": ">=6"
             }
         },
+        "node_modules/@sentry/minimal/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "dev": true,
+            "peer": true
+        },
         "node_modules/@sentry/node": {
             "version": "5.30.0",
             "resolved": "https://registry.npmjs.org/@sentry/node/-/node-5.30.0.tgz",
             "integrity": "sha512-Br5oyVBF0fZo6ZS9bxbJZG4ApAjRqAnqFFurMVJJdunNb80brh7a5Qva2kjhm+U6r9NJAB5OmDyPkA1Qnt+QVg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@sentry/core": "5.30.0",
                 "@sentry/hub": "5.30.0",
@@ -2203,11 +2190,19 @@
                 "node": ">=6"
             }
         },
+        "node_modules/@sentry/node/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "dev": true,
+            "peer": true
+        },
         "node_modules/@sentry/tracing": {
             "version": "5.30.0",
             "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-5.30.0.tgz",
             "integrity": "sha512-dUFowCr0AIMwiLD7Fs314Mdzcug+gBVo/+NCMyDw8tFxJkwWAKl7Qa2OZxLQ0ZHjakcj1hNKfCQJ9rhyfOl4Aw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@sentry/hub": "5.30.0",
                 "@sentry/minimal": "5.30.0",
@@ -2219,11 +2214,19 @@
                 "node": ">=6"
             }
         },
+        "node_modules/@sentry/tracing/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "dev": true,
+            "peer": true
+        },
         "node_modules/@sentry/types": {
             "version": "5.30.0",
             "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.30.0.tgz",
             "integrity": "sha512-R8xOqlSTZ+htqrfteCWU5Nk0CDN5ApUTvrlvBuiH1DyP6czDZ4ktbZB0hAgBlVcK0U+qpD3ag3Tqqpa5Q67rPw==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -2233,6 +2236,7 @@
             "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.30.0.tgz",
             "integrity": "sha512-zaYmoH0NWWtvnJjC9/CBseXMtKHm/tm40sz3YfJRxeQjyzRqNQPgivpd9R/oDJCYj999mzdW382p/qi2ypjLww==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@sentry/types": "5.30.0",
                 "tslib": "^1.9.3"
@@ -2241,23 +2245,12 @@
                 "node": ">=6"
             }
         },
-        "node_modules/@smithy/types": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.0.0.tgz",
-            "integrity": "sha512-VvWuQk2RKFuOr98gFhjca7fkBS+xLLURT8bUjk5XQoV0ZLm7WPwWPPY3/AwzTLuUBDeoKDCthfe1AsTUWaSEhw==",
+        "node_modules/@sentry/utils/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
             "dev": true,
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@smithy/types/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-            "dev": true
+            "peer": true
         },
         "node_modules/@solidity-parser/parser": {
             "version": "0.14.5",
@@ -2352,11 +2345,28 @@
                 "typechain": "^8.3.2"
             }
         },
+        "node_modules/@typechain/hardhat/node_modules/fs-extra": {
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+            "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "at-least-node": "^1.0.0",
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/@types/bn.js": {
             "version": "5.1.5",
             "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.5.tgz",
             "integrity": "sha512-V46N0zwKRF5Q00AZ6hWtN0T8gGmDUaUzLWQvHFo5yThtVwK/VCenFY3wXVbOvNfajEpsTfQM4IN9k/d6gUVX3A==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/node": "*"
             }
@@ -2413,7 +2423,8 @@
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.1.tgz",
             "integrity": "sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/@types/minimatch": {
             "version": "5.1.2",
@@ -2430,10 +2441,11 @@
             "peer": true
         },
         "node_modules/@types/node": {
-            "version": "20.12.12",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.12.tgz",
-            "integrity": "sha512-eWLDGF/FOSPtAvEqeRAQ4C8LSA7M1I7i0ky1I8U7kD1J5ITyW3AsRhQrKVoWf5pFKZ2kILsEGJhsI9r93PYnOw==",
+            "version": "20.14.2",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.2.tgz",
+            "integrity": "sha512-xyu6WAMVwv6AKFLB+e/7ySZVr/0zLCzOa7rSpq6jNwpqOrUbcACDWC+53d4n2QHOnDou0fbIsg8wZu/sxrnI4Q==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "undici-types": "~5.26.4"
             }
@@ -2443,6 +2455,7 @@
             "resolved": "https://registry.npmjs.org/@types/pbkdf2/-/pbkdf2-3.1.2.tgz",
             "integrity": "sha512-uRwJqmiXmh9++aSu1VNEn3iIxWOhd8AHXNSdlaLfdAAdSTY9jYVeGWnzejM3dvrkbqE3/hyQkQQ29IFATEGlew==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/node": "*"
             }
@@ -2466,6 +2479,7 @@
             "resolved": "https://registry.npmjs.org/@types/secp256k1/-/secp256k1-4.0.6.tgz",
             "integrity": "sha512-hHxJU6PAEUn0TP4S/ZOzuTUvJWuZ6eIKeNKb5RBpODvSl6hp1Wrw4s7ATY50rklRCScUDpHzVA/DQdSjJ3UoYQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/node": "*"
             }
@@ -2505,6 +2519,7 @@
             "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.16.tgz",
             "integrity": "sha512-TFi4HBKSGfIKsK5YCkKaaFG2m4PEDyViZmEwof3MTIgzimHLto6muaHVpbrljdIvIrFZzEq/p4nafOeLcYegrg==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=0.3.0"
             }
@@ -2513,13 +2528,15 @@
             "version": "4.0.0-beta.5",
             "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
             "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/agent-base": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
             "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "debug": "4"
             },
@@ -2532,6 +2549,7 @@
             "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
             "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "clean-stack": "^2.0.0",
                 "indent-string": "^4.0.0"
@@ -2541,9 +2559,9 @@
             }
         },
         "node_modules/ajv": {
-            "version": "8.13.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.13.0.tgz",
-            "integrity": "sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==",
+            "version": "8.16.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.16.0.tgz",
+            "integrity": "sha512-F0twR8U1ZU67JIEtekUcLkXkoO5mMMmgGD8sK/xUFzJ805jxHQl92hImFAqqXMyMYjSPOyUPAwHYhB72g5sTXw==",
             "dev": true,
             "peer": true,
             "dependencies": {
@@ -2555,19 +2573,6 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
-        "node_modules/amazon-cognito-identity-js": {
-            "version": "6.3.12",
-            "resolved": "https://registry.npmjs.org/amazon-cognito-identity-js/-/amazon-cognito-identity-js-6.3.12.tgz",
-            "integrity": "sha512-s7NKDZgx336cp+oDeUtB2ZzT8jWJp/v2LWuYl+LQtMEODe22RF1IJ4nRiDATp+rp1pTffCZcm44Quw4jx2bqNg==",
-            "dev": true,
-            "dependencies": {
-                "@aws-crypto/sha256-js": "1.2.2",
-                "buffer": "4.9.2",
-                "fast-base64-decode": "^1.0.0",
-                "isomorphic-unfetch": "^3.0.0",
-                "js-cookie": "^2.2.1"
             }
         },
         "node_modules/amdefine": {
@@ -2586,6 +2591,7 @@
             "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
             "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "string-width": "^4.1.0"
             }
@@ -2595,6 +2601,7 @@
             "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
             "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -2604,6 +2611,7 @@
             "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
             "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "type-fest": "^0.21.3"
             },
@@ -2619,20 +2627,25 @@
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
             "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/ansi-styles": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
-                "color-convert": "^1.9.0"
+                "color-convert": "^2.0.1"
             },
             "engines": {
-                "node": ">=4"
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
         "node_modules/antlr4ts": {
@@ -2647,6 +2660,7 @@
             "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
             "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "normalize-path": "^3.0.0",
                 "picomatch": "^2.0.4"
@@ -2666,7 +2680,8 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/array-back": {
             "version": "3.1.0",
@@ -2676,22 +2691,6 @@
             "peer": true,
             "engines": {
                 "node": ">=6"
-            }
-        },
-        "node_modules/array-buffer-byte-length": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz",
-            "integrity": "sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==",
-            "dev": true,
-            "dependencies": {
-                "call-bind": "^1.0.5",
-                "is-array-buffer": "^3.0.4"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/array-union": {
@@ -2712,48 +2711,6 @@
             "peer": true,
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/array.prototype.findlast": {
-            "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
-            "integrity": "sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==",
-            "dev": true,
-            "dependencies": {
-                "call-bind": "^1.0.7",
-                "define-properties": "^1.2.1",
-                "es-abstract": "^1.23.2",
-                "es-errors": "^1.3.0",
-                "es-object-atoms": "^1.0.0",
-                "es-shim-unscopables": "^1.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/arraybuffer.prototype.slice": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.3.tgz",
-            "integrity": "sha512-bMxMKAjg13EBSVscxTaYA4mRc5t1UAXa2kXiGTNfZ079HIWXEkKmkgFrh/nJqamaLSrXO5H4WFFkPEaLJWbs3A==",
-            "dev": true,
-            "dependencies": {
-                "array-buffer-byte-length": "^1.0.1",
-                "call-bind": "^1.0.5",
-                "define-properties": "^1.2.1",
-                "es-abstract": "^1.22.3",
-                "es-errors": "^1.2.1",
-                "get-intrinsic": "^1.2.3",
-                "is-array-buffer": "^3.0.4",
-                "is-shared-array-buffer": "^1.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/asap": {
@@ -2790,15 +2747,6 @@
             "dev": true,
             "peer": true
         },
-        "node_modules/async-retry": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
-            "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
-            "dev": true,
-            "dependencies": {
-                "retry": "0.13.1"
-            }
-        },
         "node_modules/asynckit": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -2815,25 +2763,10 @@
                 "node": ">= 4.0.0"
             }
         },
-        "node_modules/available-typed-arrays": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
-            "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
-            "dev": true,
-            "dependencies": {
-                "possible-typed-array-names": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/axios": {
-            "version": "1.7.1",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.1.tgz",
-            "integrity": "sha512-+LV37nQcd1EpFalkXksWNBiA17NZ5m5/WspmHGmZmdx1qBOg/VNq/c4eRJiA9VQQHBOs+N0ZhhdU10h2TyNK7Q==",
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
+            "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
             "dev": true,
             "dependencies": {
                 "follow-redirects": "^1.15.6",
@@ -2845,48 +2778,32 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/base-x": {
             "version": "3.0.9",
             "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.9.tgz",
             "integrity": "sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "safe-buffer": "^5.0.1"
             }
-        },
-        "node_modules/base64-js": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ]
         },
         "node_modules/bech32": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
             "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/binary-extensions": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
             "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=8"
             },
@@ -2898,19 +2815,22 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
             "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/bn.js": {
             "version": "5.2.1",
             "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
             "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/boxen": {
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/boxen/-/boxen-5.1.2.tgz",
             "integrity": "sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "ansi-align": "^3.0.0",
                 "camelcase": "^6.2.0",
@@ -2928,81 +2848,12 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/boxen/node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dev": true,
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/boxen/node_modules/chalk": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-            "dev": true,
-            "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "node_modules/boxen/node_modules/color-convert": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dev": true,
-            "dependencies": {
-                "color-name": "~1.1.4"
-            },
-            "engines": {
-                "node": ">=7.0.0"
-            }
-        },
-        "node_modules/boxen/node_modules/color-name": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true
-        },
-        "node_modules/boxen/node_modules/has-flag": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/boxen/node_modules/supports-color": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "dev": true,
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/boxen/node_modules/type-fest": {
             "version": "0.20.2",
             "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
             "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -3015,18 +2866,20 @@
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
             }
         },
         "node_modules/braces": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-            "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+            "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
-                "fill-range": "^7.0.1"
+                "fill-range": "^7.1.1"
             },
             "engines": {
                 "node": ">=8"
@@ -3036,19 +2889,22 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
             "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/browser-stdout": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
             "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/browserify-aes": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
             "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "buffer-xor": "^1.0.3",
                 "cipher-base": "^1.0.0",
@@ -3063,6 +2919,7 @@
             "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
             "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "base-x": "^3.0.2"
             }
@@ -3072,40 +2929,33 @@
             "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
             "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "bs58": "^4.0.0",
                 "create-hash": "^1.1.0",
                 "safe-buffer": "^5.1.2"
             }
         },
-        "node_modules/buffer": {
-            "version": "4.9.2",
-            "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
-            "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
-            "dev": true,
-            "dependencies": {
-                "base64-js": "^1.0.2",
-                "ieee754": "^1.1.4",
-                "isarray": "^1.0.0"
-            }
-        },
         "node_modules/buffer-from": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
             "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/buffer-xor": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
             "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/bytes": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
             "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">= 0.8"
             }
@@ -3115,6 +2965,7 @@
             "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
             "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "es-define-property": "^1.0.0",
                 "es-errors": "^1.3.0",
@@ -3134,6 +2985,7 @@
             "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
             "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -3194,17 +3046,20 @@
             }
         },
         "node_modules/chalk": {
-            "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
             },
             "engines": {
-                "node": ">=4"
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
         "node_modules/charenc": {
@@ -3235,6 +3090,7 @@
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
             "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "anymatch": "~3.1.2",
                 "braces": "~3.0.2",
@@ -3258,13 +3114,15 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
             "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/cipher-base": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
             "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "inherits": "^2.0.1",
                 "safe-buffer": "^5.0.1"
@@ -3275,6 +3133,7 @@
             "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
             "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -3284,6 +3143,7 @@
             "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
             "integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=6"
             },
@@ -3360,6 +3220,7 @@
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
             "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "string-width": "^4.2.0",
                 "strip-ansi": "^6.0.0",
@@ -3367,19 +3228,24 @@
             }
         },
         "node_modules/color-convert": {
-            "version": "1.9.3",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
-                "color-name": "1.1.3"
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
             }
         },
         "node_modules/color-name": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-            "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-            "dev": true
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true,
+            "peer": true
         },
         "node_modules/colors": {
             "version": "1.4.0",
@@ -3407,7 +3273,8 @@
             "version": "1.2.9",
             "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
             "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/command-line-args": {
             "version": "5.2.1",
@@ -3441,6 +3308,19 @@
                 "node": ">=8.0.0"
             }
         },
+        "node_modules/command-line-usage/node_modules/ansi-styles": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "color-convert": "^1.9.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/command-line-usage/node_modules/array-back": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
@@ -3449,6 +3329,71 @@
             "peer": true,
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/command-line-usage/node_modules/chalk": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/command-line-usage/node_modules/color-convert": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "color-name": "1.1.3"
+            }
+        },
+        "node_modules/command-line-usage/node_modules/color-name": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+            "dev": true,
+            "peer": true
+        },
+        "node_modules/command-line-usage/node_modules/escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+            "dev": true,
+            "peer": true,
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/command-line-usage/node_modules/has-flag": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+            "dev": true,
+            "peer": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/command-line-usage/node_modules/supports-color": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "has-flag": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/command-line-usage/node_modules/typical": {
@@ -3465,19 +3410,15 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
             "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==",
-            "dev": true
-        },
-        "node_modules/compare-versions": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.0.tgz",
-            "integrity": "sha512-LNZQXhqUvqUTotpZ00qLSaify3b4VFD588aRr8MKFw4CMUr98ytzCW5wDH5qx/DEY5kCDXcbcRuCqL0szEf2tg==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/concat-stream": {
             "version": "1.6.2",
@@ -3533,6 +3474,7 @@
             "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
             "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">= 0.6"
             }
@@ -3549,6 +3491,7 @@
             "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
             "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "cipher-base": "^1.0.1",
                 "inherits": "^2.0.1",
@@ -3562,6 +3505,7 @@
             "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
             "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "cipher-base": "^1.0.3",
                 "create-hash": "^1.1.0",
@@ -3588,57 +3532,6 @@
                 "node": "*"
             }
         },
-        "node_modules/data-view-buffer": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.1.tgz",
-            "integrity": "sha512-0lht7OugA5x3iJLOWFhWK/5ehONdprk0ISXqVFn/NFrDu+cuc8iADFrGQz5BnRK7LLU3JmkbXSxaqX+/mXYtUA==",
-            "dev": true,
-            "dependencies": {
-                "call-bind": "^1.0.6",
-                "es-errors": "^1.3.0",
-                "is-data-view": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/data-view-byte-length": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.1.tgz",
-            "integrity": "sha512-4J7wRJD3ABAzr8wP+OcIcqq2dlUKp4DVflx++hs5h5ZKydWMI6/D/fAot+yh6g2tHh8fLFTvNOaVN357NvSrOQ==",
-            "dev": true,
-            "dependencies": {
-                "call-bind": "^1.0.7",
-                "es-errors": "^1.3.0",
-                "is-data-view": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/data-view-byte-offset": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.0.tgz",
-            "integrity": "sha512-t/Ygsytq+R995EJ5PZlD4Cu56sWa8InXySaViRzw9apusqsOO2bQP+SbYzAhR0pFKoB+43lYy8rWban9JSuXnA==",
-            "dev": true,
-            "dependencies": {
-                "call-bind": "^1.0.6",
-                "es-errors": "^1.3.0",
-                "is-data-view": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/death": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/death/-/death-1.1.0.tgz",
@@ -3647,9 +3540,9 @@
             "peer": true
         },
         "node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+            "version": "4.3.5",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
+            "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
             "dev": true,
             "dependencies": {
                 "ms": "2.1.2"
@@ -3668,6 +3561,7 @@
             "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
             "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -3676,9 +3570,9 @@
             }
         },
         "node_modules/deep-eql": {
-            "version": "4.1.3",
-            "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
-            "integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
+            "version": "4.1.4",
+            "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
+            "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
             "dev": true,
             "peer": true,
             "dependencies": {
@@ -3710,27 +3604,11 @@
             "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
             "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "es-define-property": "^1.0.0",
                 "es-errors": "^1.3.0",
                 "gopd": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/define-properties": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
-            "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-            "dev": true,
-            "dependencies": {
-                "define-data-property": "^1.0.1",
-                "has-property-descriptors": "^1.0.0",
-                "object-keys": "^1.1.1"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -3753,6 +3631,7 @@
             "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
             "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">= 0.8"
             }
@@ -3762,6 +3641,7 @@
             "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
             "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=0.3.1"
             }
@@ -3797,6 +3677,7 @@
             "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
             "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "bn.js": "^4.11.9",
                 "brorand": "^1.1.0",
@@ -3811,19 +3692,22 @@
             "version": "4.12.0",
             "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
             "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/emoji-regex": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/enquirer": {
             "version": "2.4.1",
             "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
             "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "ansi-colors": "^4.1.1",
                 "strip-ansi": "^6.0.1"
@@ -3837,68 +3721,9 @@
             "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
             "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=6"
-            }
-        },
-        "node_modules/es-abstract": {
-            "version": "1.23.3",
-            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.3.tgz",
-            "integrity": "sha512-e+HfNH61Bj1X9/jLc5v1owaLYuHdeHHSQlkhCBiTK8rBvKaULl/beGMxwrMXjpYrv4pz22BlY570vVePA2ho4A==",
-            "dev": true,
-            "dependencies": {
-                "array-buffer-byte-length": "^1.0.1",
-                "arraybuffer.prototype.slice": "^1.0.3",
-                "available-typed-arrays": "^1.0.7",
-                "call-bind": "^1.0.7",
-                "data-view-buffer": "^1.0.1",
-                "data-view-byte-length": "^1.0.1",
-                "data-view-byte-offset": "^1.0.0",
-                "es-define-property": "^1.0.0",
-                "es-errors": "^1.3.0",
-                "es-object-atoms": "^1.0.0",
-                "es-set-tostringtag": "^2.0.3",
-                "es-to-primitive": "^1.2.1",
-                "function.prototype.name": "^1.1.6",
-                "get-intrinsic": "^1.2.4",
-                "get-symbol-description": "^1.0.2",
-                "globalthis": "^1.0.3",
-                "gopd": "^1.0.1",
-                "has-property-descriptors": "^1.0.2",
-                "has-proto": "^1.0.3",
-                "has-symbols": "^1.0.3",
-                "hasown": "^2.0.2",
-                "internal-slot": "^1.0.7",
-                "is-array-buffer": "^3.0.4",
-                "is-callable": "^1.2.7",
-                "is-data-view": "^1.0.1",
-                "is-negative-zero": "^2.0.3",
-                "is-regex": "^1.1.4",
-                "is-shared-array-buffer": "^1.0.3",
-                "is-string": "^1.0.7",
-                "is-typed-array": "^1.1.13",
-                "is-weakref": "^1.0.2",
-                "object-inspect": "^1.13.1",
-                "object-keys": "^1.1.1",
-                "object.assign": "^4.1.5",
-                "regexp.prototype.flags": "^1.5.2",
-                "safe-array-concat": "^1.1.2",
-                "safe-regex-test": "^1.0.3",
-                "string.prototype.trim": "^1.2.9",
-                "string.prototype.trimend": "^1.0.8",
-                "string.prototype.trimstart": "^1.0.8",
-                "typed-array-buffer": "^1.0.2",
-                "typed-array-byte-length": "^1.0.1",
-                "typed-array-byte-offset": "^1.0.2",
-                "typed-array-length": "^1.0.6",
-                "unbox-primitive": "^1.0.2",
-                "which-typed-array": "^1.1.15"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/es-define-property": {
@@ -3906,6 +3731,7 @@
             "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
             "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "get-intrinsic": "^1.2.4"
             },
@@ -3918,60 +3744,9 @@
             "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
             "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">= 0.4"
-            }
-        },
-        "node_modules/es-object-atoms": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
-            "integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
-            "dev": true,
-            "dependencies": {
-                "es-errors": "^1.3.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/es-set-tostringtag": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.3.tgz",
-            "integrity": "sha512-3T8uNMC3OQTHkFUsFq8r/BwAXLHvU/9O9mE0fBc/MY5iq/8H7ncvO947LmYA6ldWw9Uh8Yhf25zu6n7nML5QWQ==",
-            "dev": true,
-            "dependencies": {
-                "get-intrinsic": "^1.2.4",
-                "has-tostringtag": "^1.0.2",
-                "hasown": "^2.0.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/es-shim-unscopables": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.2.tgz",
-            "integrity": "sha512-J3yBRXCzDu4ULnQwxyToo/OjdMx6akgVC7K6few0a7F/0wLtmKKN7I73AH5T2836UuXRqN7Qg+IIUw/+YJksRw==",
-            "dev": true,
-            "dependencies": {
-                "hasown": "^2.0.0"
-            }
-        },
-        "node_modules/es-to-primitive": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-            "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-            "dev": true,
-            "dependencies": {
-                "is-callable": "^1.1.4",
-                "is-date-object": "^1.0.1",
-                "is-symbol": "^1.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/escalade": {
@@ -3979,17 +3754,22 @@
             "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
             "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=6"
             }
         },
         "node_modules/escape-string-regexp": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
             "dev": true,
+            "peer": true,
             "engines": {
-                "node": ">=0.8.0"
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/escodegen": {
@@ -4231,6 +4011,7 @@
             "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
             "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/pbkdf2": "^3.0.0",
                 "@types/secp256k1": "^4.0.1",
@@ -4254,6 +4035,7 @@
             "resolved": "https://registry.npmjs.org/ethereumjs-abi/-/ethereumjs-abi-0.6.8.tgz",
             "integrity": "sha512-Tx0r/iXI6r+lRsdvkFDlut0N08jWMnKRZ6Gkq+Nmw75lZe4e6o3EkSnkaBP5NF6+m5PTGAr9JP43N3LyeoglsA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "bn.js": "^4.11.8",
                 "ethereumjs-util": "^6.0.0"
@@ -4264,6 +4046,7 @@
             "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
             "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/node": "*"
             }
@@ -4272,13 +4055,15 @@
             "version": "4.12.0",
             "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
             "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/ethereumjs-abi/node_modules/ethereumjs-util": {
             "version": "6.2.1",
             "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
             "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/bn.js": "^4.11.3",
                 "bn.js": "^4.11.0",
@@ -4294,6 +4079,7 @@
             "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.5.tgz",
             "integrity": "sha512-SDl5kKrQAudFBUe5OJM9Ac6WmMyYmXX/6sTmLZ3ffG2eY6ZIGBes3pEDxNN6V72WyOw4CPD5RomKdsa8DAAwLg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/bn.js": "^5.1.0",
                 "bn.js": "^5.1.2",
@@ -4306,9 +4092,9 @@
             }
         },
         "node_modules/ethers": {
-            "version": "6.12.1",
-            "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.12.1.tgz",
-            "integrity": "sha512-j6wcVoZf06nqEcBbDWkKg8Fp895SS96dSnTCjiXT+8vt2o02raTn4Lo9ERUuIVU5bAjoPYeA+7ytQFexFmLuVw==",
+            "version": "6.13.0",
+            "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.13.0.tgz",
+            "integrity": "sha512-+yyQQQWEntY5UVbCv++guA14RRVFm1rSnO1GoLFdrK7/XRWMoktNgyG9UjwxrQqGBfGyFKknNZ81YpUS2emCgg==",
             "dev": true,
             "funding": [
                 {
@@ -4320,6 +4106,7 @@
                     "url": "https://www.buymeacoffee.com/ricmoo"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "@adraffy/ens-normalize": "1.10.1",
                 "@noble/curves": "1.2.0",
@@ -4337,19 +4124,15 @@
             "version": "18.15.13",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.13.tgz",
             "integrity": "sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q==",
-            "dev": true
-        },
-        "node_modules/ethers/node_modules/tslib": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-            "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/ethers/node_modules/ws": {
             "version": "8.5.0",
             "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
             "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=10.0.0"
             },
@@ -4393,6 +4176,7 @@
             "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.6.tgz",
             "integrity": "sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "is-hex-prefixed": "1.0.0",
                 "strip-hex-prefix": "1.0.0"
@@ -4407,16 +4191,11 @@
             "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
             "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "md5.js": "^1.3.4",
                 "safe-buffer": "^5.1.1"
             }
-        },
-        "node_modules/fast-base64-decode": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fast-base64-decode/-/fast-base64-decode-1.0.0.tgz",
-            "integrity": "sha512-qwaScUgUGBYeDNRnbc/KyllVU88Jk1pRHPStuF/lO7B0/RTRLj7U0lkdTAutlBblY08rwZDff6tNU9cjv6j//Q==",
-            "dev": true
         },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
@@ -4460,10 +4239,11 @@
             }
         },
         "node_modules/fill-range": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-            "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+            "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "to-regex-range": "^5.0.1"
             },
@@ -4489,6 +4269,7 @@
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
             "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "locate-path": "^2.0.0"
             },
@@ -4501,6 +4282,7 @@
             "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
             "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "flat": "cli.js"
             }
@@ -4525,15 +4307,6 @@
                 }
             }
         },
-        "node_modules/for-each": {
-            "version": "0.3.3",
-            "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
-            "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
-            "dev": true,
-            "dependencies": {
-                "is-callable": "^1.1.3"
-            }
-        },
         "node_modules/form-data": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
@@ -4552,22 +4325,22 @@
             "version": "1.19.3",
             "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-1.19.3.tgz",
             "integrity": "sha512-H5KQDspykdHuztLTg+ajGN0Z2qUjcEf3Ybxc6hLt0k7/zPkn29XnKnxlBPyW2XIddWrGaJBzBl4VLYOtk39yZg==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/fs-extra": {
-            "version": "9.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-            "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+            "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
             "dev": true,
             "peer": true,
             "dependencies": {
-                "at-least-node": "^1.0.0",
                 "graceful-fs": "^4.2.0",
                 "jsonfile": "^6.0.1",
                 "universalify": "^2.0.0"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=12"
             }
         },
         "node_modules/fs-readdir-recursive": {
@@ -4581,7 +4354,8 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
             "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/fsevents": {
             "version": "2.3.3",
@@ -4593,6 +4367,7 @@
             "os": [
                 "darwin"
             ],
+            "peer": true,
             "engines": {
                 "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
             }
@@ -4602,33 +4377,7 @@
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
             "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
             "dev": true,
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/function.prototype.name": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.6.tgz",
-            "integrity": "sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==",
-            "dev": true,
-            "dependencies": {
-                "call-bind": "^1.0.2",
-                "define-properties": "^1.2.0",
-                "es-abstract": "^1.22.1",
-                "functions-have-names": "^1.2.3"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/functions-have-names": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
-            "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
-            "dev": true,
+            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -4638,6 +4387,7 @@
             "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
             "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": "6.* || 8.* || >= 10.*"
             }
@@ -4657,6 +4407,7 @@
             "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
             "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "es-errors": "^1.3.0",
                 "function-bind": "^1.1.2",
@@ -4681,23 +4432,6 @@
                 "node": ">=4"
             }
         },
-        "node_modules/get-symbol-description": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.2.tgz",
-            "integrity": "sha512-g0QYk1dZBxGwk+Ngc+ltRH2IBp2f7zBkBMBJZCDerh6EhlhSR6+9irMCuT/09zD6qkarHUSn529sK/yL4S27mg==",
-            "dev": true,
-            "dependencies": {
-                "call-bind": "^1.0.5",
-                "es-errors": "^1.3.0",
-                "get-intrinsic": "^1.2.4"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/ghost-testrpc": {
             "version": "0.0.2",
             "resolved": "https://registry.npmjs.org/ghost-testrpc/-/ghost-testrpc-0.0.2.tgz",
@@ -4712,11 +4446,90 @@
                 "testrpc-sc": "index.js"
             }
         },
+        "node_modules/ghost-testrpc/node_modules/ansi-styles": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "color-convert": "^1.9.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/ghost-testrpc/node_modules/chalk": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/ghost-testrpc/node_modules/color-convert": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "color-name": "1.1.3"
+            }
+        },
+        "node_modules/ghost-testrpc/node_modules/color-name": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+            "dev": true,
+            "peer": true
+        },
+        "node_modules/ghost-testrpc/node_modules/escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+            "dev": true,
+            "peer": true,
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/ghost-testrpc/node_modules/has-flag": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+            "dev": true,
+            "peer": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/ghost-testrpc/node_modules/supports-color": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "has-flag": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/glob": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
             "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -4737,6 +4550,7 @@
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
             "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "is-glob": "^4.0.1"
             },
@@ -4781,22 +4595,6 @@
                 "node": ">=4"
             }
         },
-        "node_modules/globalthis": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
-            "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
-            "dev": true,
-            "dependencies": {
-                "define-properties": "^1.2.1",
-                "gopd": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/globby": {
             "version": "10.0.2",
             "resolved": "https://registry.npmjs.org/globby/-/globby-10.0.2.tgz",
@@ -4822,6 +4620,7 @@
             "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
             "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "get-intrinsic": "^1.1.3"
             },
@@ -4833,7 +4632,8 @@
             "version": "4.2.11",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
             "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/handlebars": {
             "version": "4.7.8",
@@ -4868,14 +4668,15 @@
             }
         },
         "node_modules/hardhat": {
-            "version": "2.22.4",
-            "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.22.4.tgz",
-            "integrity": "sha512-09qcXJFBHQUaraJkYNr7XlmwjOj27xBB0SL2rYS024hTj9tPMbp26AFjlf5quBMO9SR4AJFg+4qWahcYcvXBuQ==",
+            "version": "2.22.5",
+            "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.22.5.tgz",
+            "integrity": "sha512-9Zq+HonbXCSy6/a13GY1cgHglQRfh4qkzmj1tpPlhxJDwNVnhxlReV6K7hCWFKlOrV13EQwsdcD0rjcaQKWRZw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@ethersproject/abi": "^5.1.2",
                 "@metamask/eth-sig-util": "^4.0.0",
-                "@nomicfoundation/edr": "^0.3.7",
+                "@nomicfoundation/edr": "^0.4.0",
                 "@nomicfoundation/ethereumjs-common": "4.0.4",
                 "@nomicfoundation/ethereumjs-tx": "5.0.4",
                 "@nomicfoundation/ethereumjs-util": "9.0.4",
@@ -4958,7 +4759,8 @@
                     "type": "individual",
                     "url": "https://paulmillr.com/funding/"
                 }
-            ]
+            ],
+            "peer": true
         },
         "node_modules/hardhat/node_modules/@scure/bip32": {
             "version": "1.1.5",
@@ -4971,6 +4773,7 @@
                     "url": "https://paulmillr.com/funding/"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "@noble/hashes": "~1.2.0",
                 "@noble/secp256k1": "~1.7.0",
@@ -4988,9 +4791,65 @@
                     "url": "https://paulmillr.com/funding/"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "@noble/hashes": "~1.2.0",
                 "@scure/base": "~1.1.0"
+            }
+        },
+        "node_modules/hardhat/node_modules/ansi-styles": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "color-convert": "^1.9.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/hardhat/node_modules/chalk": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/hardhat/node_modules/color-convert": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "color-name": "1.1.3"
+            }
+        },
+        "node_modules/hardhat/node_modules/color-name": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+            "dev": true,
+            "peer": true
+        },
+        "node_modules/hardhat/node_modules/escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+            "dev": true,
+            "peer": true,
+            "engines": {
+                "node": ">=0.8.0"
             }
         },
         "node_modules/hardhat/node_modules/ethereum-cryptography": {
@@ -4998,6 +4857,7 @@
             "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-1.2.0.tgz",
             "integrity": "sha512-6yFQC9b5ug6/17CQpCyE3k9eKBMdhyVjzUy1WkiuY/E4vj/SXDBbCw8QEIaXqf0Mf2SnY6RmpDcwlUmBSS0EJw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@noble/hashes": "1.2.0",
                 "@noble/secp256k1": "1.7.1",
@@ -5010,6 +4870,7 @@
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
             "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "graceful-fs": "^4.1.2",
                 "jsonfile": "^4.0.0",
@@ -5019,13 +4880,37 @@
                 "node": ">=6 <7 || >=8"
             }
         },
+        "node_modules/hardhat/node_modules/has-flag": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+            "dev": true,
+            "peer": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/hardhat/node_modules/jsonfile": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
             "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
             "dev": true,
+            "peer": true,
             "optionalDependencies": {
                 "graceful-fs": "^4.1.6"
+            }
+        },
+        "node_modules/hardhat/node_modules/supports-color": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "has-flag": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/hardhat/node_modules/universalify": {
@@ -5033,6 +4918,7 @@
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
             "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">= 4.0.0"
             }
@@ -5042,6 +4928,7 @@
             "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
             "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=8.3.0"
             },
@@ -5058,22 +4945,14 @@
                 }
             }
         },
-        "node_modules/has-bigints": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
-            "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
-            "dev": true,
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/has-flag": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-            "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
             "dev": true,
+            "peer": true,
             "engines": {
-                "node": ">=4"
+                "node": ">=8"
             }
         },
         "node_modules/has-property-descriptors": {
@@ -5081,6 +4960,7 @@
             "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
             "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "es-define-property": "^1.0.0"
             },
@@ -5093,6 +4973,7 @@
             "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
             "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">= 0.4"
             },
@@ -5105,21 +4986,7 @@
             "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
             "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
             "dev": true,
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/has-tostringtag": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-            "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-            "dev": true,
-            "dependencies": {
-                "has-symbols": "^1.0.3"
-            },
+            "peer": true,
             "engines": {
                 "node": ">= 0.4"
             },
@@ -5132,6 +4999,7 @@
             "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
             "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "inherits": "^2.0.4",
                 "readable-stream": "^3.6.0",
@@ -5146,6 +5014,7 @@
             "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
             "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "inherits": "^2.0.3",
                 "minimalistic-assert": "^1.0.1"
@@ -5156,6 +5025,7 @@
             "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
             "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "function-bind": "^1.1.2"
             },
@@ -5168,6 +5038,7 @@
             "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
             "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "he": "bin/he"
             }
@@ -5184,6 +5055,7 @@
             "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
             "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "hash.js": "^1.0.3",
                 "minimalistic-assert": "^1.0.0",
@@ -5211,6 +5083,7 @@
             "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
             "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "depd": "2.0.0",
                 "inherits": "2.0.4",
@@ -5244,6 +5117,7 @@
             "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
             "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "agent-base": "6",
                 "debug": "4"
@@ -5257,32 +5131,13 @@
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
             "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3"
             },
             "engines": {
                 "node": ">=0.10.0"
             }
-        },
-        "node_modules/ieee754": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ]
         },
         "node_modules/ignore": {
             "version": "5.3.1",
@@ -5294,17 +5149,30 @@
                 "node": ">= 4"
             }
         },
+        "node_modules/immer": {
+            "version": "10.0.2",
+            "resolved": "https://registry.npmjs.org/immer/-/immer-10.0.2.tgz",
+            "integrity": "sha512-Rx3CqeqQ19sxUtYV9CU911Vhy8/721wRFnJv3REVGWUmoAcIwzifTsdmJte/MV+0/XpM35LZdQMBGkRIoLPwQA==",
+            "dev": true,
+            "peer": true,
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/immer"
+            }
+        },
         "node_modules/immutable": {
             "version": "4.3.6",
             "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.6.tgz",
             "integrity": "sha512-Ju0+lEMyzMVZarkTn/gqRpdqd5dOPaz1mCZ0SH3JV6iFw81PldE/PEB1hWVEA288HPt4WXW8O7AWxB10M+03QQ==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/indent-string": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
             "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -5314,6 +5182,7 @@
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "once": "^1.3.0",
                 "wrappy": "1"
@@ -5323,7 +5192,8 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/ini": {
             "version": "1.3.8",
@@ -5331,20 +5201,6 @@
             "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
             "dev": true,
             "peer": true
-        },
-        "node_modules/internal-slot": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.7.tgz",
-            "integrity": "sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==",
-            "dev": true,
-            "dependencies": {
-                "es-errors": "^1.3.0",
-                "hasown": "^2.0.0",
-                "side-channel": "^1.0.4"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
         },
         "node_modules/interpret": {
             "version": "1.4.0",
@@ -5361,36 +5217,9 @@
             "resolved": "https://registry.npmjs.org/io-ts/-/io-ts-1.10.4.tgz",
             "integrity": "sha512-b23PteSnYXSONJ6JQXRAlvJhuw8KOtkqa87W4wDtvMrud/DTJd5X+NpOOI+O/zZwVq6v0VLAaJ+1EDViKEuN9g==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "fp-ts": "^1.0.0"
-            }
-        },
-        "node_modules/is-array-buffer": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.4.tgz",
-            "integrity": "sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==",
-            "dev": true,
-            "dependencies": {
-                "call-bind": "^1.0.2",
-                "get-intrinsic": "^1.2.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-bigint": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
-            "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
-            "dev": true,
-            "dependencies": {
-                "has-bigints": "^1.0.1"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/is-binary-path": {
@@ -5398,6 +5227,7 @@
             "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
             "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "binary-extensions": "^2.0.0"
             },
@@ -5405,69 +5235,12 @@
                 "node": ">=8"
             }
         },
-        "node_modules/is-boolean-object": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
-            "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
-            "dev": true,
-            "dependencies": {
-                "call-bind": "^1.0.2",
-                "has-tostringtag": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-callable": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-            "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-            "dev": true,
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-data-view": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.1.tgz",
-            "integrity": "sha512-AHkaJrsUVW6wq6JS8y3JnM/GJF/9cf+k20+iDzlSaJrinEo5+7vRiteOSwBhHRiAyQATN1AmY4hwzxJKPmYf+w==",
-            "dev": true,
-            "dependencies": {
-                "is-typed-array": "^1.1.13"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-date-object": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
-            "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
-            "dev": true,
-            "dependencies": {
-                "has-tostringtag": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/is-extglob": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
             "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -5477,6 +5250,7 @@
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
             "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -5486,6 +5260,7 @@
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
             "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "is-extglob": "^2.1.1"
             },
@@ -5498,21 +5273,10 @@
             "resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
             "integrity": "sha512-WvtOiug1VFrE9v1Cydwm+FnXd3+w9GaeVUss5W4v/SLy3UW00vP+6iNF2SdnfiBoLy4bTqVdkftNGTUeOFVsbA==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=6.5.0",
                 "npm": ">=3"
-            }
-        },
-        "node_modules/is-negative-zero": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
-            "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
-            "dev": true,
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/is-number": {
@@ -5520,23 +5284,9 @@
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
             "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=0.12.0"
-            }
-        },
-        "node_modules/is-number-object": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
-            "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
-            "dev": true,
-            "dependencies": {
-                "has-tostringtag": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/is-plain-obj": {
@@ -5544,84 +5294,9 @@
             "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
             "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/is-regex": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
-            "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
-            "dev": true,
-            "dependencies": {
-                "call-bind": "^1.0.2",
-                "has-tostringtag": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-shared-array-buffer": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.3.tgz",
-            "integrity": "sha512-nA2hv5XIhLR3uVzDDfCIknerhx8XUKnstuOERPNNIinXG7v9u+ohXF67vxm4TPTEPU6lm61ZkwP3c9PCB97rhg==",
-            "dev": true,
-            "dependencies": {
-                "call-bind": "^1.0.7"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-string": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
-            "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
-            "dev": true,
-            "dependencies": {
-                "has-tostringtag": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-symbol": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
-            "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
-            "dev": true,
-            "dependencies": {
-                "has-symbols": "^1.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-typed-array": {
-            "version": "1.1.13",
-            "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.13.tgz",
-            "integrity": "sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==",
-            "dev": true,
-            "dependencies": {
-                "which-typed-array": "^1.1.14"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/is-unicode-supported": {
@@ -5629,6 +5304,7 @@
             "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
             "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -5636,23 +5312,12 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/is-weakref": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
-            "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
-            "dev": true,
-            "dependencies": {
-                "call-bind": "^1.0.2"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/isarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
             "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/isexe": {
             "version": "2.0.0",
@@ -5661,33 +5326,18 @@
             "dev": true,
             "peer": true
         },
-        "node_modules/isomorphic-unfetch": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/isomorphic-unfetch/-/isomorphic-unfetch-3.1.0.tgz",
-            "integrity": "sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==",
-            "dev": true,
-            "dependencies": {
-                "node-fetch": "^2.6.1",
-                "unfetch": "^4.2.0"
-            }
-        },
         "node_modules/javascript-natural-sort": {
             "version": "0.7.1",
             "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
             "integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==",
             "dev": true
         },
-        "node_modules/js-cookie": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
-            "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==",
-            "dev": true
-        },
         "node_modules/js-sha3": {
             "version": "0.8.0",
             "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
             "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/js-tokens": {
             "version": "4.0.0",
@@ -5700,6 +5350,7 @@
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
             "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "argparse": "^2.0.1"
             },
@@ -5723,6 +5374,13 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "dev": true,
+            "peer": true
+        },
+        "node_modules/json-stringify-safe": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+            "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
             "dev": true,
             "peer": true
         },
@@ -5755,6 +5413,7 @@
             "integrity": "sha512-3vKuW0jV8J3XNTzvfyicFR5qvxrSAGl7KIhvgOu5cmWwM7tZRj3fMbj/pfIf4be7aznbc+prBWGjywox/g2Y6Q==",
             "dev": true,
             "hasInstallScript": true,
+            "peer": true,
             "dependencies": {
                 "node-addon-api": "^2.0.0",
                 "node-gyp-build": "^4.2.0",
@@ -5779,8 +5438,19 @@
             "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
             "integrity": "sha512-TED5xi9gGQjGpNnvRWknrwAB1eL5GciPfVFOt3Vk1OJCVDQbzuSfrF3hkUQKlsgKrG1F+0t5W0m+Fje1jIt8rw==",
             "dev": true,
+            "peer": true,
             "optionalDependencies": {
                 "graceful-fs": "^4.1.9"
+            }
+        },
+        "node_modules/kleur": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+            "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+            "dev": true,
+            "peer": true,
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/levn": {
@@ -5802,6 +5472,7 @@
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
             "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "p-locate": "^2.0.0",
                 "path-exists": "^3.0.0"
@@ -5849,6 +5520,7 @@
             "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
             "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "chalk": "^4.1.0",
                 "is-unicode-supported": "^0.1.0"
@@ -5858,76 +5530,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/log-symbols/node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dev": true,
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/log-symbols/node_modules/chalk": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-            "dev": true,
-            "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "node_modules/log-symbols/node_modules/color-convert": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dev": true,
-            "dependencies": {
-                "color-name": "~1.1.4"
-            },
-            "engines": {
-                "node": ">=7.0.0"
-            }
-        },
-        "node_modules/log-symbols/node_modules/color-name": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true
-        },
-        "node_modules/log-symbols/node_modules/has-flag": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/log-symbols/node_modules/supports-color": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "dev": true,
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/loupe": {
@@ -5944,7 +5546,8 @@
             "version": "0.3.3",
             "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
             "integrity": "sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/make-error": {
             "version": "1.3.6",
@@ -5965,6 +5568,7 @@
             "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
             "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "hash-base": "^3.0.0",
                 "inherits": "^2.0.1",
@@ -5976,6 +5580,7 @@
             "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
             "integrity": "sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">= 0.10.0"
             }
@@ -5998,13 +5603,13 @@
             "peer": true
         },
         "node_modules/micromatch": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-            "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+            "version": "4.0.7",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
+            "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
             "dev": true,
             "peer": true,
             "dependencies": {
-                "braces": "^3.0.2",
+                "braces": "^3.0.3",
                 "picomatch": "^2.3.1"
             },
             "engines": {
@@ -6036,19 +5641,22 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
             "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/minimalistic-crypto-utils": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
             "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/minimatch": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
             "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -6061,6 +5669,7 @@
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
             "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
             "dev": true,
+            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -6083,6 +5692,7 @@
             "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.5.tgz",
             "integrity": "sha512-bZTFT5rrPKtPJxj8KSV0WkPyNxl72vQepqqVUAW2ARUpUSF2qXMB6jZj7hW5/k7C1rtpzqbD/IIbJwLXUjCHeg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "obliterator": "^2.0.0"
             }
@@ -6092,6 +5702,7 @@
             "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.4.0.tgz",
             "integrity": "sha512-eqhGB8JKapEYcC4ytX/xrzKforgEc3j1pGlAXVy3eRwrtAy5/nIfT1SvgGzfN0XZZxeLq0aQWkOUAmqIJiv+bA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "ansi-colors": "4.1.1",
                 "browser-stdout": "1.3.1",
@@ -6127,6 +5738,7 @@
             "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
             "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -6136,6 +5748,7 @@
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
             "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "balanced-match": "^1.0.0"
             }
@@ -6151,6 +5764,7 @@
                     "url": "https://paulmillr.com/funding/"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "anymatch": "~3.1.2",
                 "braces": "~3.0.2",
@@ -6167,23 +5781,37 @@
                 "fsevents": "~2.3.2"
             }
         },
-        "node_modules/mocha/node_modules/escape-string-regexp": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+        "node_modules/mocha/node_modules/debug": {
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
             "dev": true,
-            "engines": {
-                "node": ">=10"
+            "peer": true,
+            "dependencies": {
+                "ms": "2.1.2"
             },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
             }
+        },
+        "node_modules/mocha/node_modules/debug/node_modules/ms": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+            "dev": true,
+            "peer": true
         },
         "node_modules/mocha/node_modules/find-up": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
             "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "locate-path": "^6.0.0",
                 "path-exists": "^4.0.0"
@@ -6200,6 +5828,7 @@
             "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
             "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -6214,20 +5843,12 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/mocha/node_modules/has-flag": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/mocha/node_modules/locate-path": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
             "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "p-locate": "^5.0.0"
             },
@@ -6243,6 +5864,7 @@
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
             "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "brace-expansion": "^2.0.1"
             },
@@ -6254,13 +5876,15 @@
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/mocha/node_modules/p-limit": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
             "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "yocto-queue": "^0.1.0"
             },
@@ -6276,6 +5900,7 @@
             "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
             "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "p-limit": "^3.0.2"
             },
@@ -6291,6 +5916,7 @@
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
             "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -6300,6 +5926,7 @@
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
             "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "has-flag": "^4.0.0"
             },
@@ -6316,6 +5943,26 @@
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
             "dev": true
         },
+        "node_modules/ndjson": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ndjson/-/ndjson-2.0.0.tgz",
+            "integrity": "sha512-nGl7LRGrzugTtaFcJMhLbpzJM6XdivmbkdlaGcrk/LXg2KL/YBC6z1g70xh0/al+oFuVFP8N8kiWRucmeEH/qQ==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "json-stringify-safe": "^5.0.1",
+                "minimist": "^1.2.5",
+                "readable-stream": "^3.6.0",
+                "split2": "^3.0.0",
+                "through2": "^4.0.0"
+            },
+            "bin": {
+                "ndjson": "cli.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/neo-async": {
             "version": "2.6.2",
             "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
@@ -6327,7 +5974,8 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
             "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/node-emoji": {
             "version": "1.11.0",
@@ -6339,31 +5987,12 @@
                 "lodash": "^4.17.21"
             }
         },
-        "node_modules/node-fetch": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-            "dev": true,
-            "dependencies": {
-                "whatwg-url": "^5.0.0"
-            },
-            "engines": {
-                "node": "4.x || >=6.0.0"
-            },
-            "peerDependencies": {
-                "encoding": "^0.1.0"
-            },
-            "peerDependenciesMeta": {
-                "encoding": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/node-gyp-build": {
             "version": "4.8.1",
             "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.1.tgz",
             "integrity": "sha512-OSs33Z9yWr148JZcbZd5WiAXhh/n9z8TxQcdMhIOlpN9AhWpLfvVFO73+m77bBABQMaY9XSvIa+qk0jlI7Gcaw==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "node-gyp-build": "bin.js",
                 "node-gyp-build-optional": "optional.js",
@@ -6375,6 +6004,7 @@
             "resolved": "https://registry.npmjs.org/nofilter/-/nofilter-3.1.0.tgz",
             "integrity": "sha512-l2NNj07e9afPnhAhvgVrCD/oy2Ai1yfLpuo3EpiO1jFTsB4sFz6oIfAfSZyQzVpkZQ9xS8ZS5g1jCBgq4Hwo0g==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=12.19"
             }
@@ -6397,6 +6027,7 @@
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
             "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -6438,33 +6069,7 @@
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
             "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
             "dev": true,
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/object-keys": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-            "dev": true,
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/object.assign": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.5.tgz",
-            "integrity": "sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==",
-            "dev": true,
-            "dependencies": {
-                "call-bind": "^1.0.5",
-                "define-properties": "^1.2.1",
-                "has-symbols": "^1.0.3",
-                "object-keys": "^1.1.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
+            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -6473,13 +6078,15 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-2.0.4.tgz",
             "integrity": "sha512-lgHwxlxV1qIg1Eap7LgIeoBWIMFibOjbrYPIPJZcI1mmGAI2m3lNYpK12Y+GBdPQ0U1hRwSord7GIaawz962qQ==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "wrappy": "1"
             }
@@ -6514,6 +6121,7 @@
             "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
             "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -6523,6 +6131,7 @@
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
             "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "p-try": "^1.0.0"
             },
@@ -6535,6 +6144,7 @@
             "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
             "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "p-limit": "^1.1.0"
             },
@@ -6547,6 +6157,7 @@
             "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
             "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "aggregate-error": "^3.0.0"
             },
@@ -6562,6 +6173,7 @@
             "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
             "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=4"
             }
@@ -6578,6 +6190,7 @@
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
             "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=4"
             }
@@ -6587,6 +6200,7 @@
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -6595,7 +6209,8 @@
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/path-type": {
             "version": "4.0.0",
@@ -6622,6 +6237,7 @@
             "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.2.tgz",
             "integrity": "sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "create-hash": "^1.1.2",
                 "create-hmac": "^1.1.4",
@@ -6644,6 +6260,7 @@
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
             "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=8.6"
             },
@@ -6661,15 +6278,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/possible-typed-array-names": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
-            "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==",
-            "dev": true,
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
         "node_modules/prelude-ls": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -6681,9 +6289,9 @@
             }
         },
         "node_modules/prettier": {
-            "version": "3.2.5",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
-            "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.1.tgz",
+            "integrity": "sha512-7CAwy5dRsxs8PHXT3twixW9/OEll8MLE0VRPCJyl7CkS6VHGPSlsVaWTiASPTyGyYRyApxlaWTzwUxVNrhcwDg==",
             "dev": true,
             "bin": {
                 "prettier": "bin/prettier.cjs"
@@ -6712,24 +6320,18 @@
                 "asap": "~2.0.6"
             }
         },
-        "node_modules/proper-lockfile": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
-            "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+        "node_modules/prompts": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+            "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
             "dev": true,
+            "peer": true,
             "dependencies": {
-                "graceful-fs": "^4.2.4",
-                "retry": "^0.12.0",
-                "signal-exit": "^3.0.2"
-            }
-        },
-        "node_modules/proper-lockfile/node_modules/retry": {
-            "version": "0.12.0",
-            "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-            "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
-            "dev": true,
+                "kleur": "^3.0.3",
+                "sisteransi": "^1.0.5"
+            },
             "engines": {
-                "node": ">= 4"
+                "node": ">= 6"
             }
         },
         "node_modules/proxy-from-env": {
@@ -6790,6 +6392,7 @@
             "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
             "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "safe-buffer": "^5.1.0"
             }
@@ -6799,6 +6402,7 @@
             "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
             "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "bytes": "3.1.2",
                 "http-errors": "2.0.0",
@@ -6814,6 +6418,7 @@
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
             "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "inherits": "^2.0.3",
                 "string_decoder": "^1.1.1",
@@ -6828,6 +6433,7 @@
             "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
             "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "picomatch": "^2.2.1"
             },
@@ -6871,24 +6477,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/regexp.prototype.flags": {
-            "version": "1.5.2",
-            "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.2.tgz",
-            "integrity": "sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==",
-            "dev": true,
-            "dependencies": {
-                "call-bind": "^1.0.6",
-                "define-properties": "^1.2.1",
-                "es-errors": "^1.3.0",
-                "set-function-name": "^2.0.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/req-cwd": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/req-cwd/-/req-cwd-2.0.0.tgz",
@@ -6920,6 +6508,7 @@
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
             "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -6929,6 +6518,7 @@
             "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
             "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -6938,6 +6528,7 @@
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
             "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "path-parse": "^1.0.6"
             },
@@ -6953,15 +6544,6 @@
             "peer": true,
             "engines": {
                 "node": ">=4"
-            }
-        },
-        "node_modules/retry": {
-            "version": "0.13.1",
-            "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
-            "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
-            "dev": true,
-            "engines": {
-                "node": ">= 4"
             }
         },
         "node_modules/reusify": {
@@ -6980,6 +6562,7 @@
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
             "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "glob": "^7.1.3"
             },
@@ -6992,6 +6575,7 @@
             "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
             "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "hash-base": "^3.0.0",
                 "inherits": "^2.0.1"
@@ -7002,6 +6586,7 @@
             "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.7.tgz",
             "integrity": "sha512-d5gdPmgQ0Z+AklL2NVXr/IoSjNZFfTVvQWzL/AM2AOcSzYP2xjlb0AC8YyCLc41MSNf6P6QVtjgPdmVtzb+4lQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "bn.js": "^5.2.0"
             },
@@ -7033,30 +6618,6 @@
                 "queue-microtask": "^1.2.2"
             }
         },
-        "node_modules/safe-array-concat": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.2.tgz",
-            "integrity": "sha512-vj6RsCsWBCf19jIeHEfkRMw8DPiBb+DMXklQ/1SGDHOMlHdPUkZXFQ2YdplS23zESTijAcurb1aSgJA3AgMu1Q==",
-            "dev": true,
-            "dependencies": {
-                "call-bind": "^1.0.7",
-                "get-intrinsic": "^1.2.4",
-                "has-symbols": "^1.0.3",
-                "isarray": "^2.0.5"
-            },
-            "engines": {
-                "node": ">=0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/safe-array-concat/node_modules/isarray": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-            "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-            "dev": true
-        },
         "node_modules/safe-buffer": {
             "version": "5.2.1",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -7075,30 +6636,15 @@
                     "type": "consulting",
                     "url": "https://feross.org/support"
                 }
-            ]
-        },
-        "node_modules/safe-regex-test": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.3.tgz",
-            "integrity": "sha512-CdASjNJPvRa7roO6Ra/gLYBTzYzzPyyBXxIMdGW3USQLyjWEls2RgW5UBTXaQVp+OrpeCK3bLem8smtmheoRuw==",
-            "dev": true,
-            "dependencies": {
-                "call-bind": "^1.0.6",
-                "es-errors": "^1.3.0",
-                "is-regex": "^1.1.4"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
+            ],
+            "peer": true
         },
         "node_modules/safer-buffer": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/sc-istanbul": {
             "version": "0.4.6",
@@ -7215,7 +6761,8 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
             "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/secp256k1": {
             "version": "4.0.3",
@@ -7223,6 +6770,7 @@
             "integrity": "sha512-NLZVf+ROMxwtEj3Xa562qgv2BK5e2WNmXPiOdVIPLgs6lyTzMvBq0aWTYMI5XCP9jZMVKOcqZLw/Wc4vDkuxhA==",
             "dev": true,
             "hasInstallScript": true,
+            "peer": true,
             "dependencies": {
                 "elliptic": "^6.5.4",
                 "node-addon-api": "^2.0.0",
@@ -7237,6 +6785,7 @@
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
             "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
             }
@@ -7246,6 +6795,7 @@
             "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
             "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "randombytes": "^2.1.0"
             }
@@ -7255,6 +6805,7 @@
             "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
             "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "define-data-property": "^1.1.4",
                 "es-errors": "^1.3.0",
@@ -7267,38 +6818,26 @@
                 "node": ">= 0.4"
             }
         },
-        "node_modules/set-function-name": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
-            "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
-            "dev": true,
-            "dependencies": {
-                "define-data-property": "^1.1.4",
-                "es-errors": "^1.3.0",
-                "functions-have-names": "^1.2.3",
-                "has-property-descriptors": "^1.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
         "node_modules/setimmediate": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
             "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/setprototypeof": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
             "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/sha.js": {
             "version": "2.4.11",
             "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
             "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "inherits": "^2.0.1",
                 "safe-buffer": "^5.0.1"
@@ -7344,6 +6883,7 @@
             "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
             "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "call-bind": "^1.0.7",
                 "es-errors": "^1.3.0",
@@ -7357,11 +6897,12 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/signal-exit": {
-            "version": "3.0.7",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-            "dev": true
+        "node_modules/sisteransi": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+            "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+            "dev": true,
+            "peer": true
         },
         "node_modules/slash": {
             "version": "3.0.0",
@@ -7391,47 +6932,12 @@
                 "url": "https://github.com/chalk/slice-ansi?sponsor=1"
             }
         },
-        "node_modules/slice-ansi/node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/slice-ansi/node_modules/color-convert": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "color-name": "~1.1.4"
-            },
-            "engines": {
-                "node": ">=7.0.0"
-            }
-        },
-        "node_modules/slice-ansi/node_modules/color-name": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true,
-            "peer": true
-        },
         "node_modules/solc": {
             "version": "0.7.3",
             "resolved": "https://registry.npmjs.org/solc/-/solc-0.7.3.tgz",
             "integrity": "sha512-GAsWNAjGzIDg7VxzP6mPjdurby3IkGCjQcM8GFYZT6RyaoUZKmMU6Y7YwG+tFGhv7dwZ8rmR4iwFDrrD99JwqA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "command-exists": "^1.2.8",
                 "commander": "3.0.2",
@@ -7455,6 +6961,7 @@
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
             "integrity": "sha512-UvSPKyhMn6LEd/WpUaV9C9t3zATuqoqfWc3QdPhPLb58prN9tqYPlPWi8Krxi44loBoUzlobqZ3+8tGpxxSzwA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "graceful-fs": "^4.1.2",
                 "jsonfile": "^2.1.0",
@@ -7468,6 +6975,7 @@
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
             "integrity": "sha512-PKllAqbgLgxHaj8TElYymKCAgrASebJrWpTnEkOaTowt23VKXXN0sUeriJ+eh7y6ufb/CC5ap11pz71/cM0hUw==",
             "dev": true,
+            "peer": true,
             "optionalDependencies": {
                 "graceful-fs": "^4.1.6"
             }
@@ -7477,17 +6985,9 @@
             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
             "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "semver": "bin/semver"
-            }
-        },
-        "node_modules/solidity-ast": {
-            "version": "0.4.56",
-            "resolved": "https://registry.npmjs.org/solidity-ast/-/solidity-ast-0.4.56.tgz",
-            "integrity": "sha512-HgmsA/Gfklm/M8GFbCX/J1qkVH0spXHgALCNZ8fA8x5X+MFdn/8CP2gr5OVyXjXw6RZTPC/Sxl2RUDQOXyNMeA==",
-            "dev": true,
-            "dependencies": {
-                "array.prototype.findlast": "^1.2.2"
             }
         },
         "node_modules/solidity-coverage": {
@@ -7531,6 +7031,61 @@
             "dev": true,
             "peer": true
         },
+        "node_modules/solidity-coverage/node_modules/ansi-styles": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "color-convert": "^1.9.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/solidity-coverage/node_modules/chalk": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/solidity-coverage/node_modules/color-convert": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "color-name": "1.1.3"
+            }
+        },
+        "node_modules/solidity-coverage/node_modules/color-name": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+            "dev": true,
+            "peer": true
+        },
+        "node_modules/solidity-coverage/node_modules/escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+            "dev": true,
+            "peer": true,
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
         "node_modules/solidity-coverage/node_modules/fs-extra": {
             "version": "8.1.0",
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
@@ -7544,6 +7099,16 @@
             },
             "engines": {
                 "node": ">=6 <7 || >=8"
+            }
+        },
+        "node_modules/solidity-coverage/node_modules/has-flag": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+            "dev": true,
+            "peer": true,
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/solidity-coverage/node_modules/jsonfile": {
@@ -7567,6 +7132,19 @@
             },
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/solidity-coverage/node_modules/supports-color": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "has-flag": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/solidity-coverage/node_modules/universalify": {
@@ -7593,6 +7171,7 @@
             "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
             "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "buffer-from": "^1.0.0",
                 "source-map": "^0.6.0"
@@ -7603,8 +7182,19 @@
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/split2": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
+            "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "readable-stream": "^3.0.0"
             }
         },
         "node_modules/sprintf-js": {
@@ -7619,6 +7209,7 @@
             "resolved": "https://registry.npmjs.org/stacktrace-parser/-/stacktrace-parser-0.1.10.tgz",
             "integrity": "sha512-KJP1OCML99+8fhOHxwwzyWrlUuVX5GQ0ZpJTd1DFXhdkrvg1szxfHhawXUZ3g9TkXORQd4/WG68jMlQZ2p8wlg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "type-fest": "^0.7.1"
             },
@@ -7631,6 +7222,7 @@
             "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.7.1.tgz",
             "integrity": "sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -7640,6 +7232,7 @@
             "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
             "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">= 0.8"
             }
@@ -7649,6 +7242,7 @@
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
             "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "safe-buffer": "~5.2.0"
             }
@@ -7665,6 +7259,7 @@
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
             "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "emoji-regex": "^8.0.0",
                 "is-fullwidth-code-point": "^3.0.0",
@@ -7674,60 +7269,12 @@
                 "node": ">=8"
             }
         },
-        "node_modules/string.prototype.trim": {
-            "version": "1.2.9",
-            "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.9.tgz",
-            "integrity": "sha512-klHuCNxiMZ8MlsOihJhJEBJAiMVqU3Z2nEXWfWnIqjN0gEFS9J9+IxKozWWtQGcgoa1WUZzLjKPTr4ZHNFTFxw==",
-            "dev": true,
-            "dependencies": {
-                "call-bind": "^1.0.7",
-                "define-properties": "^1.2.1",
-                "es-abstract": "^1.23.0",
-                "es-object-atoms": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/string.prototype.trimend": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.8.tgz",
-            "integrity": "sha512-p73uL5VCHCO2BZZ6krwwQE3kCzM7NKmis8S//xEC6fQonchbum4eP6kR4DLEjQFO3Wnj3Fuo8NM0kOSjVdHjZQ==",
-            "dev": true,
-            "dependencies": {
-                "call-bind": "^1.0.7",
-                "define-properties": "^1.2.1",
-                "es-object-atoms": "^1.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/string.prototype.trimstart": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
-            "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
-            "dev": true,
-            "dependencies": {
-                "call-bind": "^1.0.7",
-                "define-properties": "^1.2.1",
-                "es-object-atoms": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/strip-ansi": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
             "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "ansi-regex": "^5.0.1"
             },
@@ -7740,6 +7287,7 @@
             "resolved": "https://registry.npmjs.org/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz",
             "integrity": "sha512-q8d4ue7JGEiVcypji1bALTos+0pWtyGlivAWyPuTkHzuTCJqrK9sWxYQZUq6Nq3cuyv3bm734IhHvHtGGURU6A==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "is-hex-prefixed": "1.0.0"
             },
@@ -7753,6 +7301,7 @@
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
             "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=8"
             },
@@ -7761,15 +7310,16 @@
             }
         },
         "node_modules/supports-color": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
-                "has-flag": "^3.0.0"
+                "has-flag": "^4.0.0"
             },
             "engines": {
-                "node": ">=4"
+                "node": ">=8"
             }
         },
         "node_modules/sync-request": {
@@ -7895,11 +7445,22 @@
                 "node": ">= 0.12"
             }
         },
+        "node_modules/through2": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
+            "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "readable-stream": "3"
+            }
+        },
         "node_modules/tmp": {
             "version": "0.0.33",
             "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
             "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "os-tmpdir": "~1.0.2"
             },
@@ -7921,6 +7482,7 @@
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
             "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "is-number": "^7.0.0"
             },
@@ -7933,15 +7495,10 @@
             "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
             "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=0.6"
             }
-        },
-        "node_modules/tr46": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-            "dev": true
         },
         "node_modules/ts-command-line-args": {
             "version": "2.5.1",
@@ -7957,82 +7514,6 @@
             },
             "bin": {
                 "write-markdown": "dist/write-markdown.js"
-            }
-        },
-        "node_modules/ts-command-line-args/node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/ts-command-line-args/node_modules/chalk": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "node_modules/ts-command-line-args/node_modules/color-convert": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "color-name": "~1.1.4"
-            },
-            "engines": {
-                "node": ">=7.0.0"
-            }
-        },
-        "node_modules/ts-command-line-args/node_modules/color-name": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true,
-            "peer": true
-        },
-        "node_modules/ts-command-line-args/node_modules/has-flag": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "dev": true,
-            "peer": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/ts-command-line-args/node_modules/supports-color": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/ts-essentials": {
@@ -8100,28 +7581,32 @@
             }
         },
         "node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "dev": true
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+            "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+            "dev": true,
+            "peer": true
         },
         "node_modules/tsort": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/tsort/-/tsort-0.0.1.tgz",
             "integrity": "sha512-Tyrf5mxF8Ofs1tNoxA13lFeZ2Zrbd6cKbuH3V+MQ5sb6DtBj5FjrXVsRWT8YvNAQTqNoz66dz1WsbigI22aEnw==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/tweetnacl": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
             "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/tweetnacl-util": {
             "version": "0.15.1",
             "resolved": "https://registry.npmjs.org/tweetnacl-util/-/tweetnacl-util-0.15.1.tgz",
             "integrity": "sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/type-check": {
             "version": "0.3.2",
@@ -8151,6 +7636,7 @@
             "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
             "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -8268,79 +7754,6 @@
                 "node": ">= 4.0.0"
             }
         },
-        "node_modules/typed-array-buffer": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.2.tgz",
-            "integrity": "sha512-gEymJYKZtKXzzBzM4jqa9w6Q1Jjm7x2d+sh19AdsD4wqnMPDYyvwpsIc2Q/835kHuo3BEQ7CjelGhfTsoBb2MQ==",
-            "dev": true,
-            "dependencies": {
-                "call-bind": "^1.0.7",
-                "es-errors": "^1.3.0",
-                "is-typed-array": "^1.1.13"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/typed-array-byte-length": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.1.tgz",
-            "integrity": "sha512-3iMJ9q0ao7WE9tWcaYKIptkNBuOIcZCCT0d4MRvuuH88fEoEH62IuQe0OtraD3ebQEoTRk8XCBoknUNc1Y67pw==",
-            "dev": true,
-            "dependencies": {
-                "call-bind": "^1.0.7",
-                "for-each": "^0.3.3",
-                "gopd": "^1.0.1",
-                "has-proto": "^1.0.3",
-                "is-typed-array": "^1.1.13"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/typed-array-byte-offset": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.2.tgz",
-            "integrity": "sha512-Ous0vodHa56FviZucS2E63zkgtgrACj7omjwd/8lTEMEPFFyjfixMZ1ZXenpgCFBBt4EC1J2XsyVS2gkG0eTFA==",
-            "dev": true,
-            "dependencies": {
-                "available-typed-arrays": "^1.0.7",
-                "call-bind": "^1.0.7",
-                "for-each": "^0.3.3",
-                "gopd": "^1.0.1",
-                "has-proto": "^1.0.3",
-                "is-typed-array": "^1.1.13"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/typed-array-length": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.6.tgz",
-            "integrity": "sha512-/OxDN6OtAk5KBpGb28T+HZc2M+ADtvRxXrKKbUwtsLgdoxgX13hyy7ek6bFRl5+aBs2yZzB0c4CnQfAtVypW/g==",
-            "dev": true,
-            "dependencies": {
-                "call-bind": "^1.0.7",
-                "for-each": "^0.3.3",
-                "gopd": "^1.0.1",
-                "has-proto": "^1.0.3",
-                "is-typed-array": "^1.1.13",
-                "possible-typed-array-names": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/typedarray": {
             "version": "0.0.6",
             "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
@@ -8386,26 +7799,12 @@
                 "node": ">=0.8.0"
             }
         },
-        "node_modules/unbox-primitive": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
-            "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
-            "dev": true,
-            "dependencies": {
-                "call-bind": "^1.0.2",
-                "has-bigints": "^1.0.2",
-                "has-symbols": "^1.0.3",
-                "which-boxed-primitive": "^1.0.2"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/undici": {
             "version": "5.28.4",
             "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
             "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@fastify/busboy": "^2.0.0"
             },
@@ -8417,13 +7816,8 @@
             "version": "5.26.5",
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
             "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-            "dev": true
-        },
-        "node_modules/unfetch": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.2.0.tgz",
-            "integrity": "sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/universalify": {
             "version": "2.0.1",
@@ -8440,6 +7834,7 @@
             "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
             "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">= 0.8"
             }
@@ -8465,13 +7860,15 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/uuid": {
             "version": "8.3.2",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
             "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "uuid": "dist/bin/uuid"
             }
@@ -8514,22 +7911,22 @@
             }
         },
         "node_modules/web3-utils/node_modules/@noble/curves": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.3.0.tgz",
-            "integrity": "sha512-t01iSXPuN+Eqzb4eBX0S5oubSqXbK/xXa1Ne18Hj8f9pStxztHCE2gfboSp/dZRLSqfuLpRK2nDXDK+W9puocA==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.0.tgz",
+            "integrity": "sha512-p+4cb332SFCrReJkCYe8Xzm0OWi4Jji5jVdIZRL/PmacmDkFNw6MrrV+gGpiPxLHbV+zKFRywUWbaseT+tZRXg==",
             "dev": true,
             "peer": true,
             "dependencies": {
-                "@noble/hashes": "1.3.3"
+                "@noble/hashes": "1.4.0"
             },
             "funding": {
                 "url": "https://paulmillr.com/funding/"
             }
         },
         "node_modules/web3-utils/node_modules/@noble/hashes": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.3.tgz",
-            "integrity": "sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+            "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
             "dev": true,
             "peer": true,
             "engines": {
@@ -8540,32 +7937,16 @@
             }
         },
         "node_modules/web3-utils/node_modules/ethereum-cryptography": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-2.1.3.tgz",
-            "integrity": "sha512-BlwbIL7/P45W8FGW2r7LGuvoEZ+7PWsniMvQ4p5s2xCyw9tmaDlpfsN9HjAucbF+t/qpVHwZUisgfK24TCW8aA==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-2.2.0.tgz",
+            "integrity": "sha512-hsm9JhfytIf8QME/3B7j4bc8V+VdTU+Vas1aJlvIS96ffoNAosudXvGoEvWmc7QZYdkC8mrMJz9r0fcbw7GyCA==",
             "dev": true,
             "peer": true,
             "dependencies": {
-                "@noble/curves": "1.3.0",
-                "@noble/hashes": "1.3.3",
-                "@scure/bip32": "1.3.3",
-                "@scure/bip39": "1.2.2"
-            }
-        },
-        "node_modules/webidl-conversions": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-            "dev": true
-        },
-        "node_modules/whatwg-url": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-            "dev": true,
-            "dependencies": {
-                "tr46": "~0.0.3",
-                "webidl-conversions": "^3.0.0"
+                "@noble/curves": "1.4.0",
+                "@noble/hashes": "1.4.0",
+                "@scure/bip32": "1.4.0",
+                "@scure/bip39": "1.3.0"
             }
         },
         "node_modules/which": {
@@ -8581,46 +7962,12 @@
                 "which": "bin/which"
             }
         },
-        "node_modules/which-boxed-primitive": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
-            "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
-            "dev": true,
-            "dependencies": {
-                "is-bigint": "^1.0.1",
-                "is-boolean-object": "^1.1.0",
-                "is-number-object": "^1.0.4",
-                "is-string": "^1.0.5",
-                "is-symbol": "^1.0.3"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/which-typed-array": {
-            "version": "1.1.15",
-            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.15.tgz",
-            "integrity": "sha512-oV0jmFtUky6CXfkqehVvBP/LSWJ2sy4vWMioiENyJLePrBO/yKyV9OyJySfAKosh+RYkIl5zJCNZ8/4JncrpdA==",
-            "dev": true,
-            "dependencies": {
-                "available-typed-arrays": "^1.0.7",
-                "call-bind": "^1.0.7",
-                "for-each": "^0.3.3",
-                "gopd": "^1.0.1",
-                "has-tostringtag": "^1.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/widest-line": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
             "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "string-width": "^4.0.0"
             },
@@ -8673,13 +8020,15 @@
             "version": "6.2.1",
             "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.1.tgz",
             "integrity": "sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/wrap-ansi": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
             "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "ansi-styles": "^4.0.0",
                 "string-width": "^4.1.0",
@@ -8692,44 +8041,12 @@
                 "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
             }
         },
-        "node_modules/wrap-ansi/node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dev": true,
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/wrap-ansi/node_modules/color-convert": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dev": true,
-            "dependencies": {
-                "color-name": "~1.1.4"
-            },
-            "engines": {
-                "node": ">=7.0.0"
-            }
-        },
-        "node_modules/wrap-ansi/node_modules/color-name": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true
-        },
         "node_modules/wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/ws": {
             "version": "8.17.0",
@@ -8757,6 +8074,7 @@
             "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
             "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -8766,6 +8084,7 @@
             "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
             "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "cliui": "^7.0.2",
                 "escalade": "^3.1.1",
@@ -8784,6 +8103,7 @@
             "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
             "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -8793,6 +8113,7 @@
             "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
             "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "camelcase": "^6.0.0",
                 "decamelize": "^4.0.0",
@@ -8818,6 +8139,7 @@
             "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
             "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -16,6 +16,7 @@
                 "eslint-plugin-sort": "^3.0.2",
                 "prettier": "^3.3.1",
                 "prettier-plugin-solidity": "^1.3.1",
+                "solhint": "^5.0.1",
                 "typescript-eslint": "^7.12.0",
                 "web3-types": "^1.6.0",
                 "ws": "^8.17.0"
@@ -1336,7 +1337,6 @@
             "version": "0.11.14",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
             "integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
-            "deprecated": "Use @eslint/config-array instead",
             "dev": true,
             "dependencies": {
                 "@humanwhocodes/object-schema": "^2.0.2",
@@ -1364,7 +1364,6 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
             "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
-            "deprecated": "Use @eslint/object-schema instead",
             "dev": true
         },
         "node_modules/@jridgewell/gen-mapping": {
@@ -2167,6 +2166,47 @@
                 "node": ">= 10"
             }
         },
+        "node_modules/@pnpm/config.env-replace": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@pnpm/config.env-replace/-/config.env-replace-1.1.0.tgz",
+            "integrity": "sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==",
+            "dev": true,
+            "engines": {
+                "node": ">=12.22.0"
+            }
+        },
+        "node_modules/@pnpm/network.ca-file": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@pnpm/network.ca-file/-/network.ca-file-1.0.2.tgz",
+            "integrity": "sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA==",
+            "dev": true,
+            "dependencies": {
+                "graceful-fs": "4.2.10"
+            },
+            "engines": {
+                "node": ">=12.22.0"
+            }
+        },
+        "node_modules/@pnpm/network.ca-file/node_modules/graceful-fs": {
+            "version": "4.2.10",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+            "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+            "dev": true
+        },
+        "node_modules/@pnpm/npm-conf": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-2.2.2.tgz",
+            "integrity": "sha512-UA91GwWPhFExt3IizW6bOeY/pQ0BkuNwKjk9iQW9KqxluGCrg4VenZ0/L+2Y0+ZOtme72EVvg6v0zo3AMQRCeA==",
+            "dev": true,
+            "dependencies": {
+                "@pnpm/config.env-replace": "^1.1.0",
+                "@pnpm/network.ca-file": "^1.0.1",
+                "config-chain": "^1.1.11"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/@scure/base": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.6.tgz",
@@ -2396,6 +2436,18 @@
             "dev": true,
             "peer": true
         },
+        "node_modules/@sindresorhus/is": {
+            "version": "5.6.0",
+            "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.6.0.tgz",
+            "integrity": "sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==",
+            "dev": true,
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/is?sponsor=1"
+            }
+        },
         "node_modules/@solidity-parser/parser": {
             "version": "0.14.5",
             "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.14.5.tgz",
@@ -2511,6 +2563,18 @@
             },
             "peerDependencies": {
                 "eslint": ">=8.40.0"
+            }
+        },
+        "node_modules/@szmarczak/http-timer": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
+            "integrity": "sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==",
+            "dev": true,
+            "dependencies": {
+                "defer-to-connect": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=14.16"
             }
         },
         "node_modules/@trivago/prettier-plugin-sort-imports": {
@@ -2685,6 +2749,12 @@
                 "@types/minimatch": "*",
                 "@types/node": "*"
             }
+        },
+        "node_modules/@types/http-cache-semantics": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
+            "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
+            "dev": true
         },
         "node_modules/@types/json-schema": {
             "version": "7.0.15",
@@ -3448,7 +3518,6 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.16.0.tgz",
             "integrity": "sha512-F0twR8U1ZU67JIEtekUcLkXkoO5mMMmgGD8sK/xUFzJ805jxHQl92hImFAqqXMyMYjSPOyUPAwHYhB72g5sTXw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "json-schema-traverse": "^1.0.0",
@@ -3531,6 +3600,15 @@
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
+        "node_modules/antlr4": {
+            "version": "4.13.1-patch-1",
+            "resolved": "https://registry.npmjs.org/antlr4/-/antlr4-4.13.1-patch-1.tgz",
+            "integrity": "sha512-OjFLWWLzDMV9rdFhpvroCWR4ooktNg9/nvVYSA5z28wuVpU36QUNuioR1XLnQtcjVlf8npjyz593PxnU/f/Cow==",
+            "dev": true,
+            "engines": {
+                "node": ">=16"
+            }
+        },
         "node_modules/antlr4ts": {
             "version": "0.5.0-alpha.4",
             "resolved": "https://registry.npmjs.org/antlr4ts/-/antlr4ts-0.5.0-alpha.4.tgz",
@@ -3611,12 +3689,17 @@
                 "node": "*"
             }
         },
+        "node_modules/ast-parents": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/ast-parents/-/ast-parents-0.0.1.tgz",
+            "integrity": "sha512-XHusKxKz3zoYk1ic8Un640joHbFMhbqneyoZfoKnEGtf2ey9Uh/IdpcQplODdO/kENaMIWsD0nJm4+wX3UNLHA==",
+            "dev": true
+        },
         "node_modules/astral-regex": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
             "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -3836,6 +3919,33 @@
             "peer": true,
             "engines": {
                 "node": ">= 0.8"
+            }
+        },
+        "node_modules/cacheable-lookup": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
+            "integrity": "sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==",
+            "dev": true,
+            "engines": {
+                "node": ">=14.16"
+            }
+        },
+        "node_modules/cacheable-request": {
+            "version": "10.2.14",
+            "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-10.2.14.tgz",
+            "integrity": "sha512-zkDT5WAF4hSSoUgyfg5tFIxz8XQK+25W/TLVojJTMKBaxevLBBtLxgqguAuVQB8PVW79FVjHcU+GJ9tVbDZ9mQ==",
+            "dev": true,
+            "dependencies": {
+                "@types/http-cache-semantics": "^4.0.2",
+                "get-stream": "^6.0.1",
+                "http-cache-semantics": "^4.1.1",
+                "keyv": "^4.5.3",
+                "mimic-response": "^4.0.0",
+                "normalize-url": "^8.0.0",
+                "responselike": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=14.16"
             }
         },
         "node_modules/call-bind": {
@@ -4352,6 +4462,16 @@
                 "safe-buffer": "~5.1.0"
             }
         },
+        "node_modules/config-chain": {
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+            "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+            "dev": true,
+            "dependencies": {
+                "ini": "^1.3.4",
+                "proto-list": "~1.2.1"
+            }
+        },
         "node_modules/cookie": {
             "version": "0.4.2",
             "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
@@ -4368,6 +4488,32 @@
             "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
             "dev": true,
             "peer": true
+        },
+        "node_modules/cosmiconfig": {
+            "version": "8.3.6",
+            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
+            "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
+            "dev": true,
+            "dependencies": {
+                "import-fresh": "^3.3.0",
+                "js-yaml": "^4.1.0",
+                "parse-json": "^5.2.0",
+                "path-type": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/d-fischer"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.9.5"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
         },
         "node_modules/create-hash": {
             "version": "1.2.0",
@@ -4481,6 +4627,33 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/decompress-response": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+            "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+            "dev": true,
+            "dependencies": {
+                "mimic-response": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/decompress-response/node_modules/mimic-response": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+            "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/deep-eql": {
             "version": "4.1.4",
             "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
@@ -4499,7 +4672,6 @@
             "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
             "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=4.0.0"
             }
@@ -4509,6 +4681,15 @@
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
             "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
             "dev": true
+        },
+        "node_modules/defer-to-connect": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+            "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            }
         },
         "node_modules/define-data-property": {
             "version": "1.1.4",
@@ -4621,8 +4802,7 @@
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/enquirer": {
             "version": "2.4.1",
@@ -4646,6 +4826,15 @@
             "peer": true,
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/error-ex": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+            "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+            "dev": true,
+            "dependencies": {
+                "is-arrayish": "^0.2.1"
             }
         },
         "node_modules/es-define-property": {
@@ -5470,6 +5659,12 @@
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
             "dev": true
         },
+        "node_modules/fast-diff": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+            "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
+            "dev": true
+        },
         "node_modules/fast-glob": {
             "version": "3.3.2",
             "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
@@ -5585,7 +5780,6 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
             "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-            "deprecated": "Rimraf versions prior to v4 are no longer supported",
             "dev": true,
             "dependencies": {
                 "glob": "^7.1.3"
@@ -5635,6 +5829,15 @@
             },
             "engines": {
                 "node": ">= 6"
+            }
+        },
+        "node_modules/form-data-encoder": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-2.1.4.tgz",
+            "integrity": "sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==",
+            "dev": true,
+            "engines": {
+                "node": ">= 14.17"
             }
         },
         "node_modules/fp-ts": {
@@ -5745,6 +5948,18 @@
             "peer": true,
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/get-stream": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+            "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/ghost-testrpc": {
@@ -5939,6 +6154,31 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/got": {
+            "version": "12.6.1",
+            "resolved": "https://registry.npmjs.org/got/-/got-12.6.1.tgz",
+            "integrity": "sha512-mThBblvlAF1d4O5oqyvN+ZxLAYwIJK7bpMxgYqPD9okW0C3qm5FFn7k811QrcuEBwaogR3ngOFoCfs6mRv7teQ==",
+            "dev": true,
+            "dependencies": {
+                "@sindresorhus/is": "^5.2.0",
+                "@szmarczak/http-timer": "^5.0.1",
+                "cacheable-lookup": "^7.0.0",
+                "cacheable-request": "^10.2.8",
+                "decompress-response": "^6.0.0",
+                "form-data-encoder": "^2.1.2",
+                "get-stream": "^6.0.1",
+                "http2-wrapper": "^2.1.10",
+                "lowercase-keys": "^3.0.0",
+                "p-cancelable": "^3.0.0",
+                "responselike": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/got?sponsor=1"
             }
         },
         "node_modules/graceful-fs": {
@@ -6396,6 +6636,12 @@
                 "node": ">=6.0.0"
             }
         },
+        "node_modules/http-cache-semantics": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+            "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
+            "dev": true
+        },
         "node_modules/http-errors": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -6429,6 +6675,19 @@
             "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
             "dev": true,
             "peer": true
+        },
+        "node_modules/http2-wrapper": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
+            "integrity": "sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==",
+            "dev": true,
+            "dependencies": {
+                "quick-lru": "^5.1.1",
+                "resolve-alpn": "^1.2.0"
+            },
+            "engines": {
+                "node": ">=10.19.0"
+            }
         },
         "node_modules/https-proxy-agent": {
             "version": "5.0.1",
@@ -6548,8 +6807,7 @@
             "version": "1.3.8",
             "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
             "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/interpret": {
             "version": "1.4.0",
@@ -6570,6 +6828,12 @@
             "dependencies": {
                 "fp-ts": "^1.0.0"
             }
+        },
+        "node_modules/is-arrayish": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+            "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+            "dev": true
         },
         "node_modules/is-binary-path": {
             "version": "2.1.0",
@@ -6598,7 +6862,6 @@
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
             "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -6735,12 +6998,17 @@
             "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
             "dev": true
         },
+        "node_modules/json-parse-even-better-errors": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+            "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+            "dev": true
+        },
         "node_modules/json-schema-traverse": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
@@ -6833,6 +7101,21 @@
                 "node": ">=6"
             }
         },
+        "node_modules/latest-version": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-7.0.0.tgz",
+            "integrity": "sha512-KvNT4XqAMzdcL6ka6Tl3i2lYeFDgXNCuIX+xNx6ZMVR1dFq+idXd9FLKNMOIx0t9mJ9/HudyX4oZWXZQ0UJHeg==",
+            "dev": true,
+            "dependencies": {
+                "package-json": "^8.1.0"
+            },
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/levn": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -6846,6 +7129,12 @@
             "engines": {
                 "node": ">= 0.8.0"
             }
+        },
+        "node_modules/lines-and-columns": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+            "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+            "dev": true
         },
         "node_modules/locate-path": {
             "version": "2.0.0",
@@ -6898,8 +7187,7 @@
             "version": "4.4.2",
             "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
             "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/log-symbols": {
             "version": "4.1.0",
@@ -6926,6 +7214,18 @@
             "peer": true,
             "dependencies": {
                 "get-func-name": "^2.0.1"
+            }
+        },
+        "node_modules/lowercase-keys": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
+            "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
+            "dev": true,
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/lru_map": {
@@ -7021,6 +7321,18 @@
                 "node": ">= 0.6"
             }
         },
+        "node_modules/mimic-response": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-4.0.0.tgz",
+            "integrity": "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==",
+            "dev": true,
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/minimalistic-assert": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -7052,7 +7364,6 @@
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
             "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
             "dev": true,
-            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -7421,6 +7732,18 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/normalize-url": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.0.1.tgz",
+            "integrity": "sha512-IO9QvjUMWxPQQhs60oOu10CRkWCiZzSUkzbXGGV9pviYl1fXYcvkzQ5jV9z8Y6un8ARoVRl4EtC6v6jNqbaJ/w==",
+            "dev": true,
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/number-to-bn": {
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
@@ -7514,6 +7837,15 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/p-cancelable": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-3.0.0.tgz",
+            "integrity": "sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==",
+            "dev": true,
+            "engines": {
+                "node": ">=12.20"
+            }
+        },
         "node_modules/p-limit": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
@@ -7566,6 +7898,36 @@
                 "node": ">=4"
             }
         },
+        "node_modules/package-json": {
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/package-json/-/package-json-8.1.1.tgz",
+            "integrity": "sha512-cbH9IAIJHNj9uXi196JVsRlt7cHKak6u/e6AkL/bkRelZ7rlL3X1YKxsZwa36xipOEKAsdtmaG6aAJoM1fx2zA==",
+            "dev": true,
+            "dependencies": {
+                "got": "^12.1.0",
+                "registry-auth-token": "^5.0.1",
+                "registry-url": "^6.0.0",
+                "semver": "^7.3.7"
+            },
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/package-json/node_modules/semver": {
+            "version": "7.6.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+            "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+            "dev": true,
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/parent-module": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -7584,6 +7946,24 @@
             "integrity": "sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg==",
             "dev": true,
             "peer": true
+        },
+        "node_modules/parse-json": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+            "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+            "dev": true,
+            "dependencies": {
+                "@babel/code-frame": "^7.0.0",
+                "error-ex": "^1.3.1",
+                "json-parse-even-better-errors": "^2.3.0",
+                "lines-and-columns": "^1.1.6"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/path-exists": {
             "version": "3.0.0",
@@ -7684,6 +8064,15 @@
                 "node": ">=6"
             }
         },
+        "node_modules/pluralize": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+            "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/prelude-ls": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -7775,6 +8164,12 @@
                 "node": ">= 6"
             }
         },
+        "node_modules/proto-list": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+            "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+            "dev": true
+        },
         "node_modules/proxy-from-env": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -7826,6 +8221,18 @@
                 }
             ]
         },
+        "node_modules/quick-lru": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+            "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/randombytes": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -7850,6 +8257,30 @@
             },
             "engines": {
                 "node": ">= 0.8"
+            }
+        },
+        "node_modules/rc": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+            "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+            "dev": true,
+            "dependencies": {
+                "deep-extend": "^0.6.0",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
+            },
+            "bin": {
+                "rc": "cli.js"
+            }
+        },
+        "node_modules/rc/node_modules/strip-json-comments": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+            "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/readable-stream": {
@@ -7916,6 +8347,33 @@
                 "node": ">=6"
             }
         },
+        "node_modules/registry-auth-token": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-5.0.2.tgz",
+            "integrity": "sha512-o/3ikDxtXaA59BmZuZrJZDJv8NMDGSj+6j6XaeBmHw8eY1i1qd9+6H+LjVvQXx3HN6aRCGa1cUdJ9RaJZUugnQ==",
+            "dev": true,
+            "dependencies": {
+                "@pnpm/npm-conf": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/registry-url": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-6.0.1.tgz",
+            "integrity": "sha512-+crtS5QjFRqFCoQmvGduwYWEBng99ZvmFvF+cUJkGYF1L1BfU8C6Zp9T7f5vPAwyLkUExpvK+ANVZmGU49qi4Q==",
+            "dev": true,
+            "dependencies": {
+                "rc": "1.2.8"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/req-cwd": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/req-cwd/-/req-cwd-2.0.0.tgz",
@@ -7957,7 +8415,6 @@
             "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
             "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -7975,6 +8432,12 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/resolve-alpn": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+            "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+            "dev": true
+        },
         "node_modules/resolve-from": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
@@ -7983,6 +8446,21 @@
             "peer": true,
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/responselike": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/responselike/-/responselike-3.0.0.tgz",
+            "integrity": "sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==",
+            "dev": true,
+            "dependencies": {
+                "lowercase-keys": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/reusify": {
@@ -8376,7 +8854,6 @@
             "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
             "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "ansi-styles": "^4.0.0",
                 "astral-regex": "^2.0.0",
@@ -8445,6 +8922,143 @@
             "peer": true,
             "bin": {
                 "semver": "bin/semver"
+            }
+        },
+        "node_modules/solhint": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/solhint/-/solhint-5.0.1.tgz",
+            "integrity": "sha512-QeQLS9HGCnIiibt+xiOa/+MuP7BWz9N7C5+Mj9pLHshdkNhuo3AzCpWmjfWVZBUuwIUO3YyCRVIcYLR3YOKGfg==",
+            "dev": true,
+            "dependencies": {
+                "@solidity-parser/parser": "^0.18.0",
+                "ajv": "^6.12.6",
+                "antlr4": "^4.13.1-patch-1",
+                "ast-parents": "^0.0.1",
+                "chalk": "^4.1.2",
+                "commander": "^10.0.0",
+                "cosmiconfig": "^8.0.0",
+                "fast-diff": "^1.2.0",
+                "glob": "^8.0.3",
+                "ignore": "^5.2.4",
+                "js-yaml": "^4.1.0",
+                "latest-version": "^7.0.0",
+                "lodash": "^4.17.21",
+                "pluralize": "^8.0.0",
+                "semver": "^7.5.2",
+                "strip-ansi": "^6.0.1",
+                "table": "^6.8.1",
+                "text-table": "^0.2.0"
+            },
+            "bin": {
+                "solhint": "solhint.js"
+            },
+            "optionalDependencies": {
+                "prettier": "^2.8.3"
+            }
+        },
+        "node_modules/solhint/node_modules/@solidity-parser/parser": {
+            "version": "0.18.0",
+            "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.18.0.tgz",
+            "integrity": "sha512-yfORGUIPgLck41qyN7nbwJRAx17/jAIXCTanHOJZhB6PJ1iAk/84b/xlsVKFSyNyLXIj0dhppoE0+CRws7wlzA==",
+            "dev": true
+        },
+        "node_modules/solhint/node_modules/ajv": {
+            "version": "6.12.6",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "dev": true,
+            "dependencies": {
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/solhint/node_modules/brace-expansion": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "dev": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/solhint/node_modules/commander": {
+            "version": "10.0.1",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+            "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+            "dev": true,
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/solhint/node_modules/glob": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+            "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+            "dev": true,
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^5.0.1",
+                "once": "^1.3.0"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/solhint/node_modules/json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "dev": true
+        },
+        "node_modules/solhint/node_modules/minimatch": {
+            "version": "5.1.6",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+            "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/solhint/node_modules/prettier": {
+            "version": "2.8.8",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+            "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+            "dev": true,
+            "optional": true,
+            "bin": {
+                "prettier": "bin-prettier.js"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            },
+            "funding": {
+                "url": "https://github.com/prettier/prettier?sponsor=1"
+            }
+        },
+        "node_modules/solhint/node_modules/semver": {
+            "version": "7.6.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+            "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+            "dev": true,
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/solidity-comments-extractor": {
@@ -8722,7 +9336,6 @@
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
             "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "emoji-regex": "^8.0.0",
                 "is-fullwidth-code-point": "^3.0.0",
@@ -8812,7 +9425,6 @@
             "resolved": "https://registry.npmjs.org/table/-/table-6.8.2.tgz",
             "integrity": "sha512-w2sfv80nrAh2VCbqR5AK27wswXhqcck2AhfnNW76beQXskGZ1V12GwS//yYVa3d3fcvAip2OUnbDAjW2k3v9fA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "ajv": "^8.0.1",
                 "lodash.truncate": "^4.4.2",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,14 +1,11 @@
 {
     "name": "hardhat-project",
     "devDependencies": {
-        "@nomicfoundation/hardhat-toolbox": "^4.0.0",
-        "@openzeppelin/hardhat-upgrades": "^3.0.1",
+        "@nomicfoundation/hardhat-toolbox": "^5.0.0",
         "@trivago/prettier-plugin-sort-imports": "^4.3.0",
-        "axios": "^1.6.7",
-        "ethers": "^6.9.0",
-        "hardhat": "^2.19.2",
-        "prettier": "^3.1.1",
-        "web3-types": "^1.3.1",
-        "ws": "^8.16.0"
+        "axios": "^1.7.2",
+        "prettier": "^3.3.1",
+        "web3-types": "^1.6.0",
+        "ws": "^8.17.0"
     }
 }

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -10,6 +10,7 @@
         "eslint": "^8.57.0",
         "eslint-plugin-sort": "^3.0.2",
         "prettier": "^3.3.1",
+        "prettier-plugin-solidity": "^1.3.1",
         "typescript-eslint": "^7.12.0",
         "web3-types": "^1.6.0",
         "ws": "^8.17.0"

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -11,6 +11,7 @@
         "eslint-plugin-sort": "^3.0.2",
         "prettier": "^3.3.1",
         "prettier-plugin-solidity": "^1.3.1",
+        "solhint": "^5.0.1",
         "typescript-eslint": "^7.12.0",
         "web3-types": "^1.6.0",
         "ws": "^8.17.0"

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -2,9 +2,15 @@
     "name": "hardhat-project",
     "devDependencies": {
         "@nomicfoundation/hardhat-toolbox": "^5.0.0",
+        "@stylistic/eslint-plugin": "^1.8.1",
         "@trivago/prettier-plugin-sort-imports": "^4.3.0",
+        "@typescript-eslint/eslint-plugin": "^7.12.0",
+        "@typescript-eslint/parser": "^7.12.0",
         "axios": "^1.7.2",
+        "eslint": "^8.57.0",
+        "eslint-plugin-sort": "^3.0.2",
         "prettier": "^3.3.1",
+        "typescript-eslint": "^7.12.0",
         "web3-types": "^1.6.0",
         "ws": "^8.17.0"
     }

--- a/e2e/perf/load-test.ts
+++ b/e2e/perf/load-test.ts
@@ -1,10 +1,10 @@
-import { ALICE, randomAccounts } from "../test/helpers/account";
+import { randomAccounts } from "../test/helpers/account";
 import { TX_PARAMS, deployTestContractBalances, sendRawTransaction } from "../test/helpers/rpc";
 
 async function main(): Promise<void> {
     const contract = await deployTestContractBalances();
 
-    var counter = 0;
+    let counter = 0;
     while (true) {
         if (counter % 1000 == 0) {
             console.log(counter);
@@ -13,8 +13,8 @@ async function main(): Promise<void> {
         const accounts = randomAccounts(10);
         for (const account of accounts) {
             counter++;
-            let tx = await contract.add.populateTransaction(account.address, 1, { nonce: 0, ...TX_PARAMS });
-            let signedTx = await account.signer().signTransaction(tx);
+            const tx = await contract.add.populateTransaction(account.address, 1, { nonce: 0, ...TX_PARAMS });
+            const signedTx = await account.signer().signTransaction(tx);
             await sendRawTransaction(signedTx);
         }
     }

--- a/e2e/rpc-mock-server/index.js
+++ b/e2e/rpc-mock-server/index.js
@@ -29,11 +29,12 @@ app.post("/rpc", (req, res) => {
         };
 
         switch (method) {
-            case "net_listening":
+            case "net_listening": {
                 res.json({ ...response, result: true });
                 break;
+            }
 
-            case "eth_getBlockByNumber":
+            case "eth_getBlockByNumber": {
                 const blockNumberHex = req.body.params[0];
                 const blockNumber = parseInt(blockNumberHex, 16);
 
@@ -47,8 +48,9 @@ app.post("/rpc", (req, res) => {
                     res.json({ ...response, result: null });
                 }
                 break;
+            }
 
-            case "eth_getTransactionReceipt":
+            case "eth_getTransactionReceipt": {
                 const txHash = req.body.params[0];
 
                 const matchingReceipt = csvData.find((row) => "0x" + row.transaction_hash === txHash);
@@ -60,11 +62,13 @@ app.post("/rpc", (req, res) => {
                     res.json({ ...response, result: null });
                 }
                 break;
+            }
 
-            case "eth_blockNumber":
+            case "eth_blockNumber": {
                 const latestBlock = csvData.reduce((max, row) => Math.max(max, row.block_number), 0);
                 res.json({ ...response, result: `0x${latestBlock.toString(16)}` });
                 break;
+            }
         }
     } catch (error) {
         console.error("Error processing request:", error);

--- a/e2e/test/automine/e2e-json-rpc.test.ts
+++ b/e2e/test/automine/e2e-json-rpc.test.ts
@@ -7,16 +7,16 @@ import {
     CHAIN_ID,
     CHAIN_ID_DEC,
     HEX_PATTERN,
+    ONE,
     TEST_BALANCE,
     ZERO,
     send,
     sendAndGetError,
-    sendExpect,
     sendEvmMine,
+    sendExpect,
     sendReset,
     subscribeAndGetEvent,
     subscribeAndGetEventWithContract,
-    ONE,
 } from "../helpers/rpc";
 
 describe("JSON-RPC", () => {
@@ -46,7 +46,7 @@ describe("JSON-RPC", () => {
             (await sendExpect("net_version")).eq(CHAIN_ID_DEC + "");
         });
         it("web3_clientVersion", async () => {
-            let client = await sendExpect("web3_clientVersion");
+            const client = await sendExpect("web3_clientVersion");
             if (isStratus) {
                 client.eq("stratus");
             }
@@ -55,7 +55,7 @@ describe("JSON-RPC", () => {
 
     describe("Gas", () => {
         it("eth_gasPrice", async () => {
-            let gasPrice = await sendExpect("eth_gasPrice");
+            const gasPrice = await sendExpect("eth_gasPrice");
             if (isStratus) {
                 gasPrice.eq(ZERO);
             } else {
@@ -63,8 +63,8 @@ describe("JSON-RPC", () => {
             }
         });
         it("eth_estimateGas", async () => {
-            let tx = { from: ALICE.address, to: BOB.address, value: "0x1" }
-            let gas = await send("eth_estimateGas", [tx]);
+            const tx = { from: ALICE.address, to: BOB.address, value: "0x1" };
+            const gas = await send("eth_estimateGas", [tx]);
             expect(gas).match(HEX_PATTERN, "format");
 
             const gasDec = parseInt(gas, 16);
@@ -91,7 +91,7 @@ describe("JSON-RPC", () => {
             await sendReset();
         });
         it("eth_getBlockByNumber", async function () {
-            let block: Block = await send("eth_getBlockByNumber", [ZERO, true]);
+            const block: Block = await send("eth_getBlockByNumber", [ZERO, true]);
             expect(block.transactions.length).eq(0);
         });
         it("eth_getUncleByBlockHashAndIndex", async function () {
@@ -108,13 +108,13 @@ describe("JSON-RPC", () => {
         }
 
         it("evm_mine", async () => {
-            let prev_number = (await latest()).block_number;
+            const prev_number = (await latest()).block_number;
             await sendEvmMine();
             expect((await latest()).block_number).eq(prev_number + 1);
         });
 
         describe("evm_setNextBlockTimestamp", () => {
-            let target = Math.floor(Date.now() / 1000) + 10;
+            const target = Math.floor(Date.now() / 1000) + 10;
             it("Should set the next block timestamp", async () => {
                 await send("evm_setNextBlockTimestamp", [target]);
                 await sendEvmMine();
@@ -129,9 +129,9 @@ describe("JSON-RPC", () => {
 
             it("Should reset the changes when sending 0", async () => {
                 await send("evm_setNextBlockTimestamp", [0]);
-                let mined_timestamp = Math.floor(Date.now() / 1000);
+                const mined_timestamp = Math.floor(Date.now() / 1000);
                 await sendEvmMine();
-                let latest_timestamp = (await latest()).timestamp;
+                const latest_timestamp = (await latest()).timestamp;
                 expect(latest_timestamp)
                     .gte(mined_timestamp)
                     .lte(Math.floor(Date.now() / 1000));
@@ -182,21 +182,20 @@ describe("JSON-RPC", () => {
 
             it("Subscribe to newPendingTransactions receives success subscription event", async () => {
                 const waitTimeInMilliseconds = 40;
-                 const response = await subscribeAndGetEvent("newPendingTransactions", waitTimeInMilliseconds);
-                 expect(response).to.not.be.undefined;
-                 expect(response.id).to.not.be.undefined;
-                 expect(response.result).to.not.be.undefined;
+                const response = await subscribeAndGetEvent("newPendingTransactions", waitTimeInMilliseconds);
+                expect(response).to.not.be.undefined;
+                expect(response.id).to.not.be.undefined;
+                expect(response.result).to.not.be.undefined;
             });
 
-
             it("Subscribe to unsupported receives error subscription event", async () => {
-               const waitTimeInMilliseconds = 40;
+                const waitTimeInMilliseconds = 40;
                 const response = await subscribeAndGetEvent("unsupportedSubscription", waitTimeInMilliseconds);
                 expect(response).to.not.be.undefined;
                 expect(response.id).to.not.be.undefined;
                 expect(response.error).to.not.be.undefined;
                 expect(response.error.code).to.not.be.undefined;
-                expect(response.error.code).to.be.a('number');
+                expect(response.error.code).to.be.a("number");
                 expect(response.error.code).eq(-32602);
             });
 
@@ -206,30 +205,30 @@ describe("JSON-RPC", () => {
                 expect(response).to.not.be.undefined;
 
                 const params = response.params;
-                expect(params).to.have.property('subscription').that.is.a('string');
-                expect(params).to.have.property('result').that.is.an('object');
+                expect(params).to.have.property("subscription").that.is.a("string");
+                expect(params).to.have.property("result").that.is.an("object");
 
                 const result = params.result;
-                expect(result).to.have.property('hash').that.is.a('string');
-                expect(result).to.have.property('parentHash').that.is.a('string');
-                expect(result).to.have.property('sha3Uncles').that.is.a('string');
-                expect(result).to.have.property('miner').that.is.a('string');
-                expect(result).to.have.property('stateRoot').that.is.a('string');
-                expect(result).to.have.property('transactionsRoot').that.is.a('string');
-                expect(result).to.have.property('receiptsRoot').that.is.a('string');
-                expect(result).to.have.property('number').that.is.a('string');
-                expect(result).to.have.property('gasUsed').that.is.a('string');
-                expect(result).to.have.property('extraData').that.is.a('string');
-                expect(result).to.have.property('logsBloom').that.is.a('string');
-                expect(result).to.have.property('timestamp').that.is.a('string');
-                expect(result).to.have.property('difficulty').that.is.a('string');
-                expect(result).to.have.property('totalDifficulty').that.is.a('string');
-                expect(result).to.have.property('uncles').that.is.an('array');
-                expect(result).to.have.property('transactions').that.is.an('array');
-                expect(result).to.have.property('size')
-                expect(result).to.have.property('mixHash')
-                expect(result).to.have.property('nonce').that.is.a('string');
-                expect(result).to.have.property('baseFeePerGas').that.is.a('string');
+                expect(result).to.have.property("hash").that.is.a("string");
+                expect(result).to.have.property("parentHash").that.is.a("string");
+                expect(result).to.have.property("sha3Uncles").that.is.a("string");
+                expect(result).to.have.property("miner").that.is.a("string");
+                expect(result).to.have.property("stateRoot").that.is.a("string");
+                expect(result).to.have.property("transactionsRoot").that.is.a("string");
+                expect(result).to.have.property("receiptsRoot").that.is.a("string");
+                expect(result).to.have.property("number").that.is.a("string");
+                expect(result).to.have.property("gasUsed").that.is.a("string");
+                expect(result).to.have.property("extraData").that.is.a("string");
+                expect(result).to.have.property("logsBloom").that.is.a("string");
+                expect(result).to.have.property("timestamp").that.is.a("string");
+                expect(result).to.have.property("difficulty").that.is.a("string");
+                expect(result).to.have.property("totalDifficulty").that.is.a("string");
+                expect(result).to.have.property("uncles").that.is.an("array");
+                expect(result).to.have.property("transactions").that.is.an("array");
+                expect(result).to.have.property("size");
+                expect(result).to.have.property("mixHash");
+                expect(result).to.have.property("nonce").that.is.a("string");
+                expect(result).to.have.property("baseFeePerGas").that.is.a("string");
             });
 
             it("Validate logs event", async () => {
@@ -239,30 +238,34 @@ describe("JSON-RPC", () => {
                 expect(response).to.not.be.undefined;
 
                 const params = response.params;
-                expect(params).to.have.property('subscription').that.is.a('string');
-                expect(params).to.have.property('result').that.is.an('object');
+                expect(params).to.have.property("subscription").that.is.a("string");
+                expect(params).to.have.property("result").that.is.an("object");
 
                 const result = params.result;
-                expect(result).to.have.property('address').that.is.a('string');
-                expect(result).to.have.property('topics').that.is.an('array');
-                expect(result).to.have.property('data').that.is.a('string');
-                expect(result).to.have.property('blockHash').that.is.a('string');
-                expect(result).to.have.property('blockNumber').that.is.a('string');
-                expect(result).to.have.property('transactionHash').that.is.a('string');
-                expect(result).to.have.property('transactionIndex').that.is.a('string');
-                expect(result).to.have.property('logIndex').that.is.a('string');
-                expect(result).to.have.property('removed').that.is.a('boolean');
+                expect(result).to.have.property("address").that.is.a("string");
+                expect(result).to.have.property("topics").that.is.an("array");
+                expect(result).to.have.property("data").that.is.a("string");
+                expect(result).to.have.property("blockHash").that.is.a("string");
+                expect(result).to.have.property("blockNumber").that.is.a("string");
+                expect(result).to.have.property("transactionHash").that.is.a("string");
+                expect(result).to.have.property("transactionIndex").that.is.a("string");
+                expect(result).to.have.property("logIndex").that.is.a("string");
+                expect(result).to.have.property("removed").that.is.a("boolean");
             });
 
             it("Validate newPendingTransactions event", async () => {
                 await sendReset();
                 const waitTimeInMilliseconds = 40;
-                const response = await subscribeAndGetEventWithContract("newPendingTransactions", waitTimeInMilliseconds, 2);
+                const response = await subscribeAndGetEventWithContract(
+                    "newPendingTransactions",
+                    waitTimeInMilliseconds,
+                    2,
+                );
                 expect(response).to.not.be.undefined;
 
                 const params = response.params;
-                expect(params).to.have.property('subscription').that.is.a('string');
-                expect(params).to.have.property('result').that.is.an('string');
+                expect(params).to.have.property("subscription").that.is.a("string");
+                expect(params).to.have.property("result").that.is.an("string");
             });
         });
     });

--- a/e2e/test/automine/e2e-tx-parallel-contract-dense-storage.abm.test.ts
+++ b/e2e/test/automine/e2e-tx-parallel-contract-dense-storage.abm.test.ts
@@ -1,5 +1,4 @@
-import { Account, ALICE, BOB, randomAccounts } from "../helpers/account";
-import { deployTestContractDenseStorage, sendRawTransactions, } from "../helpers/rpc";
+import { ALICE, Account, BOB, randomAccounts } from "../helpers/account";
 import {
     AccountRecord,
     applyRecordChange,
@@ -7,8 +6,9 @@ import {
     defineRecordChange,
     initialRecord,
     inverseRecordChange,
-    prepareSignedTxOfRecordChange
+    prepareSignedTxOfRecordChange,
 } from "../helpers/contract-dense-storage";
+import { deployTestContractDenseStorage, sendRawTransactions } from "../helpers/rpc";
 
 describe("Transaction: parallel for the 'TestContractDenseStorage' contract", async () => {
     it("Parallel transactions execute properly when no reverts are expected", async () => {
@@ -21,7 +21,6 @@ describe("Transaction: parallel for the 'TestContractDenseStorage' contract", as
         // Set initial records
         await contract.set(ALICE.address, expectedRecords[ALICE.address]);
         await contract.set(BOB.address, expectedRecords[BOB.address]);
-
 
         // Prepare a pair of transactions: one for Alice and another for Bob
         const txCountPerUser = 32;

--- a/e2e/test/automine/e2e-tx-parallel-contract.test.ts
+++ b/e2e/test/automine/e2e-tx-parallel-contract.test.ts
@@ -75,7 +75,7 @@ describe("Transaction: parallel TestContractBalances", async () => {
         const signedTxs = [];
         const senders = randomAccounts(20);
         for (const sender of senders) {
-            let nonce = await sendGetNonce(sender.address);
+            const nonce = await sendGetNonce(sender.address);
             const tx = await _contract.connect(sender.signer()).sub.populateTransaction(ALICE.address, 75, {
                 nonce: nonce,
                 ...TX_PARAMS,
@@ -84,8 +84,8 @@ describe("Transaction: parallel TestContractBalances", async () => {
         }
 
         // send transactions in parallel
-        let hashes = await sendRawTransactions(signedTxs);
-        let failed = hashes.filter(x => x === undefined).length;
+        const hashes = await sendRawTransactions(signedTxs);
+        const failed = hashes.filter((x) => x === undefined).length;
 
         // check remaining balance
         expect(await _contract.get(ALICE.address)).eq(15);

--- a/e2e/test/automine/e2e-tx-serial-contract.test.ts
+++ b/e2e/test/automine/e2e-tx-serial-contract.test.ts
@@ -1,12 +1,14 @@
 import { expect } from "chai";
+import { network } from "hardhat";
+import { Transaction } from "web3-types";
 
 import { TestContractBalances } from "../../typechain-types";
 import { CHARLIE } from "../helpers/account";
 import {
-    calculateSlotPosition,
     CHAIN_ID,
-    deployTestContractBalances,
     HEX_PATTERN,
+    calculateSlotPosition,
+    deployTestContractBalances,
     send,
     sendExpect,
     sendGetBlockNumber,
@@ -15,8 +17,6 @@ import {
     toHex,
     toPaddedHex,
 } from "../helpers/rpc";
-import { Transaction } from "web3-types";
-import { network } from "hardhat";
 
 // Test contract topics
 const CONTRACT_TOPIC_ADD = "0x2728c9d3205d667bbc0eefdfeda366261b4d021949630c047f3e5834b30611ab";
@@ -43,9 +43,9 @@ describe("Transaction: serial TestContractBalances", () => {
     it("Deployment transaction receipt", async () => {
         const deploymentTransactionHash = _contract.deploymentTransaction()?.hash;
         expect(deploymentTransactionHash).not.eq(undefined);
-        
+
         const receipt = await send("eth_getTransactionReceipt", [deploymentTransactionHash]);
-        
+
         // Fields existence and null checks
         expect(receipt.contractAddress).not.eq(null, "receipt.contractAddress");
         expect(receipt.transactionHash).not.eq(null, "receipt.transactionHash");
@@ -64,15 +64,21 @@ describe("Transaction: serial TestContractBalances", () => {
         // contract address
         const expectedContractAddress = _contract.target as string;
         const actualContractAddress = receipt.contractAddress as string;
-        expect(expectedContractAddress.toLowerCase()).eq(actualContractAddress.toLowerCase(), "receipt.contractAddress");
+        expect(expectedContractAddress.toLowerCase()).eq(
+            actualContractAddress.toLowerCase(),
+            "receipt.contractAddress",
+        );
 
         // transaction hash
         const expectedTransactionHash = deploymentTransactionHash as string;
         const actualTransactionHash = receipt.transactionHash as string;
-        expect(expectedTransactionHash.toLowerCase()).eq(actualTransactionHash.toLowerCase(), "receipt.transactionHash");
+        expect(expectedTransactionHash.toLowerCase()).eq(
+            actualTransactionHash.toLowerCase(),
+            "receipt.transactionHash",
+        );
 
         // transaction index
-        const expectedTransactionIndex = '0x0';
+        const expectedTransactionIndex = "0x0";
         const actualTransactionIndex = receipt.transactionIndex as number;
         expect(expectedTransactionIndex).eq(actualTransactionIndex, "receipt.transactionIndex");
 
@@ -80,7 +86,7 @@ describe("Transaction: serial TestContractBalances", () => {
         expect(receipt.from.toLowerCase()).eq(CHARLIE.address.toLowerCase(), "receipt.from");
 
         // status
-        const STATUS_SUCCESS = '0x1';
+        const STATUS_SUCCESS = "0x1";
         expect(receipt.status).eq(STATUS_SUCCESS, "receipt.status");
     });
 
@@ -89,19 +95,19 @@ describe("Transaction: serial TestContractBalances", () => {
         expect(deploymentTransactionHash).not.eq(undefined);
 
         const transaction: Transaction = await send("eth_getTransactionByHash", [deploymentTransactionHash]);
-        
+
         expect(transaction.from).eq(CHARLIE.address, "tx.from");
         expect(transaction.to).eq(null, "tx.to");
-        expect(transaction.value).eq('0x0', "tx.value");
+        expect(transaction.value).eq("0x0", "tx.value");
         expect(transaction.gas).match(HEX_PATTERN, "tx.gas format");
         expect(transaction.gasPrice).match(HEX_PATTERN, "tx.gasPrice format");
         expect(transaction.input).match(HEX_PATTERN, "tx.input format");
-        expect(transaction.nonce).eq('0x0', "tx.nonce");
+        expect(transaction.nonce).eq("0x0", "tx.nonce");
 
-        if (network.name === 'stratus') {
+        if (network.name === "stratus") {
             expect(transaction.chainId).eq(CHAIN_ID, "tx.chainId");
         }
-        
+
         expect(transaction.v).match(HEX_PATTERN, "tx.v format");
         expect(transaction.r).match(HEX_PATTERN, "tx.r format");
         expect(transaction.s).match(HEX_PATTERN, "tx.s format");
@@ -150,7 +156,7 @@ describe("Transaction: serial TestContractBalances", () => {
     });
 
     it("Generates logs", async () => {
-        let filter = { address: _contract.target, fromBlock: toHex(_block + 0) };
+        const filter = { address: _contract.target, fromBlock: toHex(_block + 0) };
 
         // filter fromBlock
         (await sendExpect("eth_getLogs", [{ ...filter, fromBlock: toHex(_block + 0) }])).length(3);

--- a/e2e/test/automine/e2e-tx-serial-transfer.test.ts
+++ b/e2e/test/automine/e2e-tx-serial-transfer.test.ts
@@ -22,17 +22,17 @@ import {
 } from "../helpers/rpc";
 
 describe("Transaction: serial transfer", () => {
-    var _tx: Transaction;
-    var _txHash: string;
-    var _block: Block;
-    var _txSentTimestamp: number;
-    var new_account: Account;
+    let _tx: Transaction;
+    let _txHash: string;
+    let _block: Block;
+    let _txSentTimestamp: number;
+    let new_account: Account;
 
     it("Resets blockchain", async () => {
         await sendReset();
     });
     it("Send transaction", async () => {
-        let txSigned = await ALICE.signWeiTransfer(BOB.address, TEST_TRANSFER);
+        const txSigned = await ALICE.signWeiTransfer(BOB.address, TEST_TRANSFER);
         _txSentTimestamp = Math.floor(Date.now() / 1000);
         _txHash = await sendRawTransaction(txSigned);
         expect(_txHash).eq(keccak256(txSigned));
@@ -74,11 +74,11 @@ describe("Transaction: serial transfer", () => {
         expect(fromHexTimestamp(_block.timestamp)).lte(Date.now());
 
         // ParentHash is the previous block's hash
-        let parentBlock = await send("eth_getBlockByNumber", [ZERO, true]);
+        const parentBlock = await send("eth_getBlockByNumber", [ZERO, true]);
         expect(_block.parentHash).eq(parentBlock.hash);
     });
     it("Receipt is created", async () => {
-        let receipt: TransactionReceipt = await send("eth_getTransactionReceipt", [_txHash]);
+        const receipt: TransactionReceipt = await send("eth_getTransactionReceipt", [_txHash]);
         expect(receipt.blockNumber).eq(_block.number, "receipt.blockNumber");
         expect(receipt.blockHash).eq(_block.hash, "receipt.blockHash");
         expect(receipt.transactionHash).eq(_txHash, "rceipt.txHash");
@@ -108,7 +108,7 @@ describe("Transaction: serial transfer", () => {
     });
     it("Send transaction to new account", async () => {
         new_account = randomAccounts(1)[0];
-        let txSigned = await ALICE.signWeiTransfer(new_account.address, TEST_TRANSFER, 1);
+        const txSigned = await ALICE.signWeiTransfer(new_account.address, TEST_TRANSFER, 1);
         _txSentTimestamp = Math.floor(Date.now() / 1000);
         _txHash = await sendRawTransaction(txSigned);
     });

--- a/e2e/test/external/e2e-multiple-tx.test.ts
+++ b/e2e/test/external/e2e-multiple-tx.test.ts
@@ -26,13 +26,13 @@ describe("Multiple Transactions Per Block", () => {
 
         const txHashes = await sendRawTransactions(signedTxs);
 
-        const latestBlockBeforeMining = await send('eth_getBlockByNumber', ['latest', true]);
+        const latestBlockBeforeMining = await send("eth_getBlockByNumber", ["latest", true]);
 
         // mine the block
         await sendEvmMine();
 
         // get the latest block after mining
-        const latestBlockAfterMining = await send('eth_getBlockByNumber', ['latest', true]);
+        const latestBlockAfterMining = await send("eth_getBlockByNumber", ["latest", true]);
 
         // check if block was mined
         expect(latestBlockAfterMining).to.exist;
@@ -41,27 +41,27 @@ describe("Multiple Transactions Per Block", () => {
         expect(latestBlockAfterMining.hash).to.not.equal(latestBlockBeforeMining.hash);
 
         // check if all transactions are in the block
-        for (let txHash of txHashes) {
+        for (const txHash of txHashes) {
             expect(latestBlockAfterMining.transactions.map((tx: any) => tx.hash)).to.include(txHash);
         }
 
         // check if transactions receipt are valid
-        for (let txHash of txHashes) {
-            const receipt = await send('eth_getTransactionReceipt', [txHash]);
+        for (const txHash of txHashes) {
+            const receipt = await send("eth_getTransactionReceipt", [txHash]);
             expect(receipt).to.exist;
             expect(receipt.transactionHash).to.equal(txHash);
 
             expect(receipt.blockHash).to.equal(latestBlockAfterMining.hash);
             expect(receipt.blockNumber).to.equal(latestBlockAfterMining.number);
             expect(receipt.contractAddress).to.be.null;
-            expect(receipt.cumulativeGasUsed).to.be.a('string');
-            expect(receipt.from).to.be.a('string');
-            expect(receipt.gasUsed).to.be.a('string');
-            expect(receipt.logs).to.be.an('array');
-            expect(receipt.logsBloom).to.be.a('string');
-            expect(receipt.status).to.be.a('string');
-            expect(receipt.to).to.be.a('string');
-            expect(receipt.transactionIndex).to.be.a('string');
+            expect(receipt.cumulativeGasUsed).to.be.a("string");
+            expect(receipt.from).to.be.a("string");
+            expect(receipt.gasUsed).to.be.a("string");
+            expect(receipt.logs).to.be.an("array");
+            expect(receipt.logsBloom).to.be.a("string");
+            expect(receipt.status).to.be.a("string");
+            expect(receipt.to).to.be.a("string");
+            expect(receipt.transactionIndex).to.be.a("string");
         }
 
         // check counterParty balance

--- a/e2e/test/external/e2e-tx-parallel-contract-dense-storage.ebm.test.ts
+++ b/e2e/test/external/e2e-tx-parallel-contract-dense-storage.ebm.test.ts
@@ -1,5 +1,4 @@
-import { Account, ALICE, BOB, randomAccounts } from "../helpers/account";
-import { deployTestContractDenseStorage, sendEvmMine, sendRawTransactions, } from "../helpers/rpc";
+import { ALICE, Account, BOB, randomAccounts } from "../helpers/account";
 import {
     AccountRecord,
     applyRecordChange,
@@ -7,8 +6,9 @@ import {
     defineRecordChange,
     initialRecord,
     inverseRecordChange,
-    prepareSignedTxOfRecordChange
+    prepareSignedTxOfRecordChange,
 } from "../helpers/contract-dense-storage";
+import { deployTestContractDenseStorage, sendEvmMine, sendRawTransactions } from "../helpers/rpc";
 
 describe("Transaction: parallel for the 'TestContractDenseStorage' contract", async () => {
     it("Parallel transactions execute properly when no reverts are expected", async () => {
@@ -24,7 +24,6 @@ describe("Transaction: parallel for the 'TestContractDenseStorage' contract", as
         await sendEvmMine();
         await contract.set(BOB.address, expectedRecords[BOB.address]);
         await sendEvmMine();
-
 
         // Prepare a pair of transactions: one for Alice and another for Bob
         const txCountPerUser = 32;

--- a/e2e/test/helpers/account.ts
+++ b/e2e/test/helpers/account.ts
@@ -69,7 +69,7 @@ export const TEST_ACCOUNTS = [ALICE, BOB, CHARLIE, DAVE, EVE, FERDIE];
 export function randomAccounts(n: number): Account[] {
     const wallets: Account[] = [];
     for (let i = 0; i < n; i++) {
-        let wallet = Wallet.createRandom();
+        const wallet = Wallet.createRandom();
         wallets.push(new Account(wallet.address, wallet.privateKey));
     }
     return wallets;

--- a/e2e/test/helpers/contract-dense-storage.ts
+++ b/e2e/test/helpers/contract-dense-storage.ts
@@ -1,7 +1,8 @@
 import { expect } from "chai";
-import { prepareSignedTx } from "./rpc";
-import { Account } from "./account";
+
 import { TestContractDenseStorage } from "../../typechain-types";
+import { Account } from "./account";
+import { prepareSignedTx } from "./rpc";
 
 export interface AccountRecord {
     field16: bigint;
@@ -10,7 +11,7 @@ export interface AccountRecord {
     field64: bigint;
     field128: bigint;
 
-    [key: string]: bigint;  // Index signature
+    [key: string]: bigint; // Index signature
 }
 
 export const initialRecord: AccountRecord = {
@@ -18,7 +19,7 @@ export const initialRecord: AccountRecord = {
     reserve: BigInt("0xABCD"),
     field32: BigInt(2) ** BigInt(32 - 1), // 0x8000_0000
     field64: BigInt(2) ** BigInt(64 - 1), // 0x8000_0000_0000_0000
-    field128: BigInt(2) ** BigInt(128 - 1) // 0x8000_0000_0000_0000_0000_0000_0000_0000
+    field128: BigInt(2) ** BigInt(128 - 1), // 0x8000_0000_0000_0000_0000_0000_0000_0000
 };
 
 export interface RecordChange {
@@ -41,7 +42,7 @@ export function defineRecordChange(index: number): RecordChange {
     if ((index & 4) !== 0) {
         changeOfField64 *= BigInt(-1);
     }
-    let changeOfField128: bigint = BigInt(2) ** BigInt(128 - 6) - BigInt(7777 * index);
+    const changeOfField128: bigint = BigInt(2) ** BigInt(128 - 6) - BigInt(7777 * index);
     if ((index & 8) !== 0) {
         changeOfField64 *= BigInt(-1);
     }
@@ -50,7 +51,7 @@ export function defineRecordChange(index: number): RecordChange {
         forField16: changeOfField16,
         forField32: changeOfField32,
         forField64: changeOfField64,
-        forField128: changeOfField128
+        forField128: changeOfField128,
     };
 }
 
@@ -63,10 +64,7 @@ export function inverseRecordChange(change: RecordChange): RecordChange {
     };
 }
 
-export function applyRecordChange(
-    record: AccountRecord,
-    change: RecordChange,
-) {
+export function applyRecordChange(record: AccountRecord, change: RecordChange) {
     record.field16 += change.forField16;
     record.field32 += change.forField32;
     record.field64 += change.forField64;
@@ -74,10 +72,10 @@ export function applyRecordChange(
 }
 
 export function compareRecords(actualRecord: any, expectedRecord: AccountRecord) {
-    Object.keys(expectedRecord).forEach(property => {
+    Object.keys(expectedRecord).forEach((property) => {
         expect(actualRecord[property]).to.eq(
             expectedRecord[property],
-            `Mismatch in the "${property}" property of the storage record`
+            `Mismatch in the "${property}" property of the storage record`,
         );
     });
 }
@@ -86,7 +84,7 @@ export async function prepareSignedTxOfRecordChange(
     contract: TestContractDenseStorage,
     sender: Account,
     targetAccount: Account,
-    recordChange: RecordChange
+    recordChange: RecordChange,
 ): Promise<string> {
     return await prepareSignedTx({
         contract,
@@ -97,7 +95,7 @@ export async function prepareSignedTxOfRecordChange(
             recordChange.forField16,
             recordChange.forField32,
             recordChange.forField64,
-            recordChange.forField128
-        ]
+            recordChange.forField128,
+        ],
     });
 }

--- a/e2e/test/helpers/misc.ts
+++ b/e2e/test/helpers/misc.ts
@@ -3,7 +3,7 @@ export function checkTimeEnough(begTimeInMs: number, timeoutInMs: number) {
     if (currentTimeInMs - begTimeInMs >= timeoutInMs) {
         throw new Error(
             "The time to properly check the conditions has expired. " +
-            "Try increasing the block interval of the blockchain you are testing"
+            "Try increasing the block interval of the blockchain you are testing",
         );
     }
 }

--- a/e2e/test/helpers/network.ts
+++ b/e2e/test/helpers/network.ts
@@ -1,4 +1,5 @@
 import { network } from "hardhat";
+
 import { defineBlockMiningIntervalInMs } from "../../hardhat.config";
 
 export enum Network {
@@ -10,7 +11,7 @@ export enum Network {
 export enum BlockMode {
     Automine = "automine",
     External = "external",
-    Interval = "interval"
+    Interval = "interval",
 }
 
 export function currentNetwork(): Network {

--- a/e2e/test/helpers/rpc.ts
+++ b/e2e/test/helpers/rpc.ts
@@ -57,16 +57,7 @@ const providerOptions: JsonRpcApiProviderOptions = {
     batchMaxCount: 1, // Do not unite the request in batches
 };
 
-export let ETHERJS = new JsonRpcProvider(providerUrl, undefined, providerOptions);
-
-export function updateProviderUrl(newUrl: string) {
-    providerUrl = newUrl;
-    ETHERJS = new JsonRpcProvider(providerUrl);
-}
-
-export function getProvider() {
-    return ETHERJS;
-}
+export const ETHERJS = new JsonRpcProvider(providerUrl, undefined, providerOptions);
 
 // Configure RPC logger if RPC_LOG env-var is configured.
 function log(event: any) {
@@ -417,7 +408,7 @@ export async function pollForTransaction(
         throw new Error("Transaction not found");
     }
     tx = await tx;
-    const txHash = (typeof tx === "string") ? tx : tx.hash;
+    const txHash = typeof tx === "string" ? tx : tx.hash;
     const [txReceipt] = await pollForTransactions([txHash], options);
     return txReceipt;
 }

--- a/e2e/test/helpers/rpc.ts
+++ b/e2e/test/helpers/rpc.ts
@@ -6,9 +6,9 @@ import {
     Contract,
     JsonRpcApiProviderOptions,
     JsonRpcProvider,
-    keccak256,
     TransactionReceipt,
-    TransactionResponse
+    TransactionResponse,
+    keccak256,
 } from "ethers";
 import { config, ethers } from "hardhat";
 import { HttpNetworkConfig } from "hardhat/types";
@@ -54,14 +54,10 @@ if (!providerUrl) {
 
 const providerOptions: JsonRpcApiProviderOptions = {
     cacheTimeout: -1, // Do not use cash request results
-    batchMaxCount: 1 // Do not unite the request in batches
+    batchMaxCount: 1, // Do not unite the request in batches
 };
 
-export let ETHERJS = new JsonRpcProvider(
-    providerUrl,
-    undefined,
-    providerOptions
-);
+export let ETHERJS = new JsonRpcProvider(providerUrl, undefined, providerOptions);
 
 export function updateProviderUrl(newUrl: string) {
     providerUrl = newUrl;
@@ -91,7 +87,7 @@ function log(event: any) {
 }
 
 if (process.env.RPC_LOG) {
-    ETHERJS.on("debug", log).catch(error => {
+    ETHERJS.on("debug", log).catch((error) => {
         console.error("Registering listener for a debug event of the RPC failed:", error);
         process.exit(1);
     });
@@ -179,7 +175,7 @@ export function toPaddedHex(number: number | bigint, bytes: number): string {
 
 // Converts a hex string timestamp into unix time in seconds
 export function fromHexTimestamp(timestamp: Numbers): number {
-    let value = timestamp.valueOf();
+    const value = timestamp.valueOf();
     if (typeof value == "string") return parseInt(value, 16);
     else throw new Error("Expected block timestamp to be a hexstring. Got: " + timestamp.valueOf());
 }
@@ -270,7 +266,7 @@ function addOpenListener(socket: WebSocket, subscription: string, params: any) {
 function addMessageListener(
     socket: WebSocket,
     messageToReturn: number,
-    callback: (messageEvent: { data: string }) => Promise<void>
+    callback: (messageEvent: { data: string }) => Promise<void>,
 ): Promise<any> {
     return new Promise((resolve) => {
         let messageCount = 0;
@@ -295,7 +291,7 @@ async function asyncContractOperation(contract: TestContractBalances) {
     const contractOps = contract.connect(CHARLIE.signer());
     await contractOps.add(CHARLIE.address, 10, { nonce: nonce++ });
 
-    return new Promise(resolve => setTimeout(resolve, 1000));
+    return new Promise((resolve) => setTimeout(resolve, 1000));
 }
 
 /// Start a subscription and return its N-th event
@@ -306,12 +302,12 @@ export async function subscribeAndGetEvent(
 ): Promise<any> {
     const socket = openWebSocketConnection();
     addOpenListener(socket, subscription, {});
-    const event = await addMessageListener(socket, messageToReturn, async (_messageEvent) => {
-    });
+    const event = await addMessageListener(socket, messageToReturn, async (_messageEvent) => {});
 
     // Wait for the specified time, if necessary
-    if (waitTimeInMilliseconds > 0)
+    if (waitTimeInMilliseconds > 0) {
         await new Promise((resolve) => setTimeout(resolve, waitTimeInMilliseconds));
+    }
 
     return event;
 }
@@ -325,25 +321,25 @@ export async function subscribeAndGetEventWithContract(
     const contract = await deployTestContractBalances();
     const contractAddress = await contract.getAddress();
     const socket = openWebSocketConnection();
-    addOpenListener(socket, subscription, { "address": contractAddress });
+    addOpenListener(socket, subscription, { address: contractAddress });
     const event = await addMessageListener(socket, messageToReturn, async (_messageEvent) => {
         await asyncContractOperation(contract);
     });
 
     // Wait for the specified time, if necessary
-    if (waitTimeInMilliseconds > 0)
+    if (waitTimeInMilliseconds > 0) {
         await new Promise((resolve) => setTimeout(resolve, waitTimeInMilliseconds));
+    }
 
     return event;
 }
 
-
 // Prepares a signed transaction to interact with a contract
 export async function prepareSignedTx(props: {
-    contract: BaseContract,
-    account: Account,
-    methodName: string,
-    methodParameters: any[]
+    contract: BaseContract;
+    account: Account;
+    methodName: string;
+    methodParameters: any[];
 }): Promise<string> {
     const { contract, account, methodName, methodParameters } = props;
     const nonce = await sendGetNonce(account);
@@ -352,7 +348,8 @@ export async function prepareSignedTx(props: {
         {
             nonce,
             ...TX_PARAMS,
-        });
+        },
+    );
     return await account.signer().signTransaction(tx);
 }
 
@@ -360,16 +357,16 @@ export async function prepareSignedTx(props: {
 export async function pollForTransactions(
     txHashes: string[],
     options: {
-        timeoutInMs?: number,
-        pollingIntervalInMs?: number
-    } = { timeoutInMs: DEFAULT_TX_TIMEOUT_IN_MS, pollingIntervalInMs: DEFAULT_TX_TIMEOUT_IN_MS / 100 }
+        timeoutInMs?: number;
+        pollingIntervalInMs?: number;
+    } = { timeoutInMs: DEFAULT_TX_TIMEOUT_IN_MS, pollingIntervalInMs: DEFAULT_TX_TIMEOUT_IN_MS / 100 },
 ): Promise<TransactionReceipt[]> {
     const { timeoutInMs, pollingIntervalInMs } = normalizePollingOptions(options);
     const startTimestamp = Date.now();
     const transactionReceipts: TransactionReceipt[] = [];
     const remainingTxHashes: Set<string> = new Set(txHashes);
     while (1) {
-        let requestTimeInMs = Date.now();
+        const requestTimeInMs = Date.now();
         const receiptPromises: Promise<TransactionReceipt | null>[] = [];
         for (const txHash of remainingTxHashes) {
             receiptPromises.push(ETHERJS.getTransactionReceipt(txHash));
@@ -388,7 +385,7 @@ export async function pollForTransactions(
         if (currentTimeInMs - startTimestamp >= timeoutInMs) {
             throw new Error(
                 `Failed to wait for transaction minting: timeout of ${timeoutInMs} ms. ` +
-                `Still waiting the transactions with hashes: ${Array.from(remainingTxHashes)}`
+                `Still waiting the transactions with hashes: ${Array.from(remainingTxHashes)}`,
             );
         }
         const cycleDurationInMs = currentTimeInMs - requestTimeInMs;
@@ -397,8 +394,8 @@ export async function pollForTransactions(
         }
     }
     const orderedTransactionReceipts: TransactionReceipt[] = [];
-    txHashes.forEach(txHash => {
-        const targetReceipt = transactionReceipts.find(receipt => receipt.hash == txHash);
+    txHashes.forEach((txHash) => {
+        const targetReceipt = transactionReceipts.find((receipt) => receipt.hash == txHash);
         if (!targetReceipt) {
             throw new Error(`Failed to wait for transaction minting: a logical error with hash: ${txHash}`);
         } else {
@@ -412,9 +409,9 @@ export async function pollForTransactions(
 export async function pollForTransaction(
     tx: TransactionResponse | string | Promise<TransactionResponse> | Promise<string> | null | undefined,
     options: {
-        timeoutInMs?: number,
-        pollingIntervalInMs?: number
-    } = { timeoutInMs: DEFAULT_TX_TIMEOUT_IN_MS, pollingIntervalInMs: DEFAULT_TX_TIMEOUT_IN_MS / 100 }
+        timeoutInMs?: number;
+        pollingIntervalInMs?: number;
+    } = { timeoutInMs: DEFAULT_TX_TIMEOUT_IN_MS, pollingIntervalInMs: DEFAULT_TX_TIMEOUT_IN_MS / 100 },
 ): Promise<TransactionReceipt> {
     if (!tx) {
         throw new Error("Transaction not found");
@@ -429,9 +426,9 @@ export async function pollForTransaction(
 export async function pollForBlock(
     blockNumber: number,
     options: {
-        timeoutInMs?: number,
-        pollingIntervalInMs?: number
-    } = { timeoutInMs: DEFAULT_TX_TIMEOUT_IN_MS, pollingIntervalInMs: DEFAULT_TX_TIMEOUT_IN_MS / 100 }
+        timeoutInMs?: number;
+        pollingIntervalInMs?: number;
+    } = { timeoutInMs: DEFAULT_TX_TIMEOUT_IN_MS, pollingIntervalInMs: DEFAULT_TX_TIMEOUT_IN_MS / 100 },
 ): Promise<Block> {
     const { timeoutInMs, pollingIntervalInMs } = normalizePollingOptions(options);
     const startTimeInMs = Date.now();
@@ -439,9 +436,7 @@ export async function pollForBlock(
     let block: Block | null = await ETHERJS.getBlock(blockNumber);
     while (!block) {
         if (Date.now() - startTimeInMs >= timeoutInMs) {
-            throw new Error(
-                `Failed to wait for minting of block ${blockNumber}: timeout of ${timeoutInMs} ms. `
-            );
+            throw new Error(`Failed to wait for minting of block ${blockNumber}: timeout of ${timeoutInMs} ms. `);
         }
         const cycleDurationInMs = Date.now() - requestTimeInMs;
         if (cycleDurationInMs < pollingIntervalInMs) {
@@ -456,23 +451,25 @@ export async function pollForBlock(
 // Polls for the next block is minted
 export async function pollForNextBlock(
     options: {
-        timeoutInMs?: number,
-        pollingIntervalInMs?: number
-    } = { timeoutInMs: DEFAULT_TX_TIMEOUT_IN_MS, pollingIntervalInMs: DEFAULT_TX_TIMEOUT_IN_MS / 100 }
+        timeoutInMs?: number;
+        pollingIntervalInMs?: number;
+    } = { timeoutInMs: DEFAULT_TX_TIMEOUT_IN_MS, pollingIntervalInMs: DEFAULT_TX_TIMEOUT_IN_MS / 100 },
 ): Promise<Block> {
     const latestBlockNumber = await sendGetBlockNumber();
     return pollForBlock(latestBlockNumber + 1, options);
 }
 
 // Normalizes the options for poll functions
-function normalizePollingOptions(options: {
-    timeoutInMs?: number;
-    pollingIntervalInMs?: number
-} = {}): { timeoutInMs: number; pollingIntervalInMs: number } {
+function normalizePollingOptions(
+    options: {
+        timeoutInMs?: number;
+        pollingIntervalInMs?: number;
+    } = {},
+): { timeoutInMs: number; pollingIntervalInMs: number } {
     const timeoutInMs: number = options.timeoutInMs ? options.timeoutInMs : DEFAULT_TX_TIMEOUT_IN_MS;
     const pollingIntervalInMs: number = options.pollingIntervalInMs ? options.pollingIntervalInMs : timeoutInMs / 100;
     return {
         timeoutInMs,
-        pollingIntervalInMs
+        pollingIntervalInMs,
     };
 }

--- a/e2e/test/issues/automine/e2e-abm-logs.ts
+++ b/e2e/test/issues/automine/e2e-abm-logs.ts
@@ -3,14 +3,11 @@ import { TransactionReceipt } from "ethers";
 
 import { ALICE } from "../../helpers/account";
 import { BlockMode, currentBlockMode } from "../../helpers/network";
-import { deployTestContractBalances, ETHERJS, send, toHex } from "../../helpers/rpc";
+import { ETHERJS, deployTestContractBalances, send, toHex } from "../../helpers/rpc";
 
 describe("Known issues for the auto block mining mode. The results of the 'eth_getLogs' API call are", async () => {
     before(async () => {
-        expect(currentBlockMode()).eq(
-            BlockMode.Automine,
-            "Wrong block mining mode is used"
-        );
+        expect(currentBlockMode()).eq(BlockMode.Automine, "Wrong block mining mode is used");
     });
 
     it("Correct for next non-existent blocks after a contract transaction", async () => {
@@ -23,13 +20,13 @@ describe("Known issues for the auto block mining mode. The results of the 'eth_g
         const txBlockNumber = txReceipt?.blockNumber ?? 0;
 
         expect(
-            await send("eth_getLogs", [{ fromBlock: toHex(txBlockNumber), address: contract.target }])
+            await send("eth_getLogs", [{ fromBlock: toHex(txBlockNumber), address: contract.target }]),
         ).length(1);
         expect(
-            await send("eth_getLogs", [{ fromBlock: toHex(txBlockNumber + 1), address: contract.target }])
+            await send("eth_getLogs", [{ fromBlock: toHex(txBlockNumber + 1), address: contract.target }]),
         ).length(0);
         expect(
-            await send("eth_getLogs", [{ fromBlock: toHex(txBlockNumber + 2), address: contract.target }])
+            await send("eth_getLogs", [{ fromBlock: toHex(txBlockNumber + 2), address: contract.target }]),
         ).length(0);
     });
 });

--- a/e2e/test/issues/external/e2e-ebm-logs.ts
+++ b/e2e/test/issues/external/e2e-ebm-logs.ts
@@ -3,14 +3,11 @@ import { TransactionReceipt } from "ethers";
 
 import { ALICE } from "../../helpers/account";
 import { BlockMode, currentBlockMode } from "../../helpers/network";
-import { deployTestContractBalances, ETHERJS, send, sendEvmMine, toHex } from "../../helpers/rpc";
+import { ETHERJS, deployTestContractBalances, send, sendEvmMine, toHex } from "../../helpers/rpc";
 
 describe("Known issues for the external block mining mode. The 'eth_getLogs' API call", async () => {
     before(async () => {
-        expect(currentBlockMode()).eq(
-            BlockMode.External,
-            "Wrong block mining mode is used"
-        );
+        expect(currentBlockMode()).eq(BlockMode.External, "Wrong block mining mode is used");
     });
 
     it("Returns an expected array for next non-existent blocks after a contract transaction", async () => {
@@ -25,13 +22,13 @@ describe("Known issues for the external block mining mode. The 'eth_getLogs' API
         const txBlockNumber = txReceipt?.blockNumber ?? 0;
 
         expect(
-            await send("eth_getLogs", [{ fromBlock: toHex(txBlockNumber), address: contract.target }])
+            await send("eth_getLogs", [{ fromBlock: toHex(txBlockNumber), address: contract.target }]),
         ).length(1);
         expect(
-            await send("eth_getLogs", [{ fromBlock: toHex(txBlockNumber + 1), address: contract.target }])
+            await send("eth_getLogs", [{ fromBlock: toHex(txBlockNumber + 1), address: contract.target }]),
         ).length(0);
         expect(
-            await send("eth_getLogs", [{ fromBlock: toHex(txBlockNumber + 2), address: contract.target }])
+            await send("eth_getLogs", [{ fromBlock: toHex(txBlockNumber + 2), address: contract.target }]),
         ).length(0);
     });
 });

--- a/e2e/test/issues/external/e2e-ebm-pending-transactions.ts
+++ b/e2e/test/issues/external/e2e-ebm-pending-transactions.ts
@@ -1,21 +1,13 @@
 import { expect } from "chai";
-import { keccak256, TransactionResponse } from "ethers";
+import { TransactionResponse, keccak256 } from "ethers";
 
 import { ALICE, BOB } from "../../helpers/account";
 import { BlockMode, currentBlockMode } from "../../helpers/network";
-import {
-    ETHERJS,
-    sendEvmMine,
-    sendGetNonce,
-    sendRawTransaction,
-} from "../../helpers/rpc";
+import { ETHERJS, sendEvmMine, sendGetNonce, sendRawTransaction } from "../../helpers/rpc";
 
 describe("Known issues for the external block mining mode. Pending transactions", async () => {
     before(async () => {
-        expect(currentBlockMode()).eq(
-            BlockMode.External,
-            "Wrong block mining mode is used"
-        );
+        expect(currentBlockMode()).eq(BlockMode.External, "Wrong block mining mode is used");
     });
 
     it("Can be fetched by the hash before and after minting", async () => {

--- a/e2e/test/issues/external/e2e-ebm-transaction-sending.ts
+++ b/e2e/test/issues/external/e2e-ebm-transaction-sending.ts
@@ -1,11 +1,11 @@
 import { expect } from "chai";
-import { keccak256, TransactionReceipt } from "ethers";
+import { TransactionReceipt, keccak256 } from "ethers";
 
 import { ALICE } from "../../helpers/account";
 import { BlockMode, currentBlockMode } from "../../helpers/network";
 import {
-    deployTestContractBalances,
     ETHERJS,
+    deployTestContractBalances,
     prepareSignedTx,
     sendEvmMine,
     sendRawTransaction,
@@ -13,10 +13,7 @@ import {
 
 describe("Known issues for the external block mining mode. The 'eth_sendRawTransaction' API call", async () => {
     before(async () => {
-        expect(currentBlockMode()).eq(
-            BlockMode.External,
-            "Wrong block mining mode is used"
-        );
+        expect(currentBlockMode()).eq(BlockMode.External, "Wrong block mining mode is used");
     });
 
     it("Returns an expected result when a contract transaction fails", async () => {
@@ -28,7 +25,7 @@ describe("Known issues for the external block mining mode. The 'eth_sendRawTrans
             contract,
             account: ALICE,
             methodName: "sub",
-            methodParameters: [ALICE.address, amount]
+            methodParameters: [ALICE.address, amount],
         });
         const expectedTxHash = keccak256(signedTx);
 

--- a/e2e/test/issues/interval/e2e-ibm-logs.ts
+++ b/e2e/test/issues/interval/e2e-ibm-logs.ts
@@ -1,31 +1,24 @@
 import { expect } from "chai";
 
 import { ALICE } from "../../helpers/account";
-import { BlockMode, currentBlockMode, currentMiningIntervalInMs } from "../../helpers/network";
-import { deployTestContractBalances, HASH_ZERO, pollForTransaction, send, toHex } from "../../helpers/rpc";
 import { checkTimeEnough } from "../../helpers/misc";
+import { BlockMode, currentBlockMode, currentMiningIntervalInMs } from "../../helpers/network";
+import { HASH_ZERO, deployTestContractBalances, pollForTransaction, send, toHex } from "../../helpers/rpc";
 
 describe("Known issues for the interval block mining mode. The 'eth_getLogs' API call", async () => {
     let blockIntervalInMs: number;
 
     before(async () => {
-        expect(currentBlockMode()).eq(
-            BlockMode.Interval,
-            "Wrong block mining mode is used"
-        );
+        expect(currentBlockMode()).eq(BlockMode.Interval, "Wrong block mining mode is used");
         blockIntervalInMs = currentMiningIntervalInMs() ?? 0;
-        expect(blockIntervalInMs).gte(
-            1000,
-            "Block interval must be at least 1000 ms"
-        );
+        expect(blockIntervalInMs).gte(1000, "Block interval must be at least 1000 ms");
     });
 
     it("Returns an expected array for next non-existent blocks after a contract transaction", async () => {
         const contract = await deployTestContractBalances();
-        await pollForTransaction(
-            contract.deploymentTransaction()?.hash ?? HASH_ZERO,
-            { timeoutInMs: blockIntervalInMs * 1.1 }
-        );
+        await pollForTransaction(contract.deploymentTransaction()?.hash ?? HASH_ZERO, {
+            timeoutInMs: blockIntervalInMs * 1.1,
+        });
 
         const txSendingTime = Date.now();
         const txResponse = await contract.connect(ALICE.signer()).add(ALICE.address, 10);
@@ -34,13 +27,13 @@ describe("Known issues for the interval block mining mode. The 'eth_getLogs' API
         const txBlockNumber = txReceipt.blockNumber;
 
         expect(
-            await send("eth_getLogs", [{ fromBlock: toHex(txBlockNumber), address: contract.target }])
+            await send("eth_getLogs", [{ fromBlock: toHex(txBlockNumber), address: contract.target }]),
         ).length(1);
         expect(
-            await send("eth_getLogs", [{ fromBlock: toHex(txBlockNumber + 1), address: contract.target }])
+            await send("eth_getLogs", [{ fromBlock: toHex(txBlockNumber + 1), address: contract.target }]),
         ).length(0);
         expect(
-            await send("eth_getLogs", [{ fromBlock: toHex(txBlockNumber + 2), address: contract.target }])
+            await send("eth_getLogs", [{ fromBlock: toHex(txBlockNumber + 2), address: contract.target }]),
         ).length(0);
 
         checkTimeEnough(txSendingTime, blockIntervalInMs * 1.7);

--- a/e2e/test/issues/interval/e2e-ibm-pending-transactions.ts.ts
+++ b/e2e/test/issues/interval/e2e-ibm-pending-transactions.ts.ts
@@ -1,24 +1,18 @@
 import { expect } from "chai";
-import { keccak256, TransactionResponse } from "ethers";
+import { TransactionResponse, keccak256 } from "ethers";
 
 import { ALICE, BOB } from "../../helpers/account";
-import { BlockMode, currentBlockMode, currentMiningIntervalInMs } from "../../helpers/network";
-import { ETHERJS, pollForNextBlock, sendGetNonce, sendRawTransaction, } from "../../helpers/rpc";
 import { checkTimeEnough } from "../../helpers/misc";
+import { BlockMode, currentBlockMode, currentMiningIntervalInMs } from "../../helpers/network";
+import { ETHERJS, pollForNextBlock, sendGetNonce, sendRawTransaction } from "../../helpers/rpc";
 
 describe("Known issues for the interval block mining mode. Pending transactions", async () => {
     let blockIntervalInMs: number;
 
     before(async () => {
-        expect(currentBlockMode()).eq(
-            BlockMode.Interval,
-            "Wrong block mining mode is used"
-        );
+        expect(currentBlockMode()).eq(BlockMode.Interval, "Wrong block mining mode is used");
         blockIntervalInMs = currentMiningIntervalInMs() ?? 0;
-        expect(blockIntervalInMs).gte(
-            1000,
-            "Block interval must be at least 1000 ms"
-        );
+        expect(blockIntervalInMs).gte(1000, "Block interval must be at least 1000 ms");
     });
 
     it("Can be fetched by the hash before and after minting", async () => {

--- a/e2e/test/issues/interval/e2e-ibm-transaction-sending.ts
+++ b/e2e/test/issues/interval/e2e-ibm-transaction-sending.ts
@@ -1,31 +1,25 @@
 import { expect } from "chai";
-import { keccak256, TransactionReceipt } from "ethers";
+import { TransactionReceipt, keccak256 } from "ethers";
 
 import { ALICE } from "../../helpers/account";
+import { checkTimeEnough } from "../../helpers/misc";
 import { BlockMode, currentBlockMode, currentMiningIntervalInMs } from "../../helpers/network";
 import {
-    deployTestContractBalances,
     ETHERJS,
     HASH_ZERO,
+    deployTestContractBalances,
     pollForTransaction,
     prepareSignedTx,
     sendRawTransaction,
 } from "../../helpers/rpc";
-import { checkTimeEnough } from "../../helpers/misc";
 
 describe("Known issues for the interval block mining mode. The 'eth_sendRawTransaction' API call", async () => {
     let blockIntervalInMs: number;
 
     before(async () => {
-        expect(currentBlockMode()).eq(
-            BlockMode.Interval,
-            "Wrong block mining mode is used"
-        );
+        expect(currentBlockMode()).eq(BlockMode.Interval, "Wrong block mining mode is used");
         blockIntervalInMs = currentMiningIntervalInMs() ?? 0;
-        expect(blockIntervalInMs).gte(
-            1000,
-            "Block interval must be at least 1000 ms"
-        );
+        expect(blockIntervalInMs).gte(1000, "Block interval must be at least 1000 ms");
     });
 
     it("Returns an expected result when a contract transaction fails", async () => {
@@ -35,22 +29,18 @@ describe("Known issues for the interval block mining mode. The 'eth_sendRawTrans
             contract,
             account: ALICE,
             methodName: "sub",
-            methodParameters: [ALICE.address, amount]
+            methodParameters: [ALICE.address, amount],
         });
         const expectedTxHash = keccak256(signedTx);
 
-        await pollForTransaction(
-            contract.deploymentTransaction()?.hash ?? HASH_ZERO,
-            { timeoutInMs: blockIntervalInMs * 1.1 }
-        );
+        await pollForTransaction(contract.deploymentTransaction()?.hash ?? HASH_ZERO, {
+            timeoutInMs: blockIntervalInMs * 1.1,
+        });
         const txSendingTime = Date.now();
         const actualTxHash = await sendRawTransaction(signedTx);
         checkTimeEnough(txSendingTime, blockIntervalInMs);
 
-        await pollForTransaction(
-            expectedTxHash,
-            { timeoutInMs: blockIntervalInMs * 1.1 }
-        );
+        await pollForTransaction(expectedTxHash, { timeoutInMs: blockIntervalInMs * 1.1 });
         const txReceipt: TransactionReceipt | null = await ETHERJS.getTransactionReceipt(expectedTxHash);
 
         expect(txReceipt).exist;

--- a/justfile
+++ b/justfile
@@ -312,13 +312,23 @@ e2e-clock-stratus-rocks:
     killport 3000
     exit $result_code
 
-# E2E: Lint and format code
+# E2E: Lint and format TS/JS and Solidity code. IMPORTANT: Styling (indents, spaces, etc.) for Solidity is not checked
 e2e-lint:
     #!/bin/bash
     if [ -d e2e ]; then
         cd e2e
     fi
-    node_modules/.bin/prettier . --write
+    npx eslint . --fix
+    npx solhint 'contracts/**/*.sol' --fix  --noPrompt
+
+# E2E: Autoformat TS/JS and Solidity code
+e2e-prettier:
+    #!/bin/bash
+    if [ -d e2e ]; then
+        cd e2e
+    fi
+    npx prettier . --write
+
 
 # E2E: profiles rpc sync and generates a flamegraph
 e2e-flamegraph:


### PR DESCRIPTION
1. The [ESLint](https://eslint.org/) and [Solhint](https://github.com/protofire/solhint) linters have been added and configured in folder `e2e` to check and auto-format TypeScript and JavaScript files.
2. The `ESLint` tool has been extended with the [ESLint Stylistic plugin](https://eslint.style/) to check and correct formatting issues (indents, spaces, etc.).
3. The existing [Prettier tool](https://prettier.io/) has been extended to auto-format the Solidity code.
4. The `.prettierignore` file has been added to make `Prettier` ignore auto-generated folders (`artifacts`, `cache`, `typechain-types`).
5. The errors and warnings found by the new linters have been fixed in the TypeScript, JavaScript and Solidity files.
6. The `e2e-lint` option in `justfile` has been corrected to run the new linters instead of Prettier. 
7. The option to run Prettier has been renamed to `e2e-prettier` in `justfile`.
8. Some unused code related to changing of the RPC provider has been removed from the `e2e/test/helpers/rpc.ts` file. That code is currently used in the `e2e-contracts` folder.
9. IMPORTANT! `Prettier` not always gives the good results of code formatting. So if you run `just e2e-prettier` you'll still find some possible changes in the code, but they are not applied intentionally due to the existing version seems more readable than that Prettier provides. It is also the reason why Prettier has not been used for check the formatting (e.g. for Solidity files through [solhint-plugin-prettier](https://github.com/fvictorio/solhint-plugin-prettier)). Linters are more suitable here. Unfortunately, no good supported formatting linter for Solidity was found. Solhint supported formatting checks up to version 3, but then dropped that (see this release note [here](https://github.com/protofire/solhint/releases/tag/v3.0.0)). So it is expected that `Prettier` will be used to  auto-format Solidity code, but then the results will be checked and inappropriate changes will be rolled back.
10. An example of a well-known issue with `Prettier` when you apply it is applied to Solidity is formatting intentional multi-line entities into a single line. E.g. the following code:
    ```solidity
    event Add(
        address indexed account,
        uint256 amount
    );
    ```
    will be changed as:
    ```solidity
    event Add(address indexed account, uint256 amount);
    ```
    A workaround to prevent that is use a comment on the first line, like:
    ```solidity
    event Add(
        address indexed account, //
        uint256 amount
    );
    ```
    But it looks a bit awkward.
