### PR TITLE
feat: limit eth_getLogs to 5000 blocks

### DIFF
--- a/src/bin/importer_online.rs
+++ b/src/bin/importer_online.rs
@@ -312,7 +312,7 @@ async fn start_block_fetcher(
         }
 
         // we are behind current, so we will fetch multiple blocks in parallel to catch up
-        let blocks_behind = external_rpc_current_block.saturating_sub(importer_block_number.as_u64()) + 1;
+        let blocks_behind = external_rpc_current_block.saturating_sub(importer_block_number.as_u64()) + 1; // TODO: use count_to from BlockNumber
         let mut blocks_to_fetch = min(blocks_behind, 1_000); // avoid spawning millions of tasks (not parallelism), at least until we know it is safe
         tracing::info!(%blocks_behind, blocks_to_fetch, "catching up with blocks");
 

--- a/src/eth/primitives/block_number.rs
+++ b/src/eth/primitives/block_number.rs
@@ -67,6 +67,17 @@ impl BlockNumber {
         self.0.is_zero()
     }
 
+    /// Count how many blocks there is between itself and the othe block.
+    ///
+    /// Assumes that self is the lower-end of the range.
+    pub fn count_to(&self, higher_end: &BlockNumber) -> u64 {
+        if higher_end >= self {
+            higher_end.as_u64() - self.as_u64() + 1
+        } else {
+            0
+        }
+    }
+
     /// Converts itself to i64.
     pub fn as_i64(&self) -> i64 {
         self.0.as_u64() as i64

--- a/src/eth/rpc/rpc_error.rs
+++ b/src/eth/rpc/rpc_error.rs
@@ -19,11 +19,18 @@ pub enum RpcError {
 // -----------------------------------------------------------------------------
 impl From<anyhow::Error> for RpcError {
     fn from(value: anyhow::Error) -> Self {
-        tracing::error!(?value);
+        tracing::error!(reason = ?value, "rpc error response");
         match value.downcast::<ErrorObject>() {
             Ok(err) => RpcError::Response(err),
             Err(err) => RpcError::Generic(err),
         }
+    }
+}
+
+impl From<ErrorObjectOwned> for RpcError {
+    fn from(value: ErrorObjectOwned) -> Self {
+        tracing::warn!(?value);
+        RpcError::Response(value)
     }
 }
 

--- a/src/eth/rpc/rpc_server.rs
+++ b/src/eth/rpc/rpc_server.rs
@@ -286,7 +286,7 @@ async fn stratus_readiness(_: Params<'_>, context: Arc<RpcContext>, _: Extension
     if should_serve {
         Ok(json!(true))
     } else {
-        Err(RpcError::Response(rpc_internal_error("Service Not Ready".to_string())))
+        Err(rpc_internal_error("Service Not Ready".to_string()).into())
     }
 }
 
@@ -294,7 +294,7 @@ fn stratus_liveness(_: Params<'_>, _: &RpcContext, _: &Extensions) -> anyhow::Re
     if !GlobalState::is_shutdown() {
         Ok(json!(true))
     } else {
-        Err(RpcError::Response(rpc_internal_error("Service Unhealthy".to_string())))
+        Err(rpc_internal_error("Service Unhealthy".to_string()).into())
     }
 }
 
@@ -435,7 +435,7 @@ fn eth_estimate_gas(params: Params<'_>, ctx: Arc<RpcContext>, _: Extensions) -> 
         Ok(result) if result.is_success() => Ok(hex_num(result.gas)),
 
         // result is failure
-        Ok(result) => Err(RpcError::Response(rpc_internal_error(hex_data(result.output)))),
+        Ok(result) => Err(rpc_internal_error(hex_data(result.output)).into()),
 
         // internal error
         Err(e) => {
@@ -487,7 +487,7 @@ fn eth_send_raw_transaction(params: Params<'_>, ctx: Arc<RpcContext>, _: Extensi
             Ok(hash) => Ok(hex_data(hash)),
             Err(e) => {
                 tracing::error!(reason = ?e, "failed to forward transaction");
-                Err(RpcError::Response(rpc_internal_error(e.to_string())))
+                Err(rpc_internal_error(e.to_string()).into())
             }
         };
     }
@@ -499,7 +499,7 @@ fn eth_send_raw_transaction(params: Params<'_>, ctx: Arc<RpcContext>, _: Extensi
         Ok(evm_result) if evm_result.is_success() => Ok(hex_data(tx_hash)),
 
         // result is failure
-        Ok(evm_result) => Err(RpcError::Response(rpc_internal_error(hex_data(evm_result.execution().output.clone())))),
+        Ok(evm_result) => Err(rpc_internal_error(hex_data(evm_result.execution().output.clone())).into()),
 
         // internal error
         Err(e) => {
@@ -515,8 +515,25 @@ fn eth_send_raw_transaction(params: Params<'_>, ctx: Arc<RpcContext>, _: Extensi
 
 #[tracing::instrument(name = "rpc::eth_getLogs", skip_all)]
 fn eth_get_logs(params: Params<'_>, ctx: Arc<RpcContext>, _: Extensions) -> anyhow::Result<JsonValue, RpcError> {
-    let (_, filter_input) = next_rpc_param::<LogFilterInput>(params.sequence())?;
-    let filter = filter_input.parse(&ctx.storage)?;
+    const MAX_BLOCK_RANGE: u64 = 5_000;
+
+    let (_, filter_input) = next_rpc_param_or_default::<LogFilterInput>(params.sequence())?;
+    let mut filter = filter_input.parse(&ctx.storage)?;
+
+    // for this operation, the filter always need the end block specified to calculate the difference
+    if filter.to_block.is_none() {
+        filter.to_block = Some(ctx.storage.read_mined_block_number()?);
+    }
+
+    // check range
+    let blocks_in_range = filter.from_block.count_to(&filter.to_block.unwrap());
+    if blocks_in_range > MAX_BLOCK_RANGE {
+        return Err(rpc_invalid_params_error(format!(
+            "filter range will fetch logs from {} blocks, but the max allowed is {}",
+            blocks_in_range, MAX_BLOCK_RANGE
+        ))
+        .into());
+    }
 
     let logs = ctx.storage.read_logs(&filter)?;
     Ok(JsonValue::Array(logs.into_iter().map(|x| x.to_json_rpc_log()).collect()))


### PR DESCRIPTION
Limit `eth_getLogs` to 5000 blocks. We can make this number configurable or tune to a better value later.

Also added automatic conversion from `ErrorObjectOwned` to `RpcError`.