### PR TITLE
Disable RocksDB backups

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -38,7 +38,6 @@ use crate::eth::BlockMiner;
 use crate::eth::BlockMinerMode;
 use crate::eth::Executor;
 use crate::eth::TransactionRelayer;
-use crate::ext::not;
 use crate::ext::parse_duration;
 use crate::infra::build_info;
 use crate::infra::tracing::TracingLogFormat;
@@ -848,10 +847,6 @@ pub struct PermanentStorageConfig {
     /// RocksDB storage path prefix to execute multiple local Stratus instances.
     #[arg(long = "rocks-path-prefix", env = "ROCKS_PATH_PREFIX")]
     pub rocks_path_prefix: Option<String>,
-
-    // Disable RocksDB backups
-    #[arg(long = "perm-storage-disable-backups", env = "PERM_STORAGE_DISABLE_BACKUPS")]
-    pub perm_storage_disable_backups: bool,
 }
 
 #[derive(DebugAsJson, Clone, serde::Serialize)]
@@ -870,9 +865,8 @@ impl PermanentStorageConfig {
             PermanentStorageKind::InMemory => Box::<InMemoryPermanentStorage>::default(),
             #[cfg(feature = "rocks")]
             PermanentStorageKind::Rocks => {
-                let enable_backups = not(self.perm_storage_disable_backups);
                 let prefix = self.rocks_path_prefix.clone();
-                Box::new(RocksPermanentStorage::new(enable_backups, prefix)?)
+                Box::new(RocksPermanentStorage::new(prefix)?)
             }
         };
         Ok(perm)

--- a/src/eth/storage/rocks/rocks_permanent.rs
+++ b/src/eth/storage/rocks/rocks_permanent.rs
@@ -22,11 +22,10 @@ use crate::eth::storage::PermanentStorage;
 pub struct RocksPermanentStorage {
     pub state: RocksStorageState,
     block_number: AtomicU64,
-    enable_backups: bool,
 }
 
 impl RocksPermanentStorage {
-    pub fn new(enable_backups: bool, rocks_path_prefix: Option<String>) -> anyhow::Result<Self> {
+    pub fn new(rocks_path_prefix: Option<String>) -> anyhow::Result<Self> {
         tracing::info!("setting up rocksdb storage");
         let path = if let Some(prefix) = rocks_path_prefix {
             // run some checks on the given prefix
@@ -45,11 +44,7 @@ impl RocksPermanentStorage {
 
         let state = RocksStorageState::new(path);
         let block_number = state.preload_block_number()?;
-        Ok(Self {
-            state,
-            block_number,
-            enable_backups,
-        })
+        Ok(Self { state, block_number })
     }
 
     // -------------------------------------------------------------------------
@@ -105,7 +100,7 @@ impl PermanentStorage for RocksPermanentStorage {
         {
             self.state.export_metrics();
         }
-        self.state.save_block(block, self.enable_backups)
+        self.state.save_block(block)
     }
 
     fn save_accounts(&self, accounts: Vec<Account>) -> anyhow::Result<()> {

--- a/src/eth/storage/stratus_storage.rs
+++ b/src/eth/storage/stratus_storage.rs
@@ -71,8 +71,7 @@ impl StratusStorage {
         let temp_dir = tempfile::TempDir::new().expect("Failed to create temp dir");
         let temp_path = temp_dir.path().to_str().expect("Failed to get temp path").to_string();
 
-        let rocks_permanent_storage =
-            crate::eth::storage::RocksPermanentStorage::new(false, Some(temp_path.clone())).expect("Failed to create RocksPermanentStorage");
+        let rocks_permanent_storage = crate::eth::storage::RocksPermanentStorage::new(Some(temp_path.clone())).expect("Failed to create RocksPermanentStorage");
 
         (
             Self {

--- a/tests/test_import_external_snapshot_rocksdb.rs
+++ b/tests/test_import_external_snapshot_rocksdb.rs
@@ -17,7 +17,7 @@ pub mod rocks_test {
 
             let (accounts, slots) = common::filter_accounts_and_slots(snapshot);
 
-            let rocks = RocksPermanentStorage::new(false, Some("test_import_external_snapshot_with_rocksdb".to_string())).unwrap();
+            let rocks = RocksPermanentStorage::new(Some("test_import_external_snapshot_with_rocksdb".to_string())).unwrap();
             rocks.save_accounts(accounts).unwrap();
             rocks.state.write_slots(slots);
 


### PR DESCRIPTION
We decided that we prefer to make snapshots on the storage instead of using the backup functionality with rocksdb