### PR TITLE
RPC: reuse log subscriptions with same filter

### DIFF
--- a/src/eth/primitives/block_filter.rs
+++ b/src/eth/primitives/block_filter.rs
@@ -3,7 +3,7 @@ use std::fmt::Display;
 use crate::eth::primitives::BlockNumber;
 use crate::eth::primitives::Hash;
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, Hash)]
 pub enum BlockFilter {
     /// Retrieve the most recent block.
     #[default]

--- a/src/eth/primitives/log_filter.rs
+++ b/src/eth/primitives/log_filter.rs
@@ -6,7 +6,7 @@ use crate::eth::primitives::LogFilterInput;
 use crate::eth::primitives::LogMined;
 use crate::ext::not;
 
-#[derive(DebugAsJson, serde::Serialize)]
+#[derive(Clone, DebugAsJson, serde::Serialize, Eq, Hash, PartialEq)]
 #[cfg_attr(test, derive(Default))]
 pub struct LogFilter {
     pub from_block: BlockNumber,

--- a/src/eth/primitives/log_filter_input.rs
+++ b/src/eth/primitives/log_filter_input.rs
@@ -23,7 +23,7 @@ use crate::eth::storage::StratusStorage;
 
 /// JSON-RPC input used in methods like `eth_getLogs` and `eth_subscribe`.
 #[serde_as]
-#[derive(Debug, Clone, Default, serde::Deserialize, serde::Serialize, PartialEq)]
+#[derive(Debug, Clone, Default, serde::Deserialize, serde::Serialize, PartialEq, Eq, Hash)]
 pub struct LogFilterInput {
     #[serde(rename = "fromBlock", default)]
     pub from_block: Option<BlockFilter>,
@@ -81,7 +81,7 @@ impl LogFilterInput {
 }
 
 #[serde_as]
-#[derive(Debug, Clone, Default, serde::Deserialize, serde::Serialize, PartialEq)]
+#[derive(Debug, Clone, Default, serde::Deserialize, serde::Serialize, PartialEq, Eq, Hash)]
 // This nested type is necessary to fine-tune how we want serde to deserialize the topics field
 pub struct LogFilterInputTopic(#[serde_as(deserialize_as = "OneOrMany<_, PreferMany>")] pub Vec<Option<LogTopic>>);
 

--- a/src/eth/primitives/log_topic.rs
+++ b/src/eth/primitives/log_topic.rs
@@ -8,7 +8,7 @@ use revm::primitives::B256 as RevmB256;
 use crate::gen_newtype_from;
 
 /// Topic is part of a [`Log`](super::Log) emitted by the EVM during contract execution.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize, Default, Hash)]
 pub struct LogTopic(H256);
 
 impl LogTopic {

--- a/src/eth/rpc/rpc_server.rs
+++ b/src/eth/rpc/rpc_server.rs
@@ -1,5 +1,6 @@
 //! RPC server for HTTP and WS.
 
+use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::ops::Deref;
 use std::sync::Arc;
@@ -332,7 +333,7 @@ async fn stratus_get_subscriptions(_: Params<'_>, ctx: Arc<RpcContext>, _: Exten
             ).collect_vec()
         ,
         "logs":
-            logs.iter().map(|s|
+            logs.values().flat_map(HashMap::values).map(|s|
                 json!({
                     "created_at": s.created_at,
                     "client": s.client,


### PR DESCRIPTION
Fix #1258.

Also, reduce RwLock unnecessary retention in subscription notifications.