### PR TITLE
fix: storage shutdown when receiving `SIGTERM`

### DIFF
--- a/src/bin/importer_offline.rs
+++ b/src/bin/importer_offline.rs
@@ -93,6 +93,9 @@ async fn run(config: ImporterOfflineConfig) -> anyhow::Result<()> {
         .join()
         .expect("'block-importer' thread panic'ed instead of properly returning an error");
 
+    // Explicitly block the `main` thread to drop the storage.
+    drop(storage);
+
     Ok(())
 }
 

--- a/src/bin/importer_online.rs
+++ b/src/bin/importer_online.rs
@@ -94,10 +94,14 @@ async fn run(config: ImporterOnlineConfig) -> anyhow::Result<()> {
         .await?,
     );
 
-    let result = run_importer_online(executor, miner, storage, chain, config.base.sync_interval).await;
+    let result = run_importer_online(executor, miner, Arc::clone(&storage), chain, config.base.sync_interval).await;
     if let Err(ref e) = result {
         tracing::error!(reason = ?e, "importer-online failed");
     }
+
+    // Explicitly block the `main` thread to drop the storage.
+    drop(storage);
+
     result
 }
 

--- a/src/bin/rpc_downloader.rs
+++ b/src/bin/rpc_downloader.rs
@@ -40,6 +40,7 @@ async fn run(config: RpcDownloaderConfig) -> anyhow::Result<()> {
     // download balances and blocks
     download_balances(Arc::clone(&rpc_storage), &chain, config.initial_accounts).await?;
     download_blocks(rpc_storage, chain, config.paralellism, block_end).await?;
+
     Ok(())
 }
 

--- a/src/bin/run_with_importer.rs
+++ b/src/bin/run_with_importer.rs
@@ -58,8 +58,8 @@ async fn run(config: RunWithImporterConfig) -> anyhow::Result<()> {
         res
     };
 
-    let importer_task = async move {
-        let res = run_importer_online(executor, miner, storage, chain, config.online.sync_interval).await;
+    let importer_task = async {
+        let res = run_importer_online(executor, miner, Arc::clone(&storage), chain, config.online.sync_interval).await;
         GlobalState::shutdown_from(TASK_NAME, "importer online finished unexpectedly");
         res
     };
@@ -69,6 +69,9 @@ async fn run(config: RunWithImporterConfig) -> anyhow::Result<()> {
     tracing::debug!(?rpc_result, ?importer_result, "rpc and importer tasks finished");
     rpc_result?;
     importer_result?;
+
+    // Explicitly block the `main` thread to drop the storage.
+    drop(storage);
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ async fn run(config: StratusConfig) -> anyhow::Result<()> {
 
     // start rpc server
     serve_rpc(
-        storage,
+        Arc::clone(&storage),
         executor,
         miner,
         consensus,
@@ -43,6 +43,9 @@ async fn run(config: StratusConfig) -> anyhow::Result<()> {
         config.replicate_request_to,
     )
     .await?;
+
+    // Explicitly block the `main` thread to drop the storage.
+    drop(storage);
 
     Ok(())
 }


### PR DESCRIPTION
it wasn't finishing properly cause other threads were blocked dropping
our Rocks storage, in turn, the `main` thread was unblocked and
exited early

---

After writing this, it seems like a more general solution is to wait for all threads and tasks to finish.

However, it's still possible to shoot you on the foot by send an `Arc` clone to a spawned thread or task and forgetting about it.

This one, although ugly, seems to work and make it hard to shoot your foot in the process.

An theoretical problem is that RocksDB lost the potential to shut down in parallel with other things, but I can't think of a simple way to do it while guaranteeing proper shutdown.