### PR TITLE
e2e: sleep between tests to fix interference

### DIFF
--- a/e2e/test/automine/e2e-tx-parallel-contract.test.ts
+++ b/e2e/test/automine/e2e-tx-parallel-contract.test.ts
@@ -17,6 +17,8 @@ describe("Transaction: parallel TestContractBalances", async () => {
     let _contract: TestContractBalances;
 
     it("Resets blockchain", async () => {
+        // HACK: sleeps for 50ms to avoid having the previous test interfering
+        await new Promise((resolve) => setTimeout(resolve, 50));
         await sendReset();
         const blockNumber = await send("eth_blockNumber", []);
         expect(blockNumber).to.be.oneOf(["0x0", "0x1"]);
@@ -109,11 +111,11 @@ describe("Transaction: parallel TestContractCounter", async () => {
     let _contract: TestContractCounter;
 
     it("Resets blockchain", async () => {
+        // HACK: sleeps for 50ms to avoid having the previous test interfering
+        await new Promise((resolve) => setTimeout(resolve, 50));
         await sendReset();
         const blockNumber = await send("eth_blockNumber", []);
-        // // TODO: re-enable this, for some reason it's returning `0x49`
-        // // maybe the Rocks running in multi-threaded mode doesn't guarantee an immediate impact
-        // expect(blockNumber).to.be.oneOf(["0x0", "0x1"]);
+        expect(blockNumber).to.be.oneOf(["0x0", "0x1"]);
     });
 
     it("Deploy TestContractCounter", async () => {

--- a/e2e/test/automine/e2e-tx-parallel-transfer.test.ts
+++ b/e2e/test/automine/e2e-tx-parallel-transfer.test.ts
@@ -5,10 +5,13 @@ import { pollReceipts, send, sendGetBalance, sendRawTransactions, sendReset } fr
 
 describe("Transaction: parallel transfer", () => {
     it("Resets blockchain", async () => {
+        // HACK: sleeps for 50ms to avoid having the previous test interfering
+        await new Promise((resolve) => setTimeout(resolve, 50));
         await sendReset();
         const blockNumber = await send("eth_blockNumber", []);
         expect(blockNumber).to.be.oneOf(["0x0", "0x1"]);
     });
+
     it("Sends parallel requests", async () => {
         const counterParty = randomAccounts(1)[0];
         expect(await sendGetBalance(counterParty.address)).eq(0, "counterParty initial balance mismatch");

--- a/e2e/test/automine/e2e-tx-serial-contract.test.ts
+++ b/e2e/test/automine/e2e-tx-serial-contract.test.ts
@@ -27,6 +27,8 @@ describe("Transaction: serial TestContractBalances", () => {
     let _block: number;
 
     it("Resets blockchain", async () => {
+        // HACK: sleeps for 50ms to avoid having the previous test interfering
+        await new Promise((resolve) => setTimeout(resolve, 50));
         await sendReset();
         const blockNumber = await send("eth_blockNumber", []);
         expect(blockNumber).to.be.oneOf(["0x0", "0x1"]);

--- a/e2e/test/automine/e2e-tx-serial-transfer.test.ts
+++ b/e2e/test/automine/e2e-tx-serial-transfer.test.ts
@@ -30,6 +30,8 @@ describe("Transaction: serial transfer", () => {
     var new_account: Account;
 
     it("Resets blockchain", async () => {
+        // HACK: sleeps for 50ms to avoid having the previous test interfering
+        await new Promise((resolve) => setTimeout(resolve, 50));
         await sendReset();
         const blockNumber = await send("eth_blockNumber", []);
         expect(blockNumber).to.be.oneOf(["0x0", "0x1"]);
@@ -126,6 +128,8 @@ describe("EIP-1559: serial transfer", () => {
     var _txSentTimestamp: number;
 
     it("Resets blockchain", async () => {
+        // HACK: sleeps for 50ms to avoid having the previous test interfering
+        await new Promise((resolve) => setTimeout(resolve, 50));
         await sendReset();
         const blockNumber = await send("eth_blockNumber", []);
         expect(blockNumber).to.be.oneOf(["0x0", "0x1"]);

--- a/e2e/test/external/e2e-multiple-tx.test.ts
+++ b/e2e/test/external/e2e-multiple-tx.test.ts
@@ -10,10 +10,13 @@ describe("Multiple Transactions Per Block", () => {
     });
 
     it("Resets blockchain", async () => {
+        // HACK: sleeps for 50ms to avoid having the previous test interfering
+        await new Promise((resolve) => setTimeout(resolve, 50));
         await sendReset();
         const blockNumber = await send("eth_blockNumber", []);
         expect(blockNumber).to.be.oneOf(["0x0", "0x1"]);
     });
+
     it("Send multiple transactions and mine block", async () => {
         const counterParty = randomAccounts(1)[0];
         expect(await sendGetBalance(counterParty.address)).eq(0);


### PR DESCRIPTION
some e2e tests were interfering with the state of the next one, to work around this, this PR adds a sleep between them (as a temporary solution)