### PR TITLE
ci: use shorter and precise names for artifacts

### DIFF
--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -56,7 +56,7 @@ jobs:
         uses: actions/upload-artifact@v4
         id: upload-rwi
         with:
-            name: stratus-run-with-importer-linux-${{ github.sha }}
+            name: run-with-importer-${{ github.sha }}
             path: target/release/run-with-importer
             if-no-files-found: error
             retention-days: ${{ env.RETENTION_DAYS }}
@@ -65,7 +65,7 @@ jobs:
         uses: actions/upload-artifact@v4
         id: upload-str
         with:
-            name: stratus-linux-${{ github.sha }}
+            name: stratus-${{ github.sha }}
             path: target/release/stratus
             if-no-files-found: error
             retention-days: ${{ env.RETENTION_DAYS }}
@@ -74,7 +74,7 @@ jobs:
         uses: actions/upload-artifact@v4
         id: upload-iom
         with:
-            name: stratus-importer-online-${{ github.sha }}
+            name: importer-online-${{ github.sha }}
             path: target/release/importer-online
             if-no-files-found: error
             retention-days: ${{ env.RETENTION_DAYS }}
@@ -83,7 +83,7 @@ jobs:
         uses: actions/upload-artifact@v4
         id: upload-rel
         with:
-            name: stratus-relayer-linux-${{ github.sha }}
+            name: relayer-${{ github.sha }}
             path: target/release/relayer
             if-no-files-found: error
             retention-days: ${{ env.RETENTION_DAYS }}


### PR DESCRIPTION
changes from `stratus-*-linux-$SHA` to `*-$SHA`