### PR TITLE
Create feature `expensive-spans`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,13 +185,16 @@ path = "src/bin/relayer.rs"
 default = ["bg-threads", "metrics", "tracing", "rocks"]
 
 # Application is running in develoment mode.
-dev  = []
+dev = []
 
 # Enable runtime metrics collection.
 metrics = ["dep:metrics-exporter-prometheus"]
 
 # Enable runtime tracing/spans collection.
 tracing = []
+
+# Enable expensive tracing spans for debugging purposes.
+expensive-spans = []
 
 # Background tasks are spawned using threads instead of Tokio blocking tasks.
 bg-threads = []

--- a/src/eth/storage/stratus_storage.rs
+++ b/src/eth/storage/stratus_storage.rs
@@ -217,6 +217,7 @@ impl StratusStorage {
 
     #[tracing::instrument(name = "storage::read_account", skip_all, fields(address, point_in_time))]
     pub fn read_account(&self, address: &Address, point_in_time: &StoragePointInTime) -> anyhow::Result<Account> {
+        #[cfg(feature = "expensive-spans")]
         Span::with(|s| {
             s.rec_str("address", address);
             s.rec_str("point_in_time", point_in_time);
@@ -253,6 +254,7 @@ impl StratusStorage {
 
     #[tracing::instrument(name = "storage::read_slot", skip_all, fields(address, index, point_in_time))]
     pub fn read_slot(&self, address: &Address, index: &SlotIndex, point_in_time: &StoragePointInTime) -> anyhow::Result<Slot> {
+        #[cfg(feature = "expensive-spans")]
         Span::with(|s| {
             s.rec_str("address", address);
             s.rec_str("index", index);


### PR DESCRIPTION
To disable spans that hurt our run time.

These can be re-enabled for debugging purposes.