### PR TITLE
enha: mutex for executor in serial mode

### DIFF
--- a/src/eth/storage/inmemory/inmemory_temporary.rs
+++ b/src/eth/storage/inmemory/inmemory_temporary.rs
@@ -224,11 +224,6 @@ impl TemporaryStorage for InMemoryTemporaryStorage {
     // Accounts and Slots
     // -------------------------------------------------------------------------
 
-    fn check_conflicts(&self, execution: &EvmExecution) -> anyhow::Result<Option<ExecutionConflicts>> {
-        let states = self.lock_read();
-        Ok(check_conflicts(&states, execution))
-    }
-
     fn read_account(&self, address: &Address) -> anyhow::Result<Option<Account>> {
         let states = self.lock_read();
         Ok(read_account(&states, address))

--- a/src/eth/storage/stratus_storage.rs
+++ b/src/eth/storage/stratus_storage.rs
@@ -9,8 +9,6 @@ use crate::eth::primitives::Address;
 use crate::eth::primitives::Block;
 use crate::eth::primitives::BlockFilter;
 use crate::eth::primitives::BlockNumber;
-use crate::eth::primitives::EvmExecution;
-use crate::eth::primitives::ExecutionConflicts;
 use crate::eth::primitives::ExternalBlock;
 use crate::eth::primitives::Hash;
 use crate::eth::primitives::LogFilter;
@@ -240,26 +238,6 @@ impl StratusStorage {
                 metrics::inc_storage_save_accounts(m.elapsed, label::PERM, m.result.is_ok());
                 if let Err(ref e) = m.result {
                     tracing::error!(reason = ?e, "failed to save accounts");
-                }
-            })
-            .map_err(Into::into)
-    }
-
-    pub fn check_conflicts(&self, execution: &EvmExecution) -> Result<Option<ExecutionConflicts>, StratusError> {
-        #[cfg(feature = "tracing")]
-        let _span = tracing::debug_span!("storage::check_conflicts").entered();
-        tracing::debug!(storage = %label::TEMP, "checking conflicts");
-
-        timed(|| self.temp.check_conflicts(execution))
-            .with(|m| {
-                metrics::inc_storage_check_conflicts(
-                    m.elapsed,
-                    label::TEMP,
-                    m.result.is_ok(),
-                    m.result.as_ref().is_ok_and(|conflicts| conflicts.is_some()),
-                );
-                if let Err(ref e) = m.result {
-                    tracing::error!(reason = ?e, "failed to check conflicts");
                 }
             })
             .map_err(Into::into)

--- a/src/eth/storage/temporary_storage.rs
+++ b/src/eth/storage/temporary_storage.rs
@@ -7,8 +7,6 @@ use display_json::DebugAsJson;
 use crate::eth::primitives::Account;
 use crate::eth::primitives::Address;
 use crate::eth::primitives::BlockNumber;
-use crate::eth::primitives::EvmExecution;
-use crate::eth::primitives::ExecutionConflicts;
 use crate::eth::primitives::ExternalBlock;
 use crate::eth::primitives::Hash;
 use crate::eth::primitives::PendingBlock;
@@ -52,9 +50,6 @@ pub trait TemporaryStorage: Send + Sync + 'static {
     // -------------------------------------------------------------------------
     // Accounts and slots
     // -------------------------------------------------------------------------
-
-    /// Checks if an execution conflicts with current storage state.
-    fn check_conflicts(&self, execution: &EvmExecution) -> anyhow::Result<Option<ExecutionConflicts>>;
 
     /// Retrieves an account from the storage. Returns Option when not found.
     fn read_account(&self, address: &Address) -> anyhow::Result<Option<Account>>;

--- a/src/infra/metrics/metrics_definitions.rs
+++ b/src/infra/metrics/metrics_definitions.rs
@@ -21,9 +21,6 @@ metrics! {
 metrics! {
     group: storage_read,
 
-    "Time to execute storage check_conflicts operation."
-    histogram_duration storage_check_conflicts{storage, success, conflicted},
-
     "Time to execute storage read_pending_block_number operation."
     histogram_duration storage_read_pending_block_number{storage, success},
 


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Introduced a `Mutex` for serial execution in the `Executor` to prevent conflicts.
- Added handling for poisoned mutex locks to ensure robustness.
- Removed `check_conflicts` method from `TemporaryStorage`, `StratusStorage`, and `TemporaryStorage` trait.
- Removed the metric definition for `storage_check_conflicts` operation.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>executor.rs</strong><dd><code>Add mutex for serial execution in Executor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/executor/executor.rs

<li>Introduced <code>ExecutorLocks</code> struct with a <code>Mutex</code> for serial execution.<br> <li> Modified <code>Executor</code> struct to include <code>ExecutorLocks</code>.<br> <li> Implemented mutex locking in <code>ExecutorStrategy::Serial</code> to prevent <br>conflicts.<br> <li> Added handling for poisoned mutex locks.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1500/files#diff-6b460d7dee8280c0287e8d9d9d59cf66a57ec9fed1bc003c6ede6fef60c7376b">+31/-2</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>inmemory_temporary.rs</strong><dd><code>Remove check_conflicts method from TemporaryStorage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/inmemory/inmemory_temporary.rs

<li>Removed <code>check_conflicts</code> method from <code>TemporaryStorage</code> implementation.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1500/files#diff-6f4ee832c01927be4b428028743a37022368d351f09fd177f59e81a5a58dd661">+0/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>stratus_storage.rs</strong><dd><code>Remove check_conflicts method from StratusStorage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/stratus_storage.rs

- Removed `check_conflicts` method from `StratusStorage`.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1500/files#diff-3b2e36e47959decdfe26b2c4fab90b41f9242bfdad29cc43b2377ee851f4f40a">+0/-22</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>temporary_storage.rs</strong><dd><code>Remove check_conflicts method from TemporaryStorage trait</code></dd></summary>
<hr>

src/eth/storage/temporary_storage.rs

- Removed `check_conflicts` method from `TemporaryStorage` trait.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1500/files#diff-58337f46f036f808e0166f195e0ed5dfbfdc092fc1665c3424f01d799a5195de">+0/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>metrics_definitions.rs</strong><dd><code>Remove storage_check_conflicts metric definition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/infra/metrics/metrics_definitions.rs

- Removed metric definition for `storage_check_conflicts` operation.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1500/files#diff-2ca1adc579301e6de5f9e1d69eb1ed2f70aeee0f3b54fe113346040b4eab652b">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

