### PR TITLE
enha: change lock order

### DIFF
--- a/src/eth/executor/evm.rs
+++ b/src/eth/executor/evm.rs
@@ -61,7 +61,7 @@ pub trait Evm {
 }
 
 /// EVM input data. Usually derived from a transaction or call.
-#[derive(Debug, Clone, Default)]
+#[derive(DebugAsJson, Clone, Default, serde::Serialize)]
 pub struct EvmInput {
     /// Operation party address.
     ///

--- a/src/eth/miner/miner.rs
+++ b/src/eth/miner/miner.rs
@@ -126,7 +126,7 @@ impl Miner {
     /// Same as [`Self::mine_external`], but automatically commits the block instead of returning it.
     pub fn mine_external_and_commit(&self) -> anyhow::Result<()> {
         let _mine_and_commit_lock = self.locks.mine_and_commit.lock().unwrap();
-        tracing::debug!("acquired mine and commit lock for external block");
+        tracing::info!("miner acquired mine and commit lock for external block");
 
         let block = self.mine_external()?;
         self.commit(block)
@@ -141,7 +141,7 @@ impl Miner {
 
         // lock
         let _mine_lock = self.locks.mine.lock().unwrap();
-        tracing::debug!("acquired mine lock for external block");
+        tracing::info!("miner acquired mine lock for external block");
 
         // mine
         let block = self.storage.finish_pending_block()?;
@@ -168,7 +168,7 @@ impl Miner {
     /// Same as [`Self::mine_external_mixed`], but automatically commits the block instead of returning it.
     pub fn mine_external_mixed_and_commit(&self) -> anyhow::Result<()> {
         let _mine_and_commit_lock = self.locks.mine_and_commit.lock().unwrap();
-        tracing::debug!("acquired mine and commit lock for external mixed local block");
+        tracing::info!("miner acquired mine and commit lock for external mixed local block");
 
         let block = self.mine_external_mixed()?;
         self.commit(block)
@@ -183,7 +183,7 @@ impl Miner {
 
         // lock
         let _mine_lock = self.locks.mine.lock().unwrap();
-        tracing::debug!("acquired mining lock for external mixed block");
+        tracing::info!("miner acquired mining lock for external mixed block");
 
         // mine
         let block = self.storage.finish_pending_block()?;
@@ -215,7 +215,7 @@ impl Miner {
     /// mainly used when is_automine is enabled.
     pub fn mine_local_and_commit(&self) -> anyhow::Result<()> {
         let _mine_and_commit_lock = self.locks.mine_and_commit.lock().unwrap();
-        tracing::debug!("acquired mine and commit lock for local block");
+        tracing::info!("miner acquired mine and commit lock for local block");
 
         let block = self.mine_local()?;
         self.commit(block)
@@ -230,7 +230,7 @@ impl Miner {
 
         // lock
         let _mine_lock = self.locks.mine.lock().unwrap();
-        tracing::debug!("acquired mining lock for local block");
+        tracing::info!("miner acquired mining lock for local block");
 
         // mine
         let block = self.storage.finish_pending_block()?;
@@ -261,7 +261,7 @@ impl Miner {
 
         // lock
         let _commit_lock = self.locks.commit.lock().unwrap();
-        tracing::debug!(block_number = %block.number(), "acquired commit lock");
+        tracing::info!(block_number = %block.number(), "miner acquired commit lock");
 
         // extract fields to use in notifications
         let block_number = block.number();
@@ -508,7 +508,7 @@ mod interval_miner {
     #[inline(always)]
     fn mine_and_commit(miner: &Miner) {
         let _mine_and_commit_lock = miner.locks.mine_and_commit.lock().unwrap();
-        tracing::debug!("acquired mine and commit lock for interval local block");
+        tracing::info!("miner acquired mine and commit lock for interval local block");
 
         // mine
         let block = loop {

--- a/src/eth/storage/storage_point_in_time.rs
+++ b/src/eth/storage/storage_point_in_time.rs
@@ -2,7 +2,7 @@ use crate::eth::primitives::BlockNumber;
 use crate::infra::metrics::MetricLabelValue;
 
 /// EVM storage point-in-time indicator.
-#[derive(Debug, strum::Display, Clone, Copy, Default, strum::EnumIs)]
+#[derive(Debug, strum::Display, Clone, Copy, Default, strum::EnumIs, serde::Serialize)]
 pub enum StoragePointInTime {
     /// State of [`Account`] or [`Slot`] at the pending block being mined.
     ///


### PR DESCRIPTION
### **PR Type**
Enhancement, Documentation


___

### **Description**
- Added `serde::Serialize` derive to `EvmInput` struct and `StoragePointInTime` enum to enable serialization.
- Changed lock acquisition order in `Executor` implementation to ensure proper synchronization.
- Added detailed logging for lock acquisition in `Executor` to aid in debugging.
- Updated log level from debug to info for lock acquisition messages in `Miner` for better visibility.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>evm.rs</strong><dd><code>Add serialization to EvmInput struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/executor/evm.rs

- Added `serde::Serialize` derive to `EvmInput` struct.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1503/files#diff-7fabd204a68cff51c55ee1391074463fa8ac005dc8ba443218bc83a9dda96658">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>executor.rs</strong><dd><code>Change lock order and add logging in Executor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/executor/executor.rs

<li>Changed lock acquisition order in <code>Executor</code> implementation.<br> <li> Added logging for lock acquisition.<br> <li> Moved miner lock acquisition inside serial lock block.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1503/files#diff-6b460d7dee8280c0287e8d9d9d59cf66a57ec9fed1bc003c6ede6fef60c7376b">+28/-16</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>storage_point_in_time.rs</strong><dd><code>Add serialization to StoragePointInTime enum</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/storage_point_in_time.rs

- Added `serde::Serialize` derive to `StoragePointInTime` enum.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1503/files#diff-6ed365e4ae454005c89dabcf56be602bcdd775874af06a0ca6aa7e1c5c941abc">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>miner.rs</strong><dd><code>Update log level for lock acquisition in Miner</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/miner/miner.rs

<li>Changed log level from debug to info for lock acquisition messages.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1503/files#diff-16f448afc7dae3e8e802f676a86dbd7051e19f6c17cbbeb53eb730d726372629">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

