### PR TITLE
refactor: tracing fields

### DIFF
--- a/src/bin/importer_offline.rs
+++ b/src/bin/importer_offline.rs
@@ -78,14 +78,14 @@ async fn run(config: ImporterOfflineConfig) -> anyhow::Result<()> {
 
     let storage_loader = execute_external_rpc_storage_loader(rpc_storage, config.blocks_by_fetch, config.paralellism, block_start, block_end, backlog_tx);
     spawn_named("storage-loader", async move {
-        if let Err(err) = storage_loader.await {
-            tracing::error!(?err, "'storage-loader' task failed");
+        if let Err(e) = storage_loader.await {
+            tracing::error!(reason = ?e, "'storage-loader' task failed");
         }
     });
 
     let block_importer = spawn_thread("block-importer", || {
-        if let Err(err) = execute_block_importer(executor, miner, backlog_rx, block_snapshots) {
-            tracing::error!(?err, "'block-importer' task failed");
+        if let Err(e) = execute_block_importer(executor, miner, backlog_rx, block_snapshots) {
+            tracing::error!(reason = ?e, "'block-importer' task failed");
         }
     });
 

--- a/src/bin/importer_online.rs
+++ b/src/bin/importer_online.rs
@@ -384,24 +384,24 @@ async fn fetch_block(chain: Arc<BlockchainClient>, block_number: BlockNumber) ->
     }
 }
 
-#[tracing::instrument(name = "importer::fetch_receipt", skip_all, fields(block_number, hash))]
-async fn fetch_receipt(chain: Arc<BlockchainClient>, block_number: BlockNumber, hash: Hash) -> ExternalReceipt {
+#[tracing::instrument(name = "importer::fetch_receipt", skip_all, fields(block_number, tx_hash))]
+async fn fetch_receipt(chain: Arc<BlockchainClient>, block_number: BlockNumber, tx_hash: Hash) -> ExternalReceipt {
     Span::with(|s| {
         s.rec_str("block_number", &block_number);
-        s.rec_str("hash", &hash);
+        s.rec_str("tx_hash", &tx_hash);
     });
 
     loop {
-        tracing::info!(%block_number, %hash, "fetching receipt");
+        tracing::info!(%block_number, %tx_hash, "fetching receipt");
 
-        match chain.fetch_receipt(hash).await {
+        match chain.fetch_receipt(tx_hash).await {
             Ok(Some(receipt)) => return receipt,
             Ok(None) => {
-                tracing::warn!(%block_number, %hash, "receipt not available yet because block is not mined. retrying now.");
+                tracing::warn!(%block_number, %tx_hash, "receipt not available yet because block is not mined. retrying now.");
                 continue;
             }
             Err(e) => {
-                tracing::error!(reason = ?e, %block_number, %hash, "failed to fetch receipt. retrying now.");
+                tracing::error!(reason = ?e, %block_number, %tx_hash, "failed to fetch receipt. retrying now.");
             }
         }
     }

--- a/src/bin/importer_online.rs
+++ b/src/bin/importer_online.rs
@@ -172,7 +172,7 @@ async fn start_block_executor(
             tracing::info!(
                 tps,
                 duraton = %duration.to_string_ext(),
-                block_number = ?block.number(),
+                block_number = %block.number(),
                 receipts = receipts.len(),
                 "reexecuted external block",
             );
@@ -234,7 +234,7 @@ async fn start_number_fetcher(chain: Arc<BlockchainClient>, sync_interval: Durat
             tracing::info!("{} awaiting block number from newHeads subscription", TASK_NAME);
             let resubscribe_ws = match timeout(TIMEOUT_NEW_HEADS, sub.next()).await {
                 Ok(Some(Ok(block))) => {
-                    tracing::info!(number = %block.number(), "{} received newHeads event", TASK_NAME);
+                    tracing::info!(block_number = %block.number(), "{} received newHeads event", TASK_NAME);
                     set_external_rpc_current_block(block.number());
                     continue;
                 }
@@ -271,13 +271,13 @@ async fn start_number_fetcher(chain: Arc<BlockchainClient>, sync_interval: Durat
         // fallback to polling
         tracing::warn!("{} falling back to http polling because subscription failed or it is not enabled", TASK_NAME);
         match chain.fetch_block_number().await {
-            Ok(number) => {
+            Ok(block_number) => {
                 tracing::info!(
-                    %number,
+                    %block_number,
                     sync_interval = %sync_interval.to_string_ext(),
                     "fetched current block number via http. awaiting sync interval to retrieve again."
                 );
-                set_external_rpc_current_block(number);
+                set_external_rpc_current_block(block_number);
                 traced_sleep(sync_interval, SleepReason::SyncData).await;
             }
             Err(e) => {
@@ -334,14 +334,14 @@ async fn start_block_fetcher(
     }
 }
 
-#[tracing::instrument(name = "importer::fetch_block_and_receipts", skip_all, fields(number))]
-async fn fetch_block_and_receipts(chain: Arc<BlockchainClient>, number: BlockNumber) -> (ExternalBlock, Vec<ExternalReceipt>) {
+#[tracing::instrument(name = "importer::fetch_block_and_receipts", skip_all, fields(block_number))]
+async fn fetch_block_and_receipts(chain: Arc<BlockchainClient>, block_number: BlockNumber) -> (ExternalBlock, Vec<ExternalReceipt>) {
     Span::with(|s| {
-        s.rec_str("number", &number);
+        s.rec_str("block_number", &block_number);
     });
 
     // fetch block
-    let block = fetch_block(Arc::clone(&chain), number).await;
+    let block = fetch_block(Arc::clone(&chain), block_number).await;
 
     // wait some time until receipts are available
     let _ = traced_sleep(INTERVAL_FETCH_RECEIPTS, SleepReason::SyncData).await;
@@ -349,33 +349,33 @@ async fn fetch_block_and_receipts(chain: Arc<BlockchainClient>, number: BlockNum
     // fetch receipts in parallel
     let mut receipts_tasks = Vec::with_capacity(block.transactions.len());
     for hash in block.transactions.iter().map(|tx| tx.hash()) {
-        receipts_tasks.push(fetch_receipt(Arc::clone(&chain), number, hash));
+        receipts_tasks.push(fetch_receipt(Arc::clone(&chain), block_number, hash));
     }
     let receipts = futures::stream::iter(receipts_tasks).buffer_unordered(PARALLEL_RECEIPTS).collect().await;
 
     (block, receipts)
 }
 
-#[tracing::instrument(name = "importer::fetch_block", skip_all, fields(number))]
-async fn fetch_block(chain: Arc<BlockchainClient>, number: BlockNumber) -> ExternalBlock {
+#[tracing::instrument(name = "importer::fetch_block", skip_all, fields(block_number))]
+async fn fetch_block(chain: Arc<BlockchainClient>, block_number: BlockNumber) -> ExternalBlock {
     const RETRY_DELAY: Duration = Duration::from_millis(10);
     Span::with(|s| {
-        s.rec_str("number", &number);
+        s.rec_str("block_number", &block_number);
     });
 
     loop {
-        tracing::info!(%number, "fetching block");
-        let block = match chain.fetch_block(number).await {
+        tracing::info!(%block_number, "fetching block");
+        let block = match chain.fetch_block(block_number).await {
             Ok(json) => json,
             Err(e) => {
-                tracing::warn!(reason = ?e, %number, delay_ms=%RETRY_DELAY.as_millis(), "failed to retrieve block. retrying with delay.");
+                tracing::warn!(reason = ?e, %block_number, delay_ms=%RETRY_DELAY.as_millis(), "failed to retrieve block. retrying with delay.");
                 traced_sleep(RETRY_DELAY, SleepReason::RetryBackoff).await;
                 continue;
             }
         };
 
         if block.is_null() {
-            tracing::warn!(%number, delay_ms=%RETRY_DELAY.as_millis(), "block not mined yet. retrying with delay.");
+            tracing::warn!(%block_number, delay_ms=%RETRY_DELAY.as_millis(), "block not mined yet. retrying with delay.");
             traced_sleep(RETRY_DELAY, SleepReason::SyncData).await;
             continue;
         }
@@ -384,24 +384,24 @@ async fn fetch_block(chain: Arc<BlockchainClient>, number: BlockNumber) -> Exter
     }
 }
 
-#[tracing::instrument(name = "importer::fetch_receipt", skip_all, fields(number, hash))]
-async fn fetch_receipt(chain: Arc<BlockchainClient>, number: BlockNumber, hash: Hash) -> ExternalReceipt {
+#[tracing::instrument(name = "importer::fetch_receipt", skip_all, fields(block_number, hash))]
+async fn fetch_receipt(chain: Arc<BlockchainClient>, block_number: BlockNumber, hash: Hash) -> ExternalReceipt {
     Span::with(|s| {
-        s.rec_str("number", &number);
+        s.rec_str("block_number", &block_number);
         s.rec_str("hash", &hash);
     });
 
     loop {
-        tracing::info!(%number, %hash, "fetching receipt");
+        tracing::info!(%block_number, %hash, "fetching receipt");
 
         match chain.fetch_receipt(hash).await {
             Ok(Some(receipt)) => return receipt,
             Ok(None) => {
-                tracing::warn!(%number, %hash, "receipt not available yet because block is not mined. retrying now.");
+                tracing::warn!(%block_number, %hash, "receipt not available yet because block is not mined. retrying now.");
                 continue;
             }
             Err(e) => {
-                tracing::error!(reason = ?e, %number, %hash, "failed to fetch receipt. retrying now.");
+                tracing::error!(reason = ?e, %block_number, %hash, "failed to fetch receipt. retrying now.");
             }
         }
     }

--- a/src/bin/relayer.rs
+++ b/src/bin/relayer.rs
@@ -38,8 +38,8 @@ async fn run(config: ExternalRelayerConfig) -> anyhow::Result<()> {
                 metrics::inc_relay_next_block(start.elapsed());
                 block_number
             }
-            Err(err) => {
-                tracing::error!(?err, "error relaying next block");
+            Err(e) => {
+                tracing::error!(reason = ?e, "error relaying next block");
                 continue;
             }
         };

--- a/src/bin/rpc_downloader.rs
+++ b/src/bin/rpc_downloader.rs
@@ -116,7 +116,7 @@ async fn download(
 
     // download blocks
     while current <= end_inclusive {
-        tracing::info!(number = %current, "downloading");
+        tracing::info!(block_number = %current, "downloading");
 
         loop {
             // retrieve block
@@ -132,7 +132,7 @@ async fn download(
             let block: ImporterBlock = match ImporterBlock::deserialize(&block_json) {
                 Ok(block) => block,
                 Err(e) => {
-                    tracing::error!(reason = ?e, number = %current, payload = ?block_json, "block does not match expected format");
+                    tracing::error!(reason = ?e, block_number = %current, payload = ?block_json, "block does not match expected format");
                     return Err(e).context(format!("block does not match expected format for block {}", current));
                 }
             };

--- a/src/bin/rpc_downloader.rs
+++ b/src/bin/rpc_downloader.rs
@@ -140,9 +140,9 @@ async fn download(
 
             // retrieve receipts
             let mut receipts_json = Vec::with_capacity(hashes.len());
-            for hash in hashes {
+            for tx_hash in hashes {
                 loop {
-                    let receipt = match chain.fetch_receipt(hash).await {
+                    let receipt = match chain.fetch_receipt(tx_hash).await {
                         Ok(receipt) => receipt,
                         Err(e) => {
                             tracing::warn!(reason = ?e, "retrying receipt download");
@@ -152,12 +152,12 @@ async fn download(
 
                     match receipt {
                         Some(receipt) => {
-                            receipts_json.push((hash, receipt));
+                            receipts_json.push((tx_hash, receipt));
                             break;
                         }
                         None => {
-                            tracing::error!(%hash, payload = ?receipt, "receipt is null");
-                            return Err(anyhow!(format!("transaction receipt is null for hash {}", hash)));
+                            tracing::error!(%tx_hash, payload = ?receipt, "receipt is null");
+                            return Err(anyhow!(format!("transaction receipt is null for hash {}", tx_hash)));
                         }
                     }
                 }

--- a/src/eth/block_miner.rs
+++ b/src/eth/block_miner.rs
@@ -86,10 +86,10 @@ impl BlockMiner {
     }
 
     /// Persists a transaction execution.
-    #[tracing::instrument(name = "miner::save_execution", skip_all, fields(hash))]
+    #[tracing::instrument(name = "miner::save_execution", skip_all, fields(tx_hash))]
     pub fn save_execution(&self, tx_execution: TransactionExecution) -> anyhow::Result<()> {
         Span::with(|s| {
-            s.rec_str("hash", &tx_execution.hash());
+            s.rec_str("tx_hash", &tx_execution.hash());
         });
 
         // save execution to temporary storage

--- a/src/eth/block_miner.rs
+++ b/src/eth/block_miner.rs
@@ -108,7 +108,7 @@ impl BlockMiner {
     /// Mines external block and external transactions.
     ///
     /// Local transactions are not allowed to be part of the block.
-    #[tracing::instrument(name = "miner::mine_external", skip_all, fields(number))]
+    #[tracing::instrument(name = "miner::mine_external", skip_all, fields(block_number))]
     pub fn mine_external(&self) -> anyhow::Result<Block> {
         tracing::debug!("mining external block");
 
@@ -128,7 +128,7 @@ impl BlockMiner {
         let block = block_from_external(external_block, mined_txs);
 
         block.map(|block| {
-            Span::with(|s| s.rec_str("number", &block.number()));
+            Span::with(|s| s.rec_str("block_number", &block.number()));
             block
         })
     }
@@ -142,7 +142,7 @@ impl BlockMiner {
     /// Mines external block and external transactions.
     ///
     /// Local transactions are allowed to be part of the block if failed, but not succesful ones.
-    #[tracing::instrument(name = "miner::mine_external_mixed", skip_all, fields(number))]
+    #[tracing::instrument(name = "miner::mine_external_mixed", skip_all, fields(block_number))]
     pub fn mine_external_mixed(&self) -> anyhow::Result<Block> {
         tracing::debug!("mining external mixed block");
 
@@ -166,7 +166,7 @@ impl BlockMiner {
             block.push_execution(tx.input, tx.result);
         }
 
-        Span::with(|s| s.rec_str("number", &block.number()));
+        Span::with(|s| s.rec_str("block_number", &block.number()));
 
         Ok(block)
     }
@@ -180,7 +180,7 @@ impl BlockMiner {
     /// Mines local transactions.
     ///
     /// External transactions are not allowed to be part of the block.
-    #[tracing::instrument(name = "miner::mine_local", skip_all, fields(number))]
+    #[tracing::instrument(name = "miner::mine_local", skip_all, fields(block_number))]
     pub fn mine_local(&self) -> anyhow::Result<Block> {
         tracing::debug!("mining local block");
 
@@ -199,7 +199,7 @@ impl BlockMiner {
         };
 
         block.map(|block| {
-            Span::with(|s| s.rec_str("number", &block.number()));
+            Span::with(|s| s.rec_str("block_number", &block.number()));
             block
         })
     }
@@ -211,11 +211,11 @@ impl BlockMiner {
     }
 
     /// Persists a mined block to permanent storage and prepares new block.
-    #[tracing::instrument(name = "miner::commit", skip_all, fields(number))]
+    #[tracing::instrument(name = "miner::commit", skip_all, fields(block_number))]
     pub fn commit(&self, block: Block) -> anyhow::Result<()> {
-        Span::with(|s| s.rec_str("number", &block.number()));
+        Span::with(|s| s.rec_str("block_number", &block.number()));
 
-        tracing::info!(number = %block.number(), transactions_len = %block.transactions.len(), "commiting block");
+        tracing::info!(block_number = %block.number(), transactions_len = %block.transactions.len(), "commiting block");
 
         // extract fields to use in notifications
         let block_number = block.number();

--- a/src/eth/consensus/discovery.rs
+++ b/src/eth/consensus/discovery.rs
@@ -54,8 +54,7 @@ pub async fn discover_peers(consensus: Arc<Consensus>) {
                     tracing::warn!("failed to discover new peers from Kubernetes (attempt {}/{}): {:?}", attempts, max_attempts, e);
 
                     if attempts >= max_attempts {
-                        tracing::error!("exceeded maximum attempts to discover peers from kubernetes. initiating shutdown.");
-                        GlobalState::shutdown_from("consensus", "failed to discover peers from Kubernetes");
+                        GlobalState::shutdown_from("consensus", "failed to discover peers from Kubernetes after maximum attempts");
                     }
 
                     sleep(Duration::from_millis(100)).await;

--- a/src/eth/consensus/forward_to.rs
+++ b/src/eth/consensus/forward_to.rs
@@ -21,7 +21,7 @@ impl TransactionRelayer {
     /// Forwards the transaction to the external blockchain if the execution was successful on our side.
     #[tracing::instrument(skip_all)]
     pub async fn forward(&self, tx_input: TransactionInput) -> anyhow::Result<PendingTransaction> {
-        tracing::debug!(hash = %tx_input.hash, "forwarding transaction");
+        tracing::debug!(tx_hash = %tx_input.hash, "forwarding transaction");
 
         let tx = self.chain.send_raw_transaction(Transaction::from(tx_input.clone()).rlp()).await?;
 

--- a/src/eth/consensus/mod.rs
+++ b/src/eth/consensus/mod.rs
@@ -421,9 +421,9 @@ impl Consensus {
                 tokio::select! {
                     Ok(tx) = rx_pending_txs.recv() => {
                         if consensus.is_leader() {
-                            tracing::info!(hash = %tx.hash(), "received transaction execution to send to followers");
+                            tracing::info!(tx_hash = %tx.hash(), "received transaction execution to send to followers");
                             if tx.is_local() {
-                                tracing::debug!(hash = %tx.hash(), "skipping local transaction because only external transactions are supported for now");
+                                tracing::debug!(tx_hash = %tx.hash(), "skipping local transaction because only external transactions are supported for now");
                                 continue;
                             }
 

--- a/src/eth/executor.rs
+++ b/src/eth/executor.rs
@@ -140,15 +140,15 @@ impl Executor {
     // -------------------------------------------------------------------------
 
     /// Reexecutes an external block locally and imports it to the temporary storage.
-    #[tracing::instrument(name = "executor::external_block", skip_all, fields(number))]
+    #[tracing::instrument(name = "executor::external_block", skip_all, fields(block_number))]
     pub fn execute_external_block(&self, block: &ExternalBlock, receipts: &ExternalReceipts) -> anyhow::Result<()> {
         #[cfg(feature = "metrics")]
         let (start, mut block_metrics) = (metrics::now(), ExecutionMetrics::default());
 
         Span::with(|s| {
-            s.rec_str("number", &block.number());
+            s.rec_str("block_number", &block.number());
         });
-        tracing::info!(number = %block.number(), "reexecuting external block");
+        tracing::info!(block_number = %block.number(), "reexecuting external block");
 
         // track active block number
         let storage = &self.storage;
@@ -195,7 +195,7 @@ impl Executor {
             s.rec_str("hash", &tx.hash);
         });
 
-        tracing::info!(number = %block.number(), hash = %tx.hash(), "reexecuting external transaction");
+        tracing::info!(block_number = %block.number(), hash = %tx.hash(), "reexecuting external transaction");
 
         #[cfg(feature = "metrics")]
         let start = metrics::now();
@@ -223,7 +223,7 @@ impl Executor {
             Err(e) => {
                 let json_tx = to_json_string(&tx);
                 let json_receipt = to_json_string(&receipt);
-                tracing::error!(reason = ?e, number = %block.number(), hash = %tx.hash(), %json_tx, %json_receipt, "failed to reexecute external transaction");
+                tracing::error!(reason = ?e, block_number = %block.number(), hash = %tx.hash(), %json_tx, %json_receipt, "failed to reexecute external transaction");
                 return Err(e);
             }
         };
@@ -243,7 +243,7 @@ impl Executor {
             let json_tx = to_json_string(&tx);
             let json_receipt = to_json_string(&receipt);
             let json_execution_logs = to_json_string(&evm_result.execution.logs);
-            tracing::error!(reason = %"mismatch reexecuting transaction", number = %block.number(), hash = %tx.hash(), %json_tx, %json_receipt, %json_execution_logs, "failed to reexecute external transaction");
+            tracing::error!(reason = %"mismatch reexecuting transaction", block_number = %block.number(), hash = %tx.hash(), %json_tx, %json_receipt, %json_execution_logs, "failed to reexecute external transaction");
             return Err(e);
         };
 

--- a/src/eth/executor.rs
+++ b/src/eth/executor.rs
@@ -184,7 +184,7 @@ impl Executor {
     ///
     /// This function wraps `reexecute_external_tx_inner` and returns back the payload
     /// to facilitate re-execution of parallel transactions that failed
-    #[tracing::instrument(name = "executor::external_transaction", skip_all, fields(hash))]
+    #[tracing::instrument(name = "executor::external_transaction", skip_all, fields(tx_hash))]
     fn execute_external_transaction<'a, 'b>(
         &'a self,
         tx: &'b ExternalTransaction,
@@ -192,10 +192,10 @@ impl Executor {
         block: &ExternalBlock,
     ) -> anyhow::Result<ExternalTransactionExecution> {
         Span::with(|s| {
-            s.rec_str("hash", &tx.hash);
+            s.rec_str("tx_hash", &tx.hash);
         });
 
-        tracing::info!(block_number = %block.number(), hash = %tx.hash(), "reexecuting external transaction");
+        tracing::info!(block_number = %block.number(), tx_hash = %tx.hash(), "reexecuting external transaction");
 
         #[cfg(feature = "metrics")]
         let start = metrics::now();
@@ -223,7 +223,7 @@ impl Executor {
             Err(e) => {
                 let json_tx = to_json_string(&tx);
                 let json_receipt = to_json_string(&receipt);
-                tracing::error!(reason = ?e, block_number = %block.number(), hash = %tx.hash(), %json_tx, %json_receipt, "failed to reexecute external transaction");
+                tracing::error!(reason = ?e, block_number = %block.number(), tx_hash = %tx.hash(), %json_tx, %json_receipt, "failed to reexecute external transaction");
                 return Err(e);
             }
         };
@@ -243,7 +243,7 @@ impl Executor {
             let json_tx = to_json_string(&tx);
             let json_receipt = to_json_string(&receipt);
             let json_execution_logs = to_json_string(&evm_result.execution.logs);
-            tracing::error!(reason = %"mismatch reexecuting transaction", block_number = %block.number(), hash = %tx.hash(), %json_tx, %json_receipt, %json_execution_logs, "failed to reexecute external transaction");
+            tracing::error!(reason = %"mismatch reexecuting transaction", block_number = %block.number(), tx_hash = %tx.hash(), %json_tx, %json_receipt, %json_execution_logs, "failed to reexecute external transaction");
             return Err(e);
         };
 
@@ -255,24 +255,24 @@ impl Executor {
     // -------------------------------------------------------------------------
 
     /// Executes a transaction persisting state changes.
-    #[tracing::instrument(name = "executor::local_transaction", skip_all, fields(hash, from, to))]
+    #[tracing::instrument(name = "executor::local_transaction", skip_all, fields(tx_hash, tx_from, tx_to))]
     pub fn execute_local_transaction(&self, tx_input: TransactionInput) -> anyhow::Result<TransactionExecution> {
         #[cfg(feature = "metrics")]
         let (start, function) = (metrics::now(), tx_input.extract_function());
 
         Span::with(|s| {
-            s.rec_str("hash", &tx_input.hash);
-            s.rec_str("from", &tx_input.signer);
-            s.rec_opt("to", &tx_input.to);
+            s.rec_str("tx_hash", &tx_input.hash);
+            s.rec_str("tx_from", &tx_input.signer);
+            s.rec_opt("tx_to", &tx_input.to);
         });
         tracing::info!(
-            hash = %tx_input.hash,
-            nonce = %tx_input.nonce,
-            from = ?tx_input.from,
-            signer = %tx_input.signer,
-            to = ?tx_input.to,
-            data_len = %tx_input.input.len(),
-            data = %tx_input.input,
+            tx_hash = %tx_input.hash,
+            tx_nonce = %tx_input.nonce,
+            tx_from = ?tx_input.from,
+            tx_signer = %tx_input.signer,
+            tx_to = ?tx_input.to,
+            tx_data_len = %tx_input.input.len(),
+            tx_data = %tx_input.input,
             "executing local transaction"
         );
 
@@ -328,7 +328,7 @@ impl Executor {
             to = ?input.to,
             data_len = input.data.len(),
             data = %input.data,
-            ?point_in_time,
+            %point_in_time,
             "executing read-only local transaction"
         );
 

--- a/src/eth/primitives/external_receipts.rs
+++ b/src/eth/primitives/external_receipts.rs
@@ -19,12 +19,12 @@ impl ExternalReceipts {
     }
 
     /// Tries to take a receipt by its hash.
-    pub fn try_get(&self, hash: &Hash) -> anyhow::Result<&ExternalReceipt> {
-        match self.get(hash) {
+    pub fn try_get(&self, tx_hash: &Hash) -> anyhow::Result<&ExternalReceipt> {
+        match self.get(tx_hash) {
             Some(receipt) => Ok(receipt),
             None => {
-                tracing::error!(%hash, "receipt is missing for hash");
-                Err(anyhow!("receipt missing for hash {}", hash))
+                tracing::error!(%tx_hash, "receipt is missing for hash");
+                Err(anyhow!("receipt missing for hash {}", tx_hash))
             }
         }
     }

--- a/src/eth/primitives/wei.rs
+++ b/src/eth/primitives/wei.rs
@@ -78,8 +78,8 @@ impl<'q> sqlx::Encode<'q, sqlx::Postgres> for Wei {
     fn encode_by_ref(&self, buf: &mut <sqlx::Postgres as HasArguments<'q>>::ArgumentBuffer) -> IsNull {
         match BigDecimal::try_from(*self) {
             Ok(res) => res.encode(buf),
-            Err(err) => {
-                tracing::error!(?err, "failed to encode gas");
+            Err(e) => {
+                tracing::error!(reason = ?e, "failed to encode gas");
                 IsNull::Yes
             }
         }
@@ -91,8 +91,8 @@ impl<'q> sqlx::Encode<'q, sqlx::Postgres> for Wei {
     {
         match BigDecimal::try_from(self) {
             Ok(res) => res.encode(buf),
-            Err(err) => {
-                tracing::error!(?err, "failed to encode gas");
+            Err(e) => {
+                tracing::error!(reason = ?e, "failed to encode gas");
                 IsNull::Yes
             }
         }

--- a/src/eth/relayer/external.rs
+++ b/src/eth/relayer/external.rs
@@ -323,7 +323,7 @@ impl ExternalRelayer {
         let tx_hash: Hash = stratus_tx.input.hash;
         let block_number: BlockNumber = stratus_tx.block_number;
 
-        tracing::info!(?block_number, ?tx_hash, ?substrate_pending_transaction.tx_hash, "comparing receipts");
+        tracing::info!(%block_number, %tx_hash, ?substrate_pending_transaction.tx_hash, "comparing receipts");
 
         // fill span
         Span::with(|s| s.rec_str("hash", &tx_hash));
@@ -370,7 +370,7 @@ impl ExternalRelayer {
         let hash = stratus_receipt.input.hash;
         let block_number = stratus_receipt.block_number;
 
-        tracing::info!(?block_number, ?hash, "saving transaction mismatch");
+        tracing::info!(%block_number, ?hash, "saving transaction mismatch");
 
         let stratus_json = to_json_value(stratus_receipt);
         let substrate_json = to_json_value(substrate_receipt);
@@ -387,14 +387,14 @@ impl ExternalRelayer {
             .await
             {
                 Ok(res) => break res,
-                Err(err) => tracing::error!(?block_number, ?hash, ?err, "failed to insert row in pgsql, retrying"),
+                Err(err) => tracing::error!(%block_number, ?hash, ?err, "failed to insert row in pgsql, retrying"),
             }
         };
 
         if res.rows_affected() == 0 {
             tracing::info!(
-                ?block_number,
-                ?hash,
+                %block_number,
+                %hash,
                 "transaction mismatch already in database (this should only happen if this block is being retried)."
             );
         };
@@ -520,7 +520,7 @@ impl ExternalRelayerClient {
         let start = metrics::now();
 
         let block_number = block.header.number;
-        tracing::info!(?block_number, "sending block to relayer");
+        tracing::info!(%block_number, "sending block to relayer");
 
         // strip bytecode
         for tx in block.transactions.iter_mut() {

--- a/src/eth/relayer/external.rs
+++ b/src/eth/relayer/external.rs
@@ -160,27 +160,27 @@ impl ExternalRelayer {
 
         let point_in_time = StoragePointInTime::Past(block_number);
         let mut futures = vec![];
-        for (addr, index) in changed_slots {
+        for (address, index) in changed_slots {
             futures.push(async move {
             let stratus_slot_value = loop {
-                match self.stratus_chain.fetch_storage_at(&addr, &index, point_in_time).await {
+                match self.stratus_chain.fetch_storage_at(&address, &index, point_in_time).await {
                     Ok(value) => break value,
-                    Err(err) => tracing::warn!(?addr, ?index, ?err, "failed to fetch slot value from stratus, retrying..."),
+                    Err(e) => tracing::warn!(reason = ?e, %address, %index, "failed to fetch slot value from stratus, retrying..."),
                 }
             };
 
             let substrate_slot_value = loop {
-                match self.substrate_chain.fetch_storage_at(&addr, &index, StoragePointInTime::Present).await {
+                match self.substrate_chain.fetch_storage_at(&address, &index, StoragePointInTime::Present).await {
                     Ok(value) => break value,
-                    Err(err) => tracing::warn!(?addr, ?index, ?err, "failed to fetch slot value from substrate, retrying..."),
+                    Err(e) => tracing::warn!(reason = ?e, %address, %index, "failed to fetch slot value from substrate, retrying..."),
                 }
             };
 
             if stratus_slot_value != substrate_slot_value {
-                tracing::error!(?addr, ?index, ?point_in_time, "evm state mismatch between stratus and substrate");
+                tracing::error!(%address, %index, %point_in_time, "evm state mismatch between stratus and substrate");
                 while let Err(e) = sqlx::query!(
                     "INSERT INTO slot_mismatches (address, index, block_number, stratus_value, substrate_value) VALUES ($1, $2, $3, $4, $5) ON CONFLICT DO NOTHING",
-                    addr as _,
+                    address as _,
                     index as _,
                     block_number as _,
                     stratus_slot_value as _,
@@ -315,7 +315,7 @@ impl ExternalRelayer {
 
     /// Compares the given receipt to the receipt returned by the pending transaction, retries until a receipt is returned
     /// to ensure the nonce was incremented. In case of a mismatch it returns an error describing what mismatched.
-    #[tracing::instrument(name = "external_relayer::compare_receipt", skip_all, fields(hash))]
+    #[tracing::instrument(name = "external_relayer::compare_receipt", skip_all, fields(tx_hash))]
     async fn compare_receipt(&self, mut stratus_tx: TransactionMined, substrate_pending_transaction: PendingTransaction<'_>) -> anyhow::Result<(), RelayError> {
         #[cfg(feature = "metrics")]
         let start_metric = metrics::now();
@@ -326,16 +326,16 @@ impl ExternalRelayer {
         tracing::info!(%block_number, %tx_hash, ?substrate_pending_transaction.tx_hash, "comparing receipts");
 
         // fill span
-        Span::with(|s| s.rec_str("hash", &tx_hash));
+        Span::with(|s| s.rec_str("tx_hash", &tx_hash));
 
         let mut substrate_receipt = substrate_pending_transaction;
         let _res = {
             let receipt = loop {
                 match substrate_receipt.await {
                     Ok(r) => break r,
-                    Err(err) => {
+                    Err(e) => {
                         substrate_receipt = PendingTransaction::new(tx_hash, &self.substrate_chain);
-                        tracing::warn!(?err);
+                        tracing::warn!(reason = ?e);
                         continue;
                     }
                 }
@@ -367,17 +367,17 @@ impl ExternalRelayer {
         #[cfg(feature = "metrics")]
         let start = metrics::now();
 
-        let hash = stratus_receipt.input.hash;
+        let tx_hash = stratus_receipt.input.hash;
         let block_number = stratus_receipt.block_number;
 
-        tracing::info!(%block_number, ?hash, "saving transaction mismatch");
+        tracing::info!(%block_number, %tx_hash, "saving transaction mismatch");
 
         let stratus_json = to_json_value(stratus_receipt);
         let substrate_json = to_json_value(substrate_receipt);
         let res = loop {
             match sqlx::query!(
                 "INSERT INTO mismatches (hash, block_number, stratus_receipt, substrate_receipt, error) VALUES ($1, $2, $3, $4, $5) ON CONFLICT DO NOTHING",
-                &hash as _,
+                &tx_hash as _,
                 block_number as _,
                 &stratus_json,
                 &substrate_json,
@@ -387,14 +387,14 @@ impl ExternalRelayer {
             .await
             {
                 Ok(res) => break res,
-                Err(err) => tracing::error!(%block_number, ?hash, ?err, "failed to insert row in pgsql, retrying"),
+                Err(e) => tracing::error!(reason = ?e, %block_number, %tx_hash, "failed to insert row in pgsql, retrying"),
             }
         };
 
         if res.rows_affected() == 0 {
             tracing::info!(
                 %block_number,
-                %hash,
+                %tx_hash,
                 "transaction mismatch already in database (this should only happen if this block is being retried)."
             );
         };
@@ -408,19 +408,19 @@ impl ExternalRelayer {
         loop {
             match self.substrate_chain.send_raw_transaction(rlp.clone()).await {
                 Ok(tx) => break tx,
-                Err(err) => {
+                Err(e) => {
                     tracing::warn!(
-                        ?tx_mined.input.nonce,
-                        ?tx_hash,
+                        tx_nonnce = %tx_mined.input.nonce,
+                        %tx_hash,
                         "substrate_chain.send_raw_transaction returned an error, checking if transaction was sent anyway"
                     );
 
                     if self.substrate_chain.fetch_transaction(tx_hash).await.unwrap_or(None).is_some() {
-                        tracing::info!(?tx_hash, "transaction found on substrate");
+                        tracing::info!(%tx_hash, "transaction found on substrate");
                         return PendingTransaction::new(tx_hash, &self.substrate_chain);
                     }
 
-                    tracing::warn!(?tx_hash, ?err, "failed to send raw transaction, retrying...");
+                    tracing::warn!(reason = ?e, %tx_hash, "failed to send raw transaction, retrying...");
                     continue;
                 }
             }
@@ -429,17 +429,17 @@ impl ExternalRelayer {
 
     /// Relays a transaction to Substrate and waits until the transaction is in the mempool by
     /// calling eth_getTransactionByHash. (infallible)
-    #[tracing::instrument(name = "external_relayer::relay_and_check_mempool", skip_all, fields(hash))]
+    #[tracing::instrument(name = "external_relayer::relay_and_check_mempool", skip_all, fields(tx_hash))]
     pub async fn relay_and_check_mempool(&self, tx_mined: TransactionMined) -> anyhow::Result<(), RelayError> {
         #[cfg(feature = "metrics")]
         let start = metrics::now();
 
         let tx_hash = tx_mined.input.hash;
 
-        tracing::info!(?tx_mined.input.nonce, ?tx_hash, "relaying transaction");
+        tracing::info!(?tx_mined.input.nonce, %tx_hash, "relaying transaction");
 
         // fill span
-        Span::with(|s| s.rec_str("hash", &tx_hash));
+        Span::with(|s| s.rec_str("tx_hash", &tx_hash));
 
         let rlp = Transaction::from(tx_mined.input.clone()).rlp();
         let mut tx = self.send_transaction(tx_mined.clone(), rlp.clone()).await;
@@ -449,7 +449,7 @@ impl ExternalRelayer {
         loop {
             if let Err(error) = self.compare_receipt(tx_mined.clone(), tx).await {
                 match error {
-                    RelayError::TransactionNotFound => tracing::warn!(?tx_hash, "transaction not found in substrate, trying to resend"),
+                    RelayError::TransactionNotFound => tracing::warn!(%tx_hash, "transaction not found in substrate, trying to resend"),
                     err => break Err(err),
                 }
                 tx = self.send_transaction(tx_mined.clone(), rlp.clone()).await;
@@ -535,7 +535,7 @@ impl ExternalRelayerClient {
         let mut remaining_tries = 5;
 
         while remaining_tries > 0 {
-            if let Err(err) = sqlx::query!(
+            if let Err(e) = sqlx::query!(
                 r#"
                     INSERT INTO relayer_blocks
                     (number, payload)
@@ -549,7 +549,7 @@ impl ExternalRelayerClient {
             .await
             {
                 remaining_tries -= 1;
-                tracing::warn!(?err, ?remaining_tries, "failed to insert into relayer_blocks");
+                tracing::warn!(reason = ?e, ?remaining_tries, "failed to insert into relayer_blocks");
             } else {
                 break;
             }

--- a/src/eth/rpc/rpc_error.rs
+++ b/src/eth/rpc/rpc_error.rs
@@ -29,7 +29,7 @@ impl From<anyhow::Error> for RpcError {
 
 impl From<ErrorObjectOwned> for RpcError {
     fn from(value: ErrorObjectOwned) -> Self {
-        tracing::warn!(?value);
+        tracing::warn!(reason = ?value, "rpc warning response");
         RpcError::Response(value)
     }
 }

--- a/src/eth/rpc/rpc_server.rs
+++ b/src/eth/rpc/rpc_server.rs
@@ -425,10 +425,10 @@ fn eth_get_uncle_by_block_hash_and_index(_: Params<'_>, _: &RpcContext, _: &Exte
 // Transaction
 // -----------------------------------------------------------------------------
 
-#[tracing::instrument(name = "rpc::eth_getTransactionByHash", skip_all, fields(hash, found))]
+#[tracing::instrument(name = "rpc::eth_getTransactionByHash", skip_all, fields(tx_hash, found))]
 fn eth_get_transaction_by_hash(params: Params<'_>, ctx: Arc<RpcContext>, _: Extensions) -> anyhow::Result<JsonValue, RpcError> {
     let (_, hash) = next_rpc_param::<Hash>(params.sequence())?;
-    Span::with(|s| s.rec_str("hash", &hash));
+    Span::with(|s| s.rec_str("tx_hash", &hash));
 
     let tx = ctx.storage.read_transaction(&hash)?;
     Span::with(|s| {
@@ -441,10 +441,10 @@ fn eth_get_transaction_by_hash(params: Params<'_>, ctx: Arc<RpcContext>, _: Exte
     }
 }
 
-#[tracing::instrument(name = "rpc::eth_getTransactionReceipt", skip_all, fields(hash, found))]
+#[tracing::instrument(name = "rpc::eth_getTransactionReceipt", skip_all, fields(tx_hash, found))]
 fn eth_get_transaction_receipt(params: Params<'_>, ctx: Arc<RpcContext>, _: Extensions) -> anyhow::Result<JsonValue, RpcError> {
     let (_, hash) = next_rpc_param::<Hash>(params.sequence())?;
-    Span::with(|s| s.rec_str("hash", &hash));
+    Span::with(|s| s.rec_str("tx_hash", &hash));
 
     let tx = ctx.storage.read_transaction(&hash)?;
     Span::with(|s| {
@@ -499,15 +499,15 @@ fn eth_call(params: Params<'_>, ctx: Arc<RpcContext>, _: Extensions) -> anyhow::
     }
 }
 
-#[tracing::instrument(name = "rpc::eth_sendRawTransaction", skip_all, fields(hash, from, to))]
+#[tracing::instrument(name = "rpc::eth_sendRawTransaction", skip_all, fields(tx_hash, tx_from, tx_to))]
 fn eth_send_raw_transaction(params: Params<'_>, ctx: Arc<RpcContext>, _: Extensions) -> anyhow::Result<String, RpcError> {
     let (_, data) = next_rpc_param::<Bytes>(params.sequence())?;
     let tx = parse_rpc_rlp::<TransactionInput>(&data)?;
 
     Span::with(|s| {
-        s.rec_str("hash", &tx.hash);
-        s.rec_str("from", &tx.signer);
-        s.rec_opt("to", &tx.to);
+        s.rec_str("tx_hash", &tx.hash);
+        s.rec_str("tx_from", &tx.signer);
+        s.rec_opt("tx_to", &tx.to);
     });
 
     // forward transaction to the leader

--- a/src/eth/rpc/rpc_server.rs
+++ b/src/eth/rpc/rpc_server.rs
@@ -376,12 +376,12 @@ fn eth_block_number(_params: Params<'_>, ctx: Arc<RpcContext>, _: Extensions) ->
     Ok(to_json_value(number))
 }
 
-#[tracing::instrument(name = "rpc::eth_getBlockByHash", skip_all, fields(filter, found, number))]
+#[tracing::instrument(name = "rpc::eth_getBlockByHash", skip_all, fields(filter, block_number, found))]
 fn eth_get_block_by_hash(params: Params<'_>, ctx: Arc<RpcContext>, ext: Extensions) -> anyhow::Result<JsonValue, RpcError> {
     eth_get_block_by_selector(params, ctx, ext)
 }
 
-#[tracing::instrument(name = "rpc::eth_getBlockByNumber", skip_all, fields(filter, found, number))]
+#[tracing::instrument(name = "rpc::eth_getBlockByNumber", skip_all, fields(filter, block_number, found))]
 fn eth_get_block_by_number(params: Params<'_>, ctx: Arc<RpcContext>, ext: Extensions) -> anyhow::Result<JsonValue, RpcError> {
     eth_get_block_by_selector(params, ctx, ext)
 }
@@ -404,7 +404,7 @@ fn eth_get_block_by_selector(params: Params<'_>, ctx: Arc<RpcContext>, _: Extens
     Span::with(|s| {
         s.record("found", block.is_some());
         if let Some(ref block) = block {
-            s.rec_str("number", &block.number());
+            s.rec_str("block_number", &block.number());
         }
     });
 

--- a/src/eth/storage/inmemory/inmemory_permanent.rs
+++ b/src/eth/storage/inmemory/inmemory_permanent.rs
@@ -195,8 +195,8 @@ impl PermanentStorage for InMemoryPermanentStorage {
         let block = match selection {
             BlockSelection::Latest => state_lock.blocks_by_number.values().last().cloned(),
             BlockSelection::Earliest => state_lock.blocks_by_number.values().next().cloned(),
-            BlockSelection::Number(number) => state_lock.blocks_by_number.get(number).cloned(),
-            BlockSelection::Hash(hash) => state_lock.blocks_by_hash.get(hash).cloned(),
+            BlockSelection::Number(block_number) => state_lock.blocks_by_number.get(block_number).cloned(),
+            BlockSelection::Hash(block_hash) => state_lock.blocks_by_hash.get(block_hash).cloned(),
         };
         match block {
             Some(block) => Ok(Some((*block).clone())),

--- a/src/eth/storage/rocks/rocks_state.rs
+++ b/src/eth/storage/rocks/rocks_state.rs
@@ -128,7 +128,7 @@ impl RocksStorageState {
 
     pub fn preload_block_number(&self) -> anyhow::Result<AtomicU64> {
         let block_number = self.blocks_by_number.last_key().unwrap_or_default();
-        tracing::info!(number = %block_number, "preloaded block_number");
+        tracing::info!(%block_number, "preloaded block_number");
         Ok((u64::from(block_number)).into())
     }
 

--- a/src/eth/storage/rocks/rocks_state.rs
+++ b/src/eth/storage/rocks/rocks_state.rs
@@ -385,9 +385,9 @@ impl RocksStorageState {
         let block = match selection {
             BlockSelection::Latest => self.blocks_by_number.iter_end().next().map(|(_, block)| block),
             BlockSelection::Earliest => self.blocks_by_number.iter_start().next().map(|(_, block)| block),
-            BlockSelection::Number(number) => self.blocks_by_number.get(&(*number).into()),
-            BlockSelection::Hash(hash) =>
-                if let Some(block_number) = self.blocks_by_hash.get(&(*hash).into()) {
+            BlockSelection::Number(block_number) => self.blocks_by_number.get(&(*block_number).into()),
+            BlockSelection::Hash(block_hash) =>
+                if let Some(block_number) = self.blocks_by_hash.get(&(*block_hash).into()) {
                     self.blocks_by_number.get(&block_number)
                 } else {
                     None
@@ -480,8 +480,8 @@ impl RocksStorageState {
         let batch_len = batch.len();
         let result = self.db.write(batch);
 
-        if let Err(err) = &result {
-            tracing::error!(?err, batch_len, "failed to write batch to DB");
+        if let Err(e) = &result {
+            tracing::error!(reason = ?e, batch_len, "failed to write batch to DB");
         }
         result.map_err(Into::into)
     }

--- a/src/infra/blockchain_client/blockchain_client.rs
+++ b/src/infra/blockchain_client/blockchain_client.rs
@@ -161,10 +161,10 @@ impl BlockchainClient {
     }
 
     /// Fetches a block by hash.
-    pub async fn fetch_block_by_hash(&self, hash: Hash, tx_detail: bool) -> anyhow::Result<JsonValue> {
-        tracing::debug!(%hash, "fetching block");
+    pub async fn fetch_block_by_hash(&self, tx_hash: Hash, tx_detail: bool) -> anyhow::Result<JsonValue> {
+        tracing::debug!(%tx_hash, "fetching block");
 
-        let hash = to_json_value(hash);
+        let hash = to_json_value(tx_hash);
         let result = self
             .http
             .request::<JsonValue, Vec<JsonValue>>("eth_getBlockByHash", vec![hash, JsonValue::Bool(tx_detail)])
@@ -177,10 +177,10 @@ impl BlockchainClient {
     }
 
     /// Fetches a transaction by hash.
-    pub async fn fetch_transaction(&self, hash: Hash) -> anyhow::Result<Option<Transaction>> {
-        tracing::debug!(%hash, "fetching transaction");
+    pub async fn fetch_transaction(&self, tx_hash: Hash) -> anyhow::Result<Option<Transaction>> {
+        tracing::debug!(%tx_hash, "fetching transaction");
 
-        let hash = to_json_value(hash);
+        let hash = to_json_value(tx_hash);
 
         let result = self
             .http
@@ -194,10 +194,10 @@ impl BlockchainClient {
     }
 
     /// Fetches a receipt by hash.
-    pub async fn fetch_receipt(&self, hash: Hash) -> anyhow::Result<Option<ExternalReceipt>> {
-        tracing::debug!(%hash, "fetching transaction receipt");
+    pub async fn fetch_receipt(&self, tx_hash: Hash) -> anyhow::Result<Option<ExternalReceipt>> {
+        tracing::debug!(%tx_hash, "fetching transaction receipt");
 
-        let hash = to_json_value(hash);
+        let hash = to_json_value(tx_hash);
         let result = self
             .http
             .request::<Option<ExternalReceipt>, Vec<JsonValue>>("eth_getTransactionReceipt", vec![hash])
@@ -225,7 +225,7 @@ impl BlockchainClient {
 
     /// Fetches a slot by a slot at some block.
     pub async fn fetch_storage_at(&self, address: &Address, index: &SlotIndex, point_in_time: StoragePointInTime) -> anyhow::Result<SlotValue> {
-        tracing::debug!(%address, ?point_in_time, "fetching account balance");
+        tracing::debug!(%address, %point_in_time, "fetching account balance");
 
         let address = to_json_value(address);
         let index = to_json_value(index);
@@ -299,9 +299,9 @@ impl BlockchainClient {
                 e @ Err(ClientError::RestartNeeded(_)) => {
                     // will try to reconnect websocket client only in first attempt
                     if first_attempt {
-                        tracing::error!(%first_attempt, reason = ?e, "failed to subscribe to newHeads event. trying to reconnect websocket client now.");
+                        tracing::error!(reason = ?e, %first_attempt, "failed to subscribe to newHeads event. trying to reconnect websocket client now.");
                     } else {
-                        tracing::error!(%first_attempt, reason = ?e, "failed to subscribe to newHeads event. will not try to reconnect websocket client.");
+                        tracing::error!(reason = ?e, %first_attempt, "failed to subscribe to newHeads event. will not try to reconnect websocket client.");
                         return e.context("failed to subscribe to newHeads event");
                     }
                     first_attempt = false;

--- a/src/infra/blockchain_client/blockchain_client.rs
+++ b/src/infra/blockchain_client/blockchain_client.rs
@@ -28,6 +28,7 @@ use crate::eth::primitives::StoragePointInTime;
 use crate::eth::primitives::Wei;
 use crate::ext::to_json_value;
 use crate::ext::DisplayExt;
+use crate::infra::tracing::TracingExt;
 use crate::log_and_err;
 
 #[derive(Debug)]
@@ -144,10 +145,10 @@ impl BlockchainClient {
     }
 
     /// Fetches a block by number.
-    pub async fn fetch_block(&self, number: BlockNumber) -> anyhow::Result<JsonValue> {
-        tracing::debug!(%number, "fetching block");
+    pub async fn fetch_block(&self, block_number: BlockNumber) -> anyhow::Result<JsonValue> {
+        tracing::debug!(%block_number, "fetching block");
 
-        let number = to_json_value(number);
+        let number = to_json_value(block_number);
         let result = self
             .http
             .request::<JsonValue, Vec<JsonValue>>("eth_getBlockByNumber", vec![number, JsonValue::Bool(true)])
@@ -209,11 +210,11 @@ impl BlockchainClient {
     }
 
     /// Fetches account balance by address and block number.
-    pub async fn fetch_balance(&self, address: &Address, number: Option<BlockNumber>) -> anyhow::Result<Wei> {
-        tracing::debug!(%address, ?number, "fetching account balance");
+    pub async fn fetch_balance(&self, address: &Address, block_number: Option<BlockNumber>) -> anyhow::Result<Wei> {
+        tracing::debug!(%address, block_number = %block_number.or_empty(), "fetching account balance");
 
         let address = to_json_value(address);
-        let number = to_json_value(number);
+        let number = to_json_value(block_number);
         let result = self.http.request::<Wei, Vec<JsonValue>>("eth_getBalance", vec![address, number]).await;
 
         match result {

--- a/src/infra/tracing.rs
+++ b/src/infra/tracing.rs
@@ -1,6 +1,8 @@
 //! Tracing services.
 
 use std::collections::HashMap;
+use std::fmt::Debug;
+use std::fmt::Display;
 use std::io::stdout;
 use std::io::IsTerminal;
 use std::net::SocketAddr;
@@ -494,6 +496,28 @@ impl SpanExt for Span {
     {
         if let Some(ref value) = value {
             self.record(field, value.to_string().as_str());
+        }
+    }
+}
+
+// -----------------------------------------------------------------------------
+// TracingExt
+// -----------------------------------------------------------------------------
+
+/// Extensions for values used as fields in `tracing` macros.
+pub trait TracingExt {
+    /// Returns the `Display` value of the inner value or an empty string.
+    fn or_empty(&self) -> String;
+}
+
+impl<T> TracingExt for Option<T>
+where
+    T: Display + Debug,
+{
+    fn or_empty(&self) -> String {
+        match self {
+            Some(value) => value.to_string(),
+            None => String::new(),
         }
     }
 }


### PR DESCRIPTION
Ensure that in tracing events and spans:
* Block number fields is always `block_number`.
* Transaction Hash is always `tx_hash`.
* Account address is `address`.
* Error cause is `reason`.

Values are displayed using Display implementation.