### PR TITLE
feat: timed function for metrics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ tower = "=0.4.13"
 
 # observability
 console-subscriber = "=0.2.0"
-metrics = { version = "=0.23.0", optional = true }
+metrics = "=0.23.0"
 metrics-exporter-prometheus = { version = "=0.15.0", optional = true }
 opentelemetry = "=0.23.0"
 opentelemetry_sdk = { version = "=0.23.0", features = ["rt-tokio"] }
@@ -187,7 +187,7 @@ default = ["bg-threads", "metrics", "tracing", "rocks"]
 dev  = []
 
 # Enable runtime metrics collection.
-metrics = ["dep:metrics", "dep:metrics-exporter-prometheus"]
+metrics = ["dep:metrics-exporter-prometheus"]
 
 # Enable runtime tracing/spans collection.
 tracing = []

--- a/src/eth/primitives/storage_point_in_time.rs
+++ b/src/eth/primitives/storage_point_in_time.rs
@@ -1,5 +1,4 @@
 use crate::eth::primitives::BlockNumber;
-#[cfg(feature = "metrics")]
 use crate::infra::metrics::MetricLabelValue;
 
 /// EVM storage point-in-time indicator.
@@ -18,7 +17,6 @@ pub enum StoragePointInTime {
 // -----------------------------------------------------------------------------
 // Conversions: Self -> Other
 // -----------------------------------------------------------------------------
-#[cfg(feature = "metrics")]
 impl From<&StoragePointInTime> for MetricLabelValue {
     fn from(value: &StoragePointInTime) -> Self {
         match value {

--- a/src/eth/storage/rocks/rocks_config.rs
+++ b/src/eth/storage/rocks/rocks_config.rs
@@ -33,9 +33,10 @@ impl DbConfig {
 
         // NOTE: As per the rocks db wiki: "The overhead of statistics is usually small but non-negligible. We usually observe an overhead of 5%-10%."
         #[cfg(feature = "metrics")]
-        opts.enable_statistics();
-        #[cfg(feature = "metrics")]
-        opts.set_statistics_level(rocksdb::statistics::StatsLevel::ExceptTimeForMutex);
+        {
+            opts.enable_statistics();
+            opts.set_statistics_level(rocksdb::statistics::StatsLevel::ExceptTimeForMutex);
+        }
 
         match self {
             DbConfig::LargeSSTFiles => {

--- a/src/globals.rs
+++ b/src/globals.rs
@@ -56,7 +56,6 @@ where
             .expect("failed to init tracing");
 
         // init metrics
-        #[cfg(feature = "metrics")]
         infra::init_metrics(common.metrics_exporter_address).expect("failed to init metrics");
 
         // init sentry

--- a/src/infra/metrics/metrics_definitions.rs
+++ b/src/infra/metrics/metrics_definitions.rs
@@ -31,7 +31,7 @@ metrics! {
     histogram_duration storage_read_mined_block_number{success},
 
     "Time to execute storage read_account operation."
-    histogram_duration storage_read_account{found_at, point_in_time, success},
+    histogram_duration storage_read_account{storage, point_in_time, success},
 
     "Time to execute storage read_block operation."
     histogram_duration storage_read_block{success},
@@ -40,7 +40,7 @@ metrics! {
     histogram_duration storage_read_logs{success},
 
     "Time to execute storage read_slot operation."
-    histogram_duration storage_read_slot{found_at, point_in_time, success},
+    histogram_duration storage_read_slot{storage, point_in_time, success},
 
     "Time to execute storage read_mined_transaction operation."
     histogram_duration storage_read_mined_transaction{success}

--- a/src/infra/metrics/metrics_types.rs
+++ b/src/infra/metrics/metrics_types.rs
@@ -118,7 +118,7 @@ where
 
 #[cfg(not(feature = "metrics"))]
 /// Executes the provided function
-pub fn metrify<F, T>(f: F) -> Timed<T>
+pub fn timed<F, T>(f: F) -> Timed<T>
 where
     F: FnOnce() -> T,
 {

--- a/src/infra/mod.rs
+++ b/src/infra/mod.rs
@@ -3,13 +3,11 @@
 pub mod blockchain_client;
 pub mod build_info;
 pub mod docker;
-#[cfg(feature = "metrics")]
 pub mod metrics;
 pub mod sentry;
 pub mod tracing;
 
 pub use blockchain_client::BlockchainClient;
-#[cfg(feature = "metrics")]
 pub use metrics::init_metrics;
 pub use sentry::init_sentry;
 pub use tracing::init_tracing;

--- a/src/infra/tracing.rs
+++ b/src/infra/tracing.rs
@@ -461,6 +461,7 @@ pub trait SpanExt {
     }
 
     #[cfg(not(feature = "tracing"))]
+    /// Do nothing because the `tracing` function is disabled.
     fn with<F>(_: F)
     where
         F: Fn(Span),


### PR DESCRIPTION
`[cfg(feature = "metrics")]` is spawning across the entire codebase.

Introducing the `timed` function aims to centralize this feature-flag inside its implementation and making code maintenance easier while still providing the benefits of having a compile-time feature-flag.