### PR TITLE
enha: create max subscription limit per client

### DIFF
--- a/src/bin/run_with_importer.rs
+++ b/src/bin/run_with_importer.rs
@@ -50,6 +50,7 @@ async fn run(config: RunWithImporterConfig) -> anyhow::Result<()> {
             config.address,
             config.executor.chain_id.into(),
             config.max_connections,
+            config.max_subscriptions,
             #[cfg(feature = "request-replication-test-sender")]
             config.replicate_request_to,
         )

--- a/src/config.rs
+++ b/src/config.rs
@@ -263,7 +263,7 @@ pub struct StratusConfig {
     pub max_connections: u32,
 
     /// JSON-RPC max active subscriptions per client.
-    #[arg(long = "max-subscriptions", env = "MAX_SUBSCRIPTIONS", default_value = "10")]
+    #[arg(long = "max-subscriptions", env = "MAX_SUBSCRIPTIONS", default_value = "15")]
     pub max_subscriptions: u32,
 
     #[clap(flatten)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -449,7 +449,7 @@ pub struct RunWithImporterConfig {
     pub max_connections: u32,
 
     /// JSON-RPC max active subscriptions per client.
-    #[arg(long = "max-subscriptions", env = "MAX_SUBSCRIPTIONS", default_value = "10")]
+    #[arg(long = "max-subscriptions", env = "MAX_SUBSCRIPTIONS", default_value = "15")]
     pub max_subscriptions: u32,
 
     #[arg(long = "leader-node", env = "LEADER_NODE")]

--- a/src/config.rs
+++ b/src/config.rs
@@ -262,6 +262,10 @@ pub struct StratusConfig {
     #[arg(long = "max-connections", env = "MAX_CONNECTIONS", default_value = "200")]
     pub max_connections: u32,
 
+    /// JSON-RPC max active subscriptions per client.
+    #[arg(long = "max-subscriptions", env = "MAX_SUBSCRIPTIONS", default_value = "10")]
+    pub max_subscriptions: u32,
+
     #[clap(flatten)]
     pub storage: StratusStorageConfig,
 
@@ -443,6 +447,10 @@ pub struct RunWithImporterConfig {
     /// JSON-RPC max active connections
     #[arg(long = "max-connections", env = "MAX_CONNECTIONS", default_value = "200")]
     pub max_connections: u32,
+
+    /// JSON-RPC max active subscriptions per client.
+    #[arg(long = "max-subscriptions", env = "MAX_SUBSCRIPTIONS", default_value = "10")]
+    pub max_subscriptions: u32,
 
     #[arg(long = "leader-node", env = "LEADER_NODE")]
     pub leader_node: Option<String>, // to simulate this in use locally with other nodes, you need to add the node name into /etc/hostname

--- a/src/eth/rpc/rpc_client_app.rs
+++ b/src/eth/rpc/rpc_client_app.rs
@@ -3,7 +3,7 @@ use std::fmt::Display;
 #[cfg(feature = "metrics")]
 use crate::infra::metrics::MetricLabelValue;
 
-#[derive(Debug, Clone, Default, strum::EnumIs)]
+#[derive(Debug, Clone, Default, strum::EnumIs, PartialEq)]
 pub enum RpcClientApp {
     /// Client application identified itself.
     Identified(String),

--- a/src/eth/rpc/rpc_context.rs
+++ b/src/eth/rpc/rpc_context.rs
@@ -16,6 +16,9 @@ pub struct RpcContext {
     // gas config
     pub gas_price: usize,
 
+    // general config
+    pub max_subscriptions: u32,
+
     // services
     pub executor: Arc<Executor>,
     #[allow(dead_code)] // HACK this was triggered in Rust 1.79

--- a/src/eth/rpc/rpc_error.rs
+++ b/src/eth/rpc/rpc_error.rs
@@ -5,6 +5,7 @@ use jsonrpsee::types::error::INTERNAL_ERROR_CODE;
 use jsonrpsee::types::error::INVALID_PARAMS_CODE;
 use jsonrpsee::types::error::INVALID_REQUEST_CODE;
 use jsonrpsee::types::error::SERVER_IS_BUSY_CODE;
+use jsonrpsee::types::error::TOO_MANY_SUBSCRIPTIONS_CODE;
 use jsonrpsee::types::ErrorObjectOwned;
 
 use crate::eth::primitives::Bytes;
@@ -21,6 +22,7 @@ pub enum RpcError {
     ParameterMissing { rust_type: &'static str },
     ParameterInvalid { rust_type: &'static str, decode_error: String },
     SubscriptionInvalid { event: String },
+    SubscriptionLimit { max_limit: String },
     TransactionInvalidRlp { decode_error: String },
 
     // Execution
@@ -48,6 +50,7 @@ impl RpcError {
             Self::ParameterInvalid { .. } => INVALID_PARAMS_CODE,
             Self::ParameterMissing { .. } => INVALID_PARAMS_CODE,
             Self::SubscriptionInvalid { .. } => INVALID_PARAMS_CODE,
+            Self::SubscriptionLimit { .. } => TOO_MANY_SUBSCRIPTIONS_CODE,
             Self::TransactionInvalidRlp { .. } => INVALID_PARAMS_CODE,
 
             // Execution
@@ -75,6 +78,7 @@ impl RpcError {
             Self::ParameterMissing { rust_type } => format!("Expected {rust_type} parameter, but received nothing."),
             Self::ParameterInvalid { rust_type, .. } => format!("Failed to decode {rust_type} parameter."),
             Self::SubscriptionInvalid { event } => format!("Invalid subscription event: {event}"),
+            Self::SubscriptionLimit { max_limit } => format!("Client has reached the maximum subscription limit of {max_limit}."),
             Self::TransactionInvalidRlp { .. } => "Failed to decode transaction RLP data.".into(),
 
             // Execution

--- a/src/eth/rpc/rpc_subscriptions.rs
+++ b/src/eth/rpc/rpc_subscriptions.rs
@@ -313,7 +313,7 @@ impl RpcSubscriptionsConnected {
             .flat_map(HashMap::values)
             .filter(|s| s.client == *client)
             .count();
-        tracing::info!(%pending_txs, %new_heads, %logs, "client subscriptions");
+        tracing::info!(%pending_txs, %new_heads, %logs, "current client subscriptions");
 
         if pending_txs + new_heads + logs >= max_subscriptions as usize {
             return Err(RpcError::SubscriptionInvalid {

--- a/src/eth/rpc/rpc_subscriptions.rs
+++ b/src/eth/rpc/rpc_subscriptions.rs
@@ -316,8 +316,8 @@ impl RpcSubscriptionsConnected {
         tracing::info!(%pending_txs, %new_heads, %logs, "current client subscriptions");
 
         if pending_txs + new_heads + logs >= max_subscriptions as usize {
-            return Err(RpcError::SubscriptionInvalid {
-                event: format!("max subscriptions per client is {}", max_subscriptions),
+            return Err(RpcError::SubscriptionLimit {
+                max_limit: max_subscriptions.to_string(),
             });
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,6 +39,7 @@ async fn run(config: StratusConfig) -> anyhow::Result<()> {
         config.address,
         config.executor.chain_id.into(),
         config.max_connections,
+        config.max_subscriptions,
         #[cfg(feature = "request-replication-test-sender")]
         config.replicate_request_to,
     )


### PR DESCRIPTION
This PR implements a configurable limit to the max number of subscriptions from `eth_subscribe`, using a default of 15.