### PR TITLE
increase heartbeat interval

### DIFF
--- a/src/eth/consensus/mod.rs
+++ b/src/eth/consensus/mod.rs
@@ -198,7 +198,7 @@ impl Consensus {
             transaction_execution_queue: Arc::new(Mutex::new(Vec::new())),
             importer_config,
             role: AtomicU8::new(Role::Follower as u8),
-            heartbeat_timeout: Duration::from_millis(rand::thread_rng().gen_range(250..350)), // Adjust as needed
+            heartbeat_timeout: Duration::from_millis(rand::thread_rng().gen_range(300..400)), // Adjust as needed
             my_address: my_address.clone(),
             grpc_address,
             reset_heartbeat_signal: tokio::sync::Notify::new(),


### PR DESCRIPTION
Sometimes the current heartbeat interval is not high enough and leads to changes in leadership when nothing relevant actually happened other than the timeout. This PR increases the interval to try to reduce these cases from happening.