### PR TITLE
tweak: set RocksDB shutdown timeout to 4 minutes

### DIFF
--- a/src/eth/storage/rocks/rocks_state.rs
+++ b/src/eth/storage/rocks/rocks_state.rs
@@ -572,15 +572,14 @@ impl Drop for RocksStorageState {
         options.set_abort_on_pause(true);
         // flush all write buffers before waiting
         options.set_flush(true);
-        // wait for 15 minutes at max, we're accepting that our shutdown might be slow to guarantee
-        // that the boot is fast
-        options.set_timeout(15 * minute_in_micros);
+        // wait for 4 minutes at max, sacrificing a long shutdown for a faster boot
+        options.set_timeout(4 * minute_in_micros);
 
         tracing::info!("starting rocksdb shutdown");
         let instant = Instant::now();
 
-        // by waiting for compaction, we are also forcing logs to be processed in shutdown so that
-        // they don't take long to process when booting up
+        // here, waiting for is done to force WAL logs to be processed, to skip replaying most of them when booting
+        // up, which was slowing things down
         let result = self.db.wait_for_compact(&options);
         let waited_for = instant.elapsed();
 


### PR DESCRIPTION
we decided that 15 minutes was too long, and 4 minutes of waiting for compaction should be enough for flushing WAL files