### PR TITLE
Increase time duration before checking leader

### DIFF
--- a/chaos/experiments/leader-election.sh
+++ b/chaos/experiments/leader-election.sh
@@ -257,6 +257,7 @@ run_test() {
         done
 
         echo "All instances are ready after restart. Waiting for new leader election."
+        sleep 15 # wait until election is settled down
 
         # Maximum timeout duration in seconds for new leader election
         max_timeout=60


### PR DESCRIPTION
Sometimes there is a case of elections in rapid succession, and this leads to the code checking leader to sometimes accuse more than one leader, even though the leaders are for different terms and correct behavior. This PR increases the time before making the check to allow some time for the leadership to settle down.