### PR TITLE
enha: improve rocksdb error treatment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1920,6 +1920,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
+name = "hex_fmt"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b07f60793ff0a4d9cef0f18e63b5357e06209987153a64648c972c1e5aff336f"
+
+[[package]]
 name = "hkdf"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5118,6 +5124,7 @@ dependencies = [
  "futures-util",
  "glob",
  "hex-literal",
+ "hex_fmt",
  "humantime",
  "indexmap 2.2.6",
  "itertools 0.13.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ const_format = "=0.2.32"
 const-hex = "=1.12.0"
 derive_more = "=0.99.17"
 derive-new = "=0.6.0"
+hex_fmt = "=0.3.0"
 hex-literal = "=0.4.1"
 humantime = "=2.1.0"
 indexmap = { version = "=2.2.6", features = ["serde"] }

--- a/src/eth/storage/rocks/mod.rs
+++ b/src/eth/storage/rocks/mod.rs
@@ -8,5 +8,5 @@ mod rocks_db;
 pub mod rocks_permanent;
 /// State handler for DB and column families.
 mod rocks_state;
-
+/// All types to be serialized and desserialized in the db.
 mod types;

--- a/src/eth/storage/rocks/rocks_cf.rs
+++ b/src/eth/storage/rocks/rocks_cf.rs
@@ -223,20 +223,6 @@ where
         RocksCfIterator::<K, V>::new(iter, &self.column_family)
     }
 
