### PR TITLE
rocks: wait for compaction in shutdown

### DIFF
--- a/src/infra/metrics/mod.rs
+++ b/src/infra/metrics/mod.rs
@@ -6,7 +6,7 @@ mod metrics_types;
 use std::time::Instant;
 
 pub use metrics_definitions::*;
-pub use metrics_init::*;
+pub use metrics_init::init_metrics;
 pub use metrics_types::*;
 
 /// Track metrics execution starting instant.


### PR DESCRIPTION
This PR is an attempt at fixing the slow RocksDB boot.

We analyzed our usage case and decided to sacrifice shutdown time in exchange
of a faster boot, this PR takes a conservative approach and waits up to 15 minutes
for the database to finish compaction.

Waiting for compaction is used in order to "force" the pending logs in WAL to be
written, the library doesn't seem to offer a more direct solution.

When it reaches 15 minutes, it safely cancels the operation and proceed with the
shutdown, I expect it to usually run out of time due to `L0 -> L1` compaction, and
not `WAL -> LOG` flushing.

Shutdowns are timed and logged.
