### PR TITLE
enha: improve save log entry behavior on leader

### DIFF
--- a/src/eth/consensus/mod.rs
+++ b/src/eth/consensus/mod.rs
@@ -449,6 +449,7 @@ impl Consensus {
                             current_term,
                             LogEntryData::TransactionExecutionEntries(executions.clone()),
                             "transaction",
+                            true,
                         ) {
                             Ok(_) => {
                                 tracing::debug!("Transaction execution entry saved successfully");
@@ -518,6 +519,7 @@ impl Consensus {
                                     current_term,
                                     LogEntryData::BlockEntry(block.header.to_append_entry_block_header(transaction_hashes.clone())),
                                     "block",
+                                    true
                                 ) {
                                     Ok(_) => {
                                         tracing::debug!("Block entry saved successfully");

--- a/src/eth/consensus/server.rs
+++ b/src/eth/consensus/server.rs
@@ -108,7 +108,7 @@ impl AppendEntryService for AppendEntryServiceImpl {
             //    }
             //}
 
-            if let Err(e) = consensus.log_entries_storage.save_log_entry(index, term, data, "transaction") {
+            if let Err(e) = consensus.log_entries_storage.save_log_entry(index, term, data, "transaction", false) {
                 tracing::error!("Failed to save log entry: {:?}", e);
                 return Err(Status::internal("Failed to save log entry"));
             }
@@ -228,7 +228,7 @@ impl AppendEntryService for AppendEntryServiceImpl {
             //}
             tracing::info!(number = block_entry.number, "appending new block");
 
-            if let Err(e) = consensus.log_entries_storage.save_log_entry(index, term, data, "block") {
+            if let Err(e) = consensus.log_entries_storage.save_log_entry(index, term, data, "block", false) {
                 tracing::error!("Failed to save log entry: {:?}", e);
                 return Err(Status::internal("Failed to save log entry"));
             }


### PR DESCRIPTION
As per RAFT specification, a leader never overwrites or deletes entries in its log; it only appends new entries. This PR adds a conditional to save_log_entry method to distinguish between leader or follower behavior.