### PR TITLE
test: type 2 transactions

### DIFF
--- a/e2e/test/automine/e2e-tx-serial-transfer.test.ts
+++ b/e2e/test/automine/e2e-tx-serial-transfer.test.ts
@@ -13,6 +13,7 @@ import {
     ONE,
     TEST_BALANCE,
     TEST_TRANSFER,
+    TWO,
     ZERO,
     fromHexTimestamp,
     send,
@@ -116,5 +117,53 @@ describe("Transaction: serial transfer", () => {
     });
     it("Receiver balance is increased", async () => {
         expect(await sendGetBalance(new_account)).eq(TEST_TRANSFER);
+    });
+});
+
+describe("EIP-1559: serial transfer", () => {
+    var _tx: Transaction;
+    var _txHash: string;
+    var _txSentTimestamp: number;
+
+    it("Resets blockchain", async () => {
+        await sendReset();
+        const blockNumber = await send("eth_blockNumber", []);
+        expect(blockNumber).to.be.oneOf(["0x0", "0x1"]);
+    });
+
+    it("Send transaction", async () => {
+        let txSigned = await ALICE.signWeiTransferEIP1559(BOB.address, TEST_TRANSFER);
+        _txSentTimestamp = Math.floor(Date.now() / 1000);
+        _txHash = await sendRawTransaction(txSigned);
+        expect(_txHash).eq(keccak256(txSigned));
+    });
+
+    it("Transaction is created", async () => {
+        _tx = await send("eth_getTransactionByHash", [_txHash]);
+        expect(_tx.from).eq(ALICE.address, "tx.from");
+        expect(_tx.to).eq(BOB.address, "tx.to");
+        expect(_tx.nonce).eq(ZERO, "tx.nonce");
+        expect(_tx.chainId).eq(CHAIN_ID, "tx.chainId");
+
+        const expectedValue = `0x${TEST_TRANSFER.toString(16)}`;
+        expect(_tx.value).eq(expectedValue, "tx.value");
+
+        expect(_tx.gasPrice).eq(ZERO, "tx.gasPrice");
+        expect(_tx.gas).match(HEX_PATTERN, "tx.gas format");
+        // FIXME expect(_tx.maxFeePerGas).eq(ZERO, "tx.maxFeePerGas");
+        // FIXME expect(_tx.maxPriorityFeePerGas).eq(ZERO, "tx.maxPriorityFeePerGas");
+        expect(_tx.input).eq("0x", "tx.input");
+        expect(_tx.v).match(HEX_PATTERN, "tx.v format");
+        expect(_tx.r).match(HEX_PATTERN, "tx.r format");
+        expect(_tx.s).match(HEX_PATTERN, "tx.s format");
+        expect(_tx.type).eq(TWO, "tx.type");
+    });
+
+    it("Receipt states a succesful type 2 transfer", async () => {
+        let receipt: TransactionReceipt = await send("eth_getTransactionReceipt", [_txHash]);
+        expect(receipt.from).eq(ALICE.address, "receipt.from");
+        expect(receipt.to).eq(BOB.address, "receipt.to");
+        expect(receipt.status).eq(ONE, "receipt.status");
+        // FIXME expect(receipt.type).eq(TWO, "receipt.type");
     });
 });

--- a/e2e/test/automine/e2e-tx-serial-transfer.test.ts
+++ b/e2e/test/automine/e2e-tx-serial-transfer.test.ts
@@ -156,7 +156,7 @@ describe("EIP-1559: serial transfer", () => {
         expect(_tx.v).match(HEX_PATTERN, "tx.v format");
         expect(_tx.r).match(HEX_PATTERN, "tx.r format");
         expect(_tx.s).match(HEX_PATTERN, "tx.s format");
-        expect(_tx.type).eq(TWO, "tx.type");
+        // FIXME expect(_tx.type).eq(TWO, "tx.type");
     });
 
     it("Receipt states a succesful type 2 transfer", async () => {

--- a/e2e/test/helpers/account.ts
+++ b/e2e/test/helpers/account.ts
@@ -6,7 +6,7 @@ export class Account implements Addressable {
     constructor(
         readonly address: string,
         readonly privateKey: string,
-    ) {}
+    ) { }
 
     getAddress(): Promise<string> {
         return Promise.resolve(this.address);
@@ -28,6 +28,23 @@ export class Account implements Addressable {
             chainId: CHAIN_ID_DEC,
             gasPrice: 0,
             gasLimit: gasLimit,
+            nonce,
+        });
+    }
+
+    async signWeiTransferEIP1559(
+        counterParty: string,
+        amount: BigNumberish,
+        nonce: number = 0,
+        gasLimit: BigNumberish = 1_000_000,
+    ): Promise<string> {
+        return await this.signer().signTransaction({
+            to: counterParty,
+            value: amount,
+            chainId: CHAIN_ID_DEC,
+            maxFeePerGas: 0,
+            maxPriorityFeePerGas: 0,
+            gasLimit,
             nonce,
         });
     }

--- a/e2e/test/helpers/rpc.ts
+++ b/e2e/test/helpers/rpc.ts
@@ -33,6 +33,7 @@ export const DEFAULT_TX_TIMEOUT_IN_MS = (currentMiningIntervalInMs() ?? 1000) * 
 // Special numbers
 export const ZERO = "0x0";
 export const ONE = "0x1";
+export const TWO = "0x2";
 export const TEST_BALANCE = "0xffffffffffffffff";
 export const TEST_TRANSFER = 12345678;
 export const NATIVE_TRANSFER_GAS = "0x5208"; // 21000


### PR DESCRIPTION
- regression test for #1184 
- basic test for type 2 transactions
 
ignored (left as comment) tests
- `type` in receipts (already known in #1136)
- `type` (rocks storage only), `maxFeePerGas` and `maxPriorityFeePerGas` in inputs (opened #1187)