### PR TITLE
refactor: remove unnecessary inner_value methods by exposing the newtypes inner value where necessary

### DIFF
--- a/src/eth/primitives/address.rs
+++ b/src/eth/primitives/address.rs
@@ -21,7 +21,7 @@ use crate::gen_newtype_from;
 
 /// Address of an Ethereum account (wallet or contract).
 #[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Hash, serde::Serialize, serde::Deserialize)]
-pub struct Address(H160);
+pub struct Address(pub H160);
 
 impl Address {
     // Special ETH address used in some contexts.
@@ -56,10 +56,6 @@ impl Address {
     /// * Not sure if zero address should be ignored or not.
     pub fn is_ignored(&self) -> bool {
         self.is_coinbase() || self.is_zero()
-    }
-
-    pub fn inner_value(&self) -> H160 {
-        self.0
     }
 }
 

--- a/src/eth/primitives/block_number.rs
+++ b/src/eth/primitives/block_number.rs
@@ -22,7 +22,7 @@ use crate::gen_newtype_from;
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, derive_more::Add, derive_more::Sub, serde::Serialize, serde::Deserialize)]
 #[serde(transparent)]
-pub struct BlockNumber(U64);
+pub struct BlockNumber(pub U64);
 
 impl BlockNumber {
     pub const ZERO: BlockNumber = BlockNumber(U64::zero());
@@ -72,10 +72,6 @@ impl BlockNumber {
     /// Converts itself to u64.
     pub fn as_u64(&self) -> u64 {
         self.0.as_u64()
-    }
-
-    pub fn inner_value(&self) -> U64 {
-        self.0
     }
 }
 

--- a/src/eth/primitives/chain_id.rs
+++ b/src/eth/primitives/chain_id.rs
@@ -8,15 +8,11 @@ use crate::gen_newtype_from;
 use crate::gen_newtype_try_from;
 
 #[derive(Debug, derive_more::Display, Clone, Copy, Default, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
-pub struct ChainId(U64);
+pub struct ChainId(pub U64);
 
 impl ChainId {
     pub fn new(value: U64) -> Self {
         Self(value)
-    }
-
-    pub fn inner_value(&self) -> U64 {
-        self.0
     }
 }
 

--- a/src/eth/primitives/hash.rs
+++ b/src/eth/primitives/hash.rs
@@ -13,7 +13,7 @@ use crate::gen_newtype_from;
 
 #[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Hash, serde::Serialize, serde::Deserialize)]
 #[serde(transparent)]
-pub struct Hash(H256);
+pub struct Hash(pub H256);
 
 impl Hash {
     /// Creates a hash from the given bytes.
@@ -38,10 +38,6 @@ impl Hash {
     pub fn into_hash_partition(self) -> i16 {
         let n = self.0.to_low_u64_ne() % 10;
         n as i16
-    }
-
-    pub fn inner_value(&self) -> H256 {
-        self.0
     }
 
     pub fn as_fixed_bytes(&self) -> &[u8; 32] {

--- a/src/eth/primitives/index.rs
+++ b/src/eth/primitives/index.rs
@@ -10,7 +10,7 @@ use crate::gen_newtype_try_from;
 #[derive(
     Debug, derive_more::Display, Clone, Copy, PartialEq, Eq, fake::Dummy, serde::Serialize, serde::Deserialize, derive_more::Add, Hash, PartialOrd, Ord,
 )]
-pub struct Index(u64);
+pub struct Index(pub u64);
 
 impl Index {
     pub const ZERO: Index = Index(0u64);
@@ -18,10 +18,6 @@ impl Index {
 
     pub fn new(inner: u64) -> Self {
         Index(inner)
-    }
-
-    pub fn inner_value(&self) -> u64 {
-        self.0
     }
 }
 

--- a/src/eth/primitives/transaction_input.rs
+++ b/src/eth/primitives/transaction_input.rs
@@ -185,7 +185,7 @@ impl From<TransactionInput> for TransactionRequest {
     fn from(value: TransactionInput) -> Self {
         let input = value;
         Self {
-            chain_id: input.chain_id.map(|id| id.inner_value()),
+            chain_id: input.chain_id.map(|id| id.0),
             nonce: Some(input.nonce.into()),
             from: Some(input.signer.into()),
             to: input.to.map(|to| NameOrAddress::Address(to.into())),

--- a/src/eth/primitives/transaction_mined.rs
+++ b/src/eth/primitives/transaction_mined.rs
@@ -167,7 +167,7 @@ mod tests {
         let v = (0..1000)
             .map(|_| create_tx(rng.gen_range(0..100), rng.gen_range(0..100)))
             .sorted()
-            .map(|tx| (tx.block_number.as_u64(), tx.transaction_index.inner_value()))
+            .map(|tx| (tx.block_number.as_u64(), tx.transaction_index.0))
             .collect_vec();
         for pair in v {
             format!("{:?}", pair);

--- a/src/eth/relayer/transaction_dag.rs
+++ b/src/eth/relayer/transaction_dag.rs
@@ -276,7 +276,7 @@ mod tests {
         let mut i = 0;
         while let Some(roots) = dag.take_roots() {
             assert_eq!(roots.len(), expected[i].len());
-            assert!(roots.iter().all(|tx| expected[i].contains(&tx.transaction_index.inner_value())));
+            assert!(roots.iter().all(|tx| expected[i].contains(&tx.transaction_index.0)));
             i += 1;
         }
         //println!("{:?}", petgraph::dot::Dot::with_config(&dag.dag, &[petgraph::dot::Config::EdgeNoLabel, petgraph::dot::Config::NodeIndexLabel]));
@@ -325,7 +325,7 @@ mod tests {
                 let expected = expected_component_1.clone();
                 while let Some(roots) = component.take_roots() {
                     assert_eq!(roots.len(), expected[i].len());
-                    assert!(roots.iter().all(|tx| expected[i].contains(&tx.transaction_index.inner_value())));
+                    assert!(roots.iter().all(|tx| expected[i].contains(&tx.transaction_index.0)));
                     i += 1;
                 }
                 continue;
@@ -336,7 +336,7 @@ mod tests {
                 let mut i = 0;
                 while let Some(roots) = component.take_roots() {
                     assert_eq!(roots.len(), expected[i].len());
-                    assert!(roots.iter().all(|tx| expected[i].contains(&tx.transaction_index.inner_value())));
+                    assert!(roots.iter().all(|tx| expected[i].contains(&tx.transaction_index.0)));
                     i += 1;
                 }
                 continue;
@@ -404,7 +404,7 @@ mod tests {
             while let Some(roots) = dag.take_roots() {
                 assert_eq!(roots.len(), expected[i].len());
 
-                assert!(roots.iter().all(|tx| expected[i].contains(&tx.transaction_index.inner_value())));
+                assert!(roots.iter().all(|tx| expected[i].contains(&tx.transaction_index.0)));
                 i += 1;
             }
         }

--- a/src/eth/storage/rocks/types.rs
+++ b/src/eth/storage/rocks/types.rs
@@ -164,13 +164,7 @@ impl AccountRocksdb {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub struct SlotValueRocksdb(U256);
-
-impl SlotValueRocksdb {
-    pub fn inner_value(&self) -> U256 {
-        self.0
-    }
-}
+pub struct SlotValueRocksdb(pub U256);
 
 impl From<SlotValue> for SlotValueRocksdb {
     fn from(item: SlotValue) -> Self {
@@ -180,50 +174,39 @@ impl From<SlotValue> for SlotValueRocksdb {
 
 impl From<SlotValueRocksdb> for SlotValue {
     fn from(item: SlotValueRocksdb) -> Self {
-        SlotValue::from(item.inner_value())
+        SlotValue::from(item.0)
     }
 }
 
 #[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Hash, serde::Serialize, serde::Deserialize)]
-pub struct AddressRocksdb(H160);
-
-impl AddressRocksdb {
-    pub fn inner_value(&self) -> H160 {
-        self.0
-    }
-}
+pub struct AddressRocksdb(pub H160);
 
 impl From<Address> for AddressRocksdb {
     fn from(item: Address) -> Self {
-        AddressRocksdb(item.inner_value())
+        AddressRocksdb(item.0)
     }
 }
 
 impl From<AddressRocksdb> for Address {
     fn from(item: AddressRocksdb) -> Self {
-        Address::new_from_h160(item.inner_value())
+        Address::new_from_h160(item.0)
     }
 }
 
 #[derive(Debug, derive_more::Display, Clone, Copy, Default, Eq, PartialEq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize)]
-pub struct BlockNumberRocksdb(U64);
+pub struct BlockNumberRocksdb(pub U64);
 
 gen_newtype_from!(self = BlockNumberRocksdb, other = u8, u16, u32, u64, U64, usize, i32, i64);
-impl BlockNumberRocksdb {
-    pub fn inner_value(&self) -> U64 {
-        self.0
-    }
-}
 
 impl From<BlockNumber> for BlockNumberRocksdb {
     fn from(item: BlockNumber) -> Self {
-        BlockNumberRocksdb(item.inner_value())
+        BlockNumberRocksdb(item.0)
     }
 }
 
 impl From<BlockNumberRocksdb> for BlockNumber {
     fn from(item: BlockNumberRocksdb) -> Self {
-        BlockNumber::from(item.inner_value())
+        BlockNumber::from(item.0)
     }
 }
 
@@ -238,12 +221,6 @@ pub struct SlotIndexRocksdb(U256);
 
 gen_newtype_from!(self = SlotIndexRocksdb, other = u64);
 
-impl SlotIndexRocksdb {
-    pub fn inner_value(&self) -> U256 {
-        self.0
-    }
-}
-
 impl From<SlotIndex> for SlotIndexRocksdb {
     fn from(item: SlotIndex) -> Self {
         SlotIndexRocksdb(item.as_u256())
@@ -252,49 +229,37 @@ impl From<SlotIndex> for SlotIndexRocksdb {
 
 impl From<SlotIndexRocksdb> for SlotIndex {
     fn from(item: SlotIndexRocksdb) -> Self {
-        SlotIndex::from(item.inner_value())
+        SlotIndex::from(item.0)
     }
 }
 
 #[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Hash, serde::Serialize, serde::Deserialize)]
-pub struct HashRocksdb(H256);
-
-impl HashRocksdb {
-    pub fn inner_value(&self) -> H256 {
-        self.0
-    }
-}
+pub struct HashRocksdb(pub H256);
 
 impl From<Hash> for HashRocksdb {
     fn from(item: Hash) -> Self {
-        HashRocksdb(item.inner_value())
+        HashRocksdb(item.0)
     }
 }
 
 impl From<HashRocksdb> for Hash {
     fn from(item: HashRocksdb) -> Self {
-        Hash::new_from_h256(item.inner_value())
+        Hash::new_from_h256(item.0)
     }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, fake::Dummy, serde::Serialize, serde::Deserialize, derive_more::Add, Copy, Hash)]
-pub struct IndexRocksdb(u64);
-
-impl IndexRocksdb {
-    pub fn inner_value(&self) -> u64 {
-        self.0
-    }
-}
+pub struct IndexRocksdb(pub u64);
 
 impl From<Index> for IndexRocksdb {
     fn from(item: Index) -> Self {
-        IndexRocksdb(item.inner_value())
+        IndexRocksdb(item.0)
     }
 }
 
 impl From<IndexRocksdb> for Index {
     fn from(item: IndexRocksdb) -> Self {
-        Index::new(item.inner_value())
+        Index::new(item.0)
     }
 }
 
@@ -415,23 +380,17 @@ impl From<SizeRocksdb> for Size {
 }
 
 #[derive(Debug, Clone, Copy, Default, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
-pub struct ChainIdRocksdb(U64);
-
-impl ChainIdRocksdb {
-    pub fn inner_value(&self) -> U64 {
-        self.0
-    }
-}
+pub struct ChainIdRocksdb(pub U64);
 
 impl From<ChainId> for ChainIdRocksdb {
     fn from(value: ChainId) -> Self {
-        ChainIdRocksdb(value.inner_value())
+        ChainIdRocksdb(value.0)
     }
 }
 
 impl From<ChainIdRocksdb> for ChainId {
     fn from(value: ChainIdRocksdb) -> Self {
-        ChainId::new(value.inner_value())
+        ChainId::new(value.0)
     }
 }
 


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Made inner fields of several structs (`Address`, `BlockNumber`, `ChainId`, `Hash`, `Index`, and various RocksDB types) public.
- Removed the `inner_value` methods from these structs.
- Updated related code and tests to use public field access instead of the removed `inner_value` methods.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>address.rs</strong><dd><code>Expose inner value of `Address` struct directly</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/address.rs

<li>Made the <code>H160</code> field of <code>Address</code> public.<br> <li> Removed the <code>inner_value</code> method.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1509/files#diff-43c180e22a2858040d18def981f15acd2fbe7f76fe1b59b76121e9aceeead96d">+1/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>block_number.rs</strong><dd><code>Expose inner value of `BlockNumber` struct directly</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/block_number.rs

<li>Made the <code>U64</code> field of <code>BlockNumber</code> public.<br> <li> Removed the <code>inner_value</code> method.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1509/files#diff-23597a90086820357b399bf33f2db790baaf7f0d4617a74a134c4d200022bb93">+1/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>chain_id.rs</strong><dd><code>Expose inner value of `ChainId` struct directly</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/chain_id.rs

<li>Made the <code>U64</code> field of <code>ChainId</code> public.<br> <li> Removed the <code>inner_value</code> method.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1509/files#diff-978961769008df4bebfd5a1b182a3393a14662062aca34cf09846d1109dcc0ec">+1/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>hash.rs</strong><dd><code>Expose inner value of `Hash` struct directly</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/hash.rs

<li>Made the <code>H256</code> field of <code>Hash</code> public.<br> <li> Removed the <code>inner_value</code> method.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1509/files#diff-aaa0979af0896a585e49e9531c826d3dae201577fa9630a01d79fe80d23f42f3">+1/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>index.rs</strong><dd><code>Expose inner value of `Index` struct directly</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/index.rs

<li>Made the <code>u64</code> field of <code>Index</code> public.<br> <li> Removed the <code>inner_value</code> method.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1509/files#diff-7948334d6b8ee12539c59e1b74a232841e15538ff454e5d2a31be87f46e1a64a">+1/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>transaction_input.rs</strong><dd><code>Update `TransactionInput` conversion for public field access</code></dd></summary>
<hr>

src/eth/primitives/transaction_input.rs

- Updated `TransactionInput` conversion to use public field access.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1509/files#diff-82805cb38a9fb8fc686e7186838bde829d2e092c13ec88636aa57a4129ffedde">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>types.rs</strong><dd><code>Expose inner values and update conversions in RocksDB types</code></dd></summary>
<hr>

src/eth/storage/rocks/types.rs

<li>Made various fields public in RocksDB-related structs.<br> <li> Removed the <code>inner_value</code> methods.<br> <li> Updated conversions to use public field access.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1509/files#diff-4137f44608b6358ce43e18294a7b890c17094f26643f6033bf928b107fd4fbce">+18/-59</a>&nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>transaction_mined.rs</strong><dd><code>Update tests for public field access of `transaction_index`</code></dd></summary>
<hr>

src/eth/primitives/transaction_mined.rs

- Updated tests to use public field access for `transaction_index`.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1509/files#diff-79809f5ea2cc1e67126d745072125f6992cb5857ac9abf5c0d21b1f67879359b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>transaction_dag.rs</strong><dd><code>Update tests for public field access of `transaction_index`</code></dd></summary>
<hr>

src/eth/relayer/transaction_dag.rs

- Updated tests to use public field access for `transaction_index`.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1509/files#diff-22ec1ceecaa07f09404041bd2892e4afdab77faa080d485f26139997cc9fd540">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