-    #[allow(dead_code)]
-    pub fn last(&self) -> Option<(K, V)> {
-        let cf = self.handle();
-
-        let mut iter = self.db.iterator_cf(&cf, IteratorMode::End);
-        if let Some(Ok((k, v))) = iter.next() {
-            let key = self.deserialize_key_with_context(&k).unwrap();
-            let value = self.deserialize_value_with_context(&v).unwrap();
-            Some((key, value))
-        } else {
-            None
-        }
-    }
-
     pub fn last_key(&self) -> Option<K> {
         let cf = self.handle();
 

--- a/src/eth/storage/rocks/rocks_cf.rs
+++ b/src/eth/storage/rocks/rocks_cf.rs
@@ -13,7 +13,6 @@ use const_hex::hex;
 use rocksdb::BoundColumnFamily;
 use rocksdb::DBIteratorWithThreadMode;
 use rocksdb::IteratorMode;
-use rocksdb::Options;
 use rocksdb::WriteBatch;
 use rocksdb::DB;
 use serde::Deserialize;
@@ -35,8 +34,6 @@ use crate::infra::metrics;
 #[derive(Clone)]
 pub struct RocksCfRef<K, V> {
     db: Arc<DB>,
-    // TODO: check if it's possible to gather metrics from a Column Family, if not, remove this
-    _opts: Options,
     column_family: String,
     _marker: PhantomData<(K, V)>,
 }
@@ -47,11 +44,10 @@ where
     V: Serialize + for<'de> Deserialize<'de> + Debug + Clone,
 {
     /// Create Column Family reference struct.
-    pub fn new(db: Arc<DB>, column_family: &str, opts: Options) -> Self {
+    pub fn new(db: Arc<DB>, column_family: &str) -> Self {
         let this = Self {
             db,
             column_family: column_family.to_owned(),
-            _opts: opts,
             _marker: PhantomData,
         };
 

--- a/src/eth/storage/rocks/rocks_db.rs
+++ b/src/eth/storage/rocks/rocks_db.rs
@@ -49,7 +49,7 @@ pub fn create_or_open_db(path: impl AsRef<Path>, cf_configs: &HashMap<&'static s
 
     #[cfg(feature = "metrics")]
     {
-        let db_name = path.file_name().unwrap().to_str();
+        let db_name = path.file_name().with_context(|| format!("invalid db path without name '{path:?}'"))?.to_str();
         metrics::set_rocks_last_startup_delay_millis(waited_for.as_millis() as u64, db_name);
     }
 

--- a/src/eth/storage/rocks/rocks_permanent.rs
+++ b/src/eth/storage/rocks/rocks_permanent.rs
@@ -75,15 +75,19 @@ impl PermanentStorage for RocksPermanentStorage {
     // ------------------------------------------------------------------------
 
     fn read_account(&self, address: &Address, point_in_time: &StoragePointInTime) -> anyhow::Result<Option<Account>> {
-        Ok(self.state.read_account(address, point_in_time))
+        self.state.read_account(address, point_in_time)
     }
 
     fn read_slot(&self, address: &Address, index: &SlotIndex, point_in_time: &StoragePointInTime) -> anyhow::Result<Option<Slot>> {
-        Ok(self.state.read_slot(address, index, point_in_time))
+        self.state.read_slot(address, index, point_in_time)
     }
 
     fn read_block(&self, selection: &BlockFilter) -> anyhow::Result<Option<Block>> {
-        Ok(self.state.read_block(selection))
+        let block = self.state.read_block(selection);
+        if let Ok(Some(block)) = &block {
+            tracing::trace!(?selection, ?block, "block found");
+        }
+        block
     }
 
     fn read_transaction(&self, hash: &Hash) -> anyhow::Result<Option<TransactionMined>> {

--- a/src/eth/storage/rocks/rocks_permanent.rs
+++ b/src/eth/storage/rocks/rocks_permanent.rs
@@ -107,8 +107,7 @@ impl PermanentStorage for RocksPermanentStorage {
     }
 
     fn save_accounts(&self, accounts: Vec<Account>) -> anyhow::Result<()> {
-        self.state.save_accounts(accounts);
-        Ok(())
+        self.state.save_accounts(accounts)
     }
 
     fn reset_at(&self, block_number: BlockNumber) -> anyhow::Result<()> {

--- a/src/eth/storage/rocks/rocks_state.rs
+++ b/src/eth/storage/rocks/rocks_state.rs
@@ -402,12 +402,13 @@ impl RocksStorageState {
         block.map(Option::map_into)
     }
 
-    pub fn save_accounts(&self, accounts: Vec<Account>) {
+    pub fn save_accounts(&self, accounts: Vec<Account>) -> Result<()> {
         for account in accounts {
             let (key, value) = account.into();
-            self.accounts.insert(key, value.clone());
-            self.accounts_history.insert((key, 0.into()), value);
+            self.accounts.insert(key, value.clone())?;
+            self.accounts_history.insert((key, 0.into()), value)?;
         }
+        Ok(())
     }
 
     pub fn save_block(&self, block: Block) -> anyhow::Result<()> {

--- a/src/eth/storage/rocks/rocks_state.rs
+++ b/src/eth/storage/rocks/rocks_state.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::fmt;
+use std::fmt::Debug;
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::atomic::AtomicU64;
@@ -77,8 +78,8 @@ lazy_static! {
 /// Helper for creating a `RocksCfRef` with our option presets.
 fn new_cf_ref<K, V>(db: &Arc<DB>, column_family: &str) -> RocksCfRef<K, V>
 where
-    K: Serialize + for<'de> Deserialize<'de> + std::hash::Hash + Eq,
-    V: Serialize + for<'de> Deserialize<'de> + Clone,
+    K: Serialize + for<'de> Deserialize<'de> + Debug + std::hash::Hash + Eq,
+    V: Serialize + for<'de> Deserialize<'de> + Debug + Clone,
 {
     tracing::debug!(column_family = column_family, "creating new column family");
 

--- a/src/eth/storage/rocks/rocks_state.rs
+++ b/src/eth/storage/rocks/rocks_state.rs
@@ -466,7 +466,7 @@ impl RocksStorageState {
         self.db.write(batch).unwrap();
     }
 
-    /// Write to all DBs in a batch
+    /// Write to DB in a batch
     fn write_batch(&self, batch: WriteBatch) -> anyhow::Result<()> {
         let batch_len = batch.len();
         let result = self.db.write(batch);
@@ -479,14 +479,14 @@ impl RocksStorageState {
 
     /// Clears in-memory state.
     pub fn clear(&self) -> anyhow::Result<()> {
-        self.accounts.clear()?;
-        self.accounts_history.clear()?;
-        self.account_slots.clear()?;
-        self.account_slots_history.clear()?;
-        self.transactions.clear()?;
-        self.blocks_by_hash.clear()?;
-        self.blocks_by_number.clear()?;
-        self.logs.clear()?;
+        self.accounts.clear().context("when clearing accounts")?;
+        self.accounts_history.clear().context("when clearing accounts_history")?;
+        self.account_slots.clear().context("when clearing account_slots")?;
+        self.account_slots_history.clear().context("when clearing account_slots_history")?;
+        self.transactions.clear().context("when clearing transactions")?;
+        self.blocks_by_hash.clear().context("when clearing blocks_by_hash")?;
+        self.blocks_by_number.clear().context("when clearing blocks_by_number")?;
+        self.logs.clear().context("when clearing logs")?;
         Ok(())
     }
 }

--- a/src/eth/storage/rocks/rocks_state.rs
+++ b/src/eth/storage/rocks/rocks_state.rs
@@ -75,7 +75,7 @@ lazy_static! {
     };
 }
 
-/// Helper for creating a `RocksCfRef` with our option presets.
+/// Helper for creating a `RocksCfRef`, aborting if it wasn't declared in our option presets.
 fn new_cf_ref<K, V>(db: &Arc<DB>, column_family: &str) -> RocksCfRef<K, V>
 where
     K: Serialize + for<'de> Deserialize<'de> + Debug + std::hash::Hash + Eq,
@@ -83,12 +83,12 @@ where
 {
     tracing::debug!(column_family = column_family, "creating new column family");
 
-    let Some(options) = CF_OPTIONS_MAP.get(column_family) else {
-        panic!("column_family `{column_family}` given to `new_cf_ref` not found in config options map");
+    let Some(_options) = CF_OPTIONS_MAP.get(column_family) else {
+        panic!("matching column_family `{column_family}` given to `new_cf_ref` wasn't found in configuration map");
     };
 
     // NOTE: this doesn't create the CFs in the database, read `RocksCfRef` docs for details
-    RocksCfRef::new(Arc::clone(db), column_family, options.clone())
+    RocksCfRef::new(Arc::clone(db), column_family)
 }
 
 /// State handler for our RocksDB storage, separating "tables" by column families.

--- a/src/eth/storage/rocks/rocks_state.rs
+++ b/src/eth/storage/rocks/rocks_state.rs
@@ -387,44 +387,6 @@ impl RocksStorageState {
         }
     }
 
-    pub fn read_all_slots(&self, address: &Address, point_in_time: &StoragePointInTime) -> Result<Vec<Slot>> {
-        let rocks_address: AddressRocksdb = (*address).into();
-
-        let present_slots = {
-            let iter = self
-                .account_slots
-                .iter_from((rocks_address, SlotIndexRocksdb::from(0)), rocksdb::Direction::Forward)?;
-
-            let mut present_slots = vec![];
-            for next in iter {
-                let ((addr, idx), value) = next?;
-
-                if addr != rocks_address {
-                    break;
-                }
-                present_slots.push(Slot {
-                    index: idx.into(),
-                    value: value.into(),
-                });
-            }
-            present_slots
-        };
-
-        match point_in_time {
-            StoragePointInTime::Mined | StoragePointInTime::Pending => Ok(present_slots),
-            StoragePointInTime::MinedPast(_) => {
-                let mut past_slots = Vec::with_capacity(present_slots.len());
-                for index in present_slots.iter().map(|s| s.index) {
-                    let past_slot = self.read_slot(address, &index, point_in_time)?;
-                    if let Some(past_slot) = past_slot {
-                        past_slots.push(past_slot);
-                    }
-                }
-                Ok(past_slots)
-            }
-        }
-    }
-
     pub fn read_account(&self, address: &Address, point_in_time: &StoragePointInTime) -> Result<Option<Account>> {
         if address.is_coinbase() || address.is_zero() {
             //XXX temporary, we will reload the database later without it

--- a/src/eth/storage/rocks/rocks_state.rs
+++ b/src/eth/storage/rocks/rocks_state.rs
@@ -1,9 +1,7 @@
 use std::collections::HashMap;
 use std::collections::HashSet;
-use std::ffi::OsStr;
 use std::fmt;
 use std::fmt::Debug;
-use std::path::Path;
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 use std::time::Instant;
@@ -644,9 +642,8 @@ impl RocksStorageState {
         // The stats are cumulative since opening the db
         // we can get the average in the time interval with: avg = (new_sum - sum)/(new_count - count)
 
-        let mut prev_values = match self.prev_stats.lock() {
-            Ok(guard) => guard,
-            Err(_) => bail!("mutex in get_histogram_average_in_interval is poisoned"),
+        let Ok(mut prev_values) = self.prev_stats.lock() else {
+            bail!("mutex in get_histogram_average_in_interval is poisoned")
         };
         let (prev_sum, prev_count): (Sum, Count) = *prev_values.get(&(hist as u32)).unwrap_or(&(0, 0));
         let data = self.db_options.get_histogram_data(hist);

--- a/src/eth/storage/rocks/types/slot.rs
+++ b/src/eth/storage/rocks/types/slot.rs
@@ -27,7 +27,7 @@ impl From<SlotValueRocksdb> for SlotValue {
     }
 }
 
-#[derive(Clone, Copy, Default, Hash, Eq, PartialEq, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, Copy, Default, Hash, Eq, PartialEq, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]
 pub struct SlotIndexRocksdb(U256);
 
 gen_newtype_from!(self = SlotIndexRocksdb, other = u64);

--- a/tests/test_import_external_snapshot_rocksdb.rs
+++ b/tests/test_import_external_snapshot_rocksdb.rs
@@ -18,7 +18,7 @@ pub mod rocks_test {
 
             let rocks = RocksPermanentStorage::new(Some("test_import_external_snapshot_with_rocksdb".to_string())).unwrap();
             rocks.save_accounts(accounts).unwrap();
-            rocks.state.write_slots(slots);
+            rocks.state.write_slots(slots).unwrap();
 
             common::execute_test("RocksDB", &global_services.config, &docker, rocks, block, receipts).await;
         });


### PR DESCRIPTION
### **User description**
This PR improves error treatment in the lower layers of the RocksDB code.

Things that used to unwrap are now returned and errors are contextualized.

A couple of things to improve (possibly in another PR):
1. Ensure that panics are logged.
2. Minimize the amount of panics.
3. Ensure that all errors are logged once before returning.
4. Add more context (with anyhow) at the storage trait layers.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Improved error handling across RocksDB-related modules using `anyhow`.
- Added detailed context to error messages for better debugging.
- Made several functions fallible to handle errors gracefully.
- Introduced `RocksCfIterator` for iterating over column families with error handling.
- Enhanced logging for block reads and other operations.
- Documented types used for serialization and deserialization in the database.
- Updated tests to handle fallible functions.
- Added `hex_fmt` dependency to `Cargo.toml`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Add `types` module for serialization and deserialization</code>&nbsp; </dd></summary>
<hr>

src/eth/storage/rocks/mod.rs

- Added a new module `types` for serialization and deserialization.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1497/files#diff-38613469ff37344dd2d68aa4da8280b321c01993e312518834dbf4834f9422bc">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rocks_cf.rs</strong><dd><code>Improve error handling and add context in `RocksCfRef`</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/rocks/rocks_cf.rs

<li>Added context to error handling using <code>anyhow</code>.<br> <li> Made <code>RocksCfRef::get</code> and <code>RocksCfRef::insert</code> fallible.<br> <li> Added detailed error messages and context for serialization and <br>deserialization.<br> <li> Introduced <code>RocksCfIterator</code> for iterating over column families with <br>error handling.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1497/files#diff-0eaed53baca4bd2355e2a54a150b305569904a45c93547da288208c6373d1df2">+180/-87</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rocks_permanent.rs</strong><dd><code>Simplify return statements and add logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/rocks/rocks_permanent.rs

<li>Removed unnecessary <code>Ok</code> wrapping in functions.<br> <li> Added logging for block reads.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1497/files#diff-c129c50a85915e0c5154c4e048a4577bd45ce6ae9ec98e95acbcad09ff79b3c6">+8/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rocks_state.rs</strong><dd><code>Enhance error handling and logging in `RocksStorageState`</code></dd></summary>
<hr>

src/eth/storage/rocks/rocks_state.rs

<li>Added context to error handling using <code>anyhow</code>.<br> <li> Improved error messages and logging.<br> <li> Made various functions fallible.<br> <li> Enhanced batch operations with error handling.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1497/files#diff-f7b822022d2c4fd93ec507cd6b5302dcf1646acbf0ee0dd077a047272b686009">+191/-148</a></td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>types.rs</strong><dd><code>Document and enhance types for DB serialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/rocks/types.rs

<li>Added documentation for types used in the database.<br> <li> Added <code>Debug</code> trait to <code>SlotIndexRocksdb</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1497/files#diff-4137f44608b6358ce43e18294a7b890c17094f26643f6033bf928b107fd4fbce">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_import_external_snapshot_rocksdb.rs</strong><dd><code>Handle result of `write_slots` in tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_import_external_snapshot_rocksdb.rs

- Made `write_slots` function fallible and handled the result.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1497/files#diff-9e4f4ad7b1daee21c09ab92d1c54764c6059f6d6ef46ccd5eb249efea22da7b3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Add `hex_fmt` dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Cargo.toml

- Added `hex_fmt` dependency.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1497/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

