### PR TITLE
fix: compute transaction's LogsBloom when creating the receipt

### DIFF
--- a/src/eth/block_miner.rs
+++ b/src/eth/block_miner.rs
@@ -296,10 +296,7 @@ pub fn block_from_local(number: BlockNumber, txs: NonEmpty<LocalTransactionExecu
         let mut mined_logs: Vec<LogMined> = Vec::with_capacity(tx.result.execution.logs.len());
         for mined_log in tx.result.execution.logs.clone() {
             // calculate bloom
-            block.header.bloom.accrue(BloomInput::Raw(mined_log.address.as_ref()));
-            for topic in mined_log.topics().into_iter() {
-                block.header.bloom.accrue(BloomInput::Raw(topic.as_ref()));
-            }
+            block.header.bloom.accrue_log(&mined_log);
 
             // mine log
             let mined_log = LogMined {

--- a/src/eth/primitives/logs_bloom.rs
+++ b/src/eth/primitives/logs_bloom.rs
@@ -3,6 +3,7 @@ use std::ops::DerefMut;
 
 use ethereum_types::Bloom;
 
+use crate::eth::primitives::Log;
 use crate::gen_newtype_from;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize, Default)]
@@ -16,6 +17,13 @@ impl LogsBloom {
 
     pub fn from_bytes(bytes: &[u8]) -> Self {
         Self(Bloom::from_slice(bytes))
+    }
+
+    pub fn accrue_log(&mut self, log: &Log) {
+        self.accrue(ethereum_types::BloomInput::Raw(log.address.as_ref()));
+        for topic in log.topics() {
+            self.accrue(ethereum_types::BloomInput::Raw(topic.as_ref()));
+        }
     }
 }
 
@@ -45,5 +53,53 @@ gen_newtype_from!(self = LogsBloom, other = [u8; 256], Bloom);
 impl From<LogsBloom> for Bloom {
     fn from(value: LogsBloom) -> Self {
         value.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use hex_literal::hex;
+
+    use super::*;
+    use crate::eth::primitives::Log;
+
+    #[test]
+    fn compute_bloom() {
+        let log1 = Log {
+            address: hex!("c6d1efd908ef6b69da0749600f553923c465c812").into(),
+            topic0: Some(hex!("ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef").into()),
+            topic1: Some(hex!("000000000000000000000000d1ff9b395856e5a6810f626eca09d61d34fce3b8").into()),
+            topic2: Some(hex!("000000000000000000000000081d2c5b26db6f6e0944e4725b3b61b26e25dd8a").into()),
+            topic3: None,
+            data: hex!("0000000000000000000000000000000000000000000000000000000005f5e100").as_ref().into(),
+        };
+        let log2 = Log {
+            address: hex!("b1f571b3254c99a0a562124738f0193de2b2b2a9").into(),
+            topic0: Some(hex!("8d995e7fbf7a5ef41cee9e6936368925d88e07af89306bb78a698551562e683c").into()),
+            topic1: Some(hex!("000000000000000000000000081d2c5b26db6f6e0944e4725b3b61b26e25dd8a").into()),
+            topic2: None,
+            topic3: None,
+            data: hex!(
+                "0000000000000000000000000000000000000000000000000000000000004dca00000000\
+                0000000000000000000000000000000000000000000000030c9281f0"
+            )
+            .as_ref()
+            .into(),
+        };
+        let mut bloom = LogsBloom::default();
+        bloom.accrue_log(&log1);
+        bloom.accrue_log(&log2);
+
+        let expected: LogsBloom = hex!(
+            "000000000400000000000000000000000000000000000000000000000000\
+        00000000000000000000000000000000000000080000000000000000000000000000000000000000000000000008\
+        00008400202000000000002000000000000000000000000000000010000000000000000000000000040000000000\
+        00100000000000000000000000000000000000000000000000000000000000000000000000001000000000000100\
+        00000000000000000000000000000000000000000000080000000002000000000000000000000000000000002000\
+        000000440000000000000000000000000000000000000000000000000000000000000000000000000000"
+        )
+        .into();
+
+        assert_eq!(bloom, expected);
     }
 }

--- a/src/eth/primitives/logs_bloom.rs
+++ b/src/eth/primitives/logs_bloom.rs
@@ -61,7 +61,6 @@ mod tests {
     use hex_literal::hex;
 
     use super::*;
-    use crate::eth::primitives::Log;
 
     #[test]
     fn compute_bloom() {

--- a/src/eth/primitives/transaction_mined.rs
+++ b/src/eth/primitives/transaction_mined.rs
@@ -4,6 +4,7 @@ use ethers_core::types::Transaction as EthersTransaction;
 use ethers_core::types::TransactionReceipt as EthersReceipt;
 use itertools::Itertools;
 
+use super::logs_bloom::LogsBloom;
 use crate::eth::primitives::BlockNumber;
 use crate::eth::primitives::EvmExecution;
 use crate::eth::primitives::ExternalReceipt;
@@ -74,6 +75,18 @@ impl TransactionMined {
     pub fn is_success(&self) -> bool {
         self.execution.is_success()
     }
+
+    /// Compute the LogsBloom of this transaction
+    pub fn compute_bloom(&self) -> LogsBloom {
+        let mut bloom = LogsBloom::default();
+        for mined_log in self.logs.iter() {
+            bloom.accrue(ethereum_types::BloomInput::Raw(mined_log.log.address.as_ref()));
+            for topic in mined_log.topics().into_iter() {
+                bloom.accrue(ethereum_types::BloomInput::Raw(topic.as_ref()));
+            }
+        }
+        bloom
+    }
 }
 
 // -----------------------------------------------------------------------------
@@ -106,6 +119,7 @@ impl From<TransactionMined> for EthersTransaction {
 
 impl From<TransactionMined> for EthersReceipt {
     fn from(value: TransactionMined) -> Self {
+        let logs_bloom = value.compute_bloom().0;
         Self {
             // receipt specific
             status: Some(if_else!(value.is_success(), 1, 0).into()),
@@ -124,6 +138,7 @@ impl From<TransactionMined> for EthersReceipt {
 
             // logs
             logs: value.logs.into_iter().map_into().collect(),
+            logs_bloom, // TODO: save this to the database instead of computing it every time (could also be useful for eth_getLogs)
 
             // TODO: there are more fields to populate here
             ..Default::default()
@@ -135,9 +150,11 @@ impl From<TransactionMined> for EthersReceipt {
 mod tests {
     use fake::Fake;
     use fake::Faker;
+    use hex_literal::hex;
     use rand::Rng;
 
     use super::*;
+    use crate::eth::primitives::Log;
 
     fn create_tx(transaction_index: u64, block_number: u64) -> TransactionMined {
         TransactionMined {
@@ -161,5 +178,56 @@ mod tests {
         for pair in v {
             format!("{:?}", pair);
         }
+    }
+
+    #[test]
+    fn compute_bloom() {
+        let mut tx = create_tx(0, 0);
+        tx.logs.push(LogMined {
+            transaction_hash: tx.input.hash,
+            transaction_index: tx.transaction_index,
+            log_index: 0.into(),
+            block_number: tx.block_number,
+            block_hash: tx.block_hash,
+            log: Log {
+                address: hex!("c6d1efd908ef6b69da0749600f553923c465c812").into(),
+                topic0: Some(hex!("ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef").into()),
+                topic1: Some(hex!("000000000000000000000000d1ff9b395856e5a6810f626eca09d61d34fce3b8").into()),
+                topic2: Some(hex!("000000000000000000000000081d2c5b26db6f6e0944e4725b3b61b26e25dd8a").into()),
+                topic3: None,
+                data: hex!("0000000000000000000000000000000000000000000000000000000005f5e100").as_ref().into(),
+            },
+        });
+        tx.logs.push(LogMined {
+            transaction_hash: tx.input.hash,
+            transaction_index: tx.transaction_index,
+            log_index: 1.into(),
+            block_number: tx.block_number,
+            block_hash: tx.block_hash,
+            log: Log {
+                address: hex!("b1f571b3254c99a0a562124738f0193de2b2b2a9").into(),
+                topic0: Some(hex!("8d995e7fbf7a5ef41cee9e6936368925d88e07af89306bb78a698551562e683c").into()),
+                topic1: Some(hex!("000000000000000000000000081d2c5b26db6f6e0944e4725b3b61b26e25dd8a").into()),
+                topic2: None,
+                topic3: None,
+                data: hex!(
+                    "0000000000000000000000000000000000000000000000000000000000004dca00000000\
+                0000000000000000000000000000000000000000000000030c9281f0"
+                )
+                .as_ref()
+                .into(),
+            },
+        });
+        let expected: LogsBloom = hex!(
+            "000000000400000000000000000000000000000000000000000000000000\
+        00000000000000000000000000000000000000080000000000000000000000000000000000000000000000000008\
+        00008400202000000000002000000000000000000000000000000010000000000000000000000000040000000000\
+        00100000000000000000000000000000000000000000000000000000000000000000000000001000000000000100\
+        00000000000000000000000000000000000000000000080000000002000000000000000000000000000000002000\
+        000000440000000000000000000000000000000000000000000000000000000000000000000000000000"
+        )
+        .into();
+
+        assert_eq!(tx.compute_bloom(), expected);
     }
 }


### PR DESCRIPTION
closes #1134
Ideally we'd save the bloom to the database when mining the block, but this will have to wait until we have db versioning.