### PR TITLE
ci: ignore flaky consensus tests

### DIFF
--- a/.github/workflows/merge-gatekeeper.yml
+++ b/.github/workflows/merge-gatekeeper.yml
@@ -20,4 +20,4 @@ jobs:
           self: Merge Gatekeeper
           interval: 5
           timeout: 1800
-          ignored: PR Agent,E2E Rocks on pixv3,E2E InMemory on pixv3,E2E Rocks on pixv4,E2E InMemory on pixv4,E2E Rocks on cppv2,E2E InMemory on cppv2
+          ignored: PR Agent,E2E Rocks on pixv3,E2E InMemory on pixv3,E2E Rocks on pixv4,E2E InMemory on pixv4,E2E Rocks on cppv2,E2E InMemory on cppv2,E2E Leader Election with 2 instance(s) and leader restart true,E2E Leader Election with 3 instance(s) and leader restart true


### PR DESCRIPTION
### **PR Type**
configuration changes


___

### **Description**
- Updated the merge gatekeeper workflow to ignore additional flaky consensus tests.
- Added "E2E Leader Election with 2 instance(s) and leader restart true" to the ignored list.
- Added "E2E Leader Election with 3 instance(s) and leader restart true" to the ignored list.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>merge-gatekeeper.yml</strong><dd><code>Update ignored tests in merge gatekeeper workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/merge-gatekeeper.yml

<li>Added two new test scenarios to the ignored list in the merge <br>gatekeeper workflow.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1406/files#diff-81bfd69063f188ba06a94835cf828b1dd5e4fc28f39531b69e246c3cd7e190e1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

