### PR TITLE
perf: remove nonce depencency, split graph components for parallel relaying

### DIFF
--- a/src/eth/relayer/external.rs
+++ b/src/eth/relayer/external.rs
@@ -532,14 +532,9 @@ impl ExternalRelayer {
         }
     }
 
-    /// Relays a dag by removing its roots and sending them consecutively. Returns `Ok` if we confirmed that all transactions
-    /// had the same receipts, returns `Err` if one or more transactions had receipts mismatches. The mismatches are saved
-    /// on the `mismatches` table in pgsql, or in ./data as a fallback.
-    #[tracing::instrument(name = "external_relayer::relay_dag", skip_all)]
-    async fn relay_dag(&self, mut dag: TransactionDag) -> MismatchedBlocks {
+    /// Relays a dag by removing its roots and sending them consecutively.
+    async fn relay_component(&self, mut dag: TransactionDag) -> MismatchedBlocks {
         let start = Instant::now();
-
-        tracing::debug!("relaying transactions");
 
         let mut results = vec![];
         while let Some(roots) = dag.take_roots() {
@@ -561,6 +556,20 @@ impl ExternalRelayer {
                 _ => panic!("unexpected error"),
             };
         }
+
+        mismatched_blocks
+    }
+
+    #[tracing::instrument(name = "external_relayer::relay_dag", skip_all)]
+    async fn relay_dag(&self, dag: TransactionDag) -> MismatchedBlocks {
+        let start = Instant::now();
+
+        tracing::debug!("relaying transactions");
+
+        let futures = dag.split_components().into_iter().map(|dag| self.relay_component(dag));
+        let results = join_all(futures).await;
+
+        let mismatched_blocks: MismatchedBlocks = results.into_iter().flatten().collect();
 
         #[cfg(feature = "metrics")]
         metrics::inc_relay_dag(start.elapsed());

--- a/src/eth/relayer/external.rs
+++ b/src/eth/relayer/external.rs
@@ -560,7 +560,6 @@ impl ExternalRelayer {
         mismatched_blocks
     }
 
-
     // Split the dag and relay its components.
     #[tracing::instrument(name = "external_relayer::relay_dag", skip_all)]
     async fn relay_dag(&self, dag: TransactionDag) -> MismatchedBlocks {

--- a/src/eth/relayer/external.rs
+++ b/src/eth/relayer/external.rs
@@ -560,6 +560,8 @@ impl ExternalRelayer {
         mismatched_blocks
     }
 
+
+    // Split the dag and relay its components.
     #[tracing::instrument(name = "external_relayer::relay_dag", skip_all)]
     async fn relay_dag(&self, dag: TransactionDag) -> MismatchedBlocks {
         let start = Instant::now();


### PR DESCRIPTION
Adding a nonce dependency obviously defeated the whole purpose of resigning the transactions. But it fixed a logic error this also fixes the same issue but does so without compromising on performance.