### PR TITLE
refactor: remove unnecessary inner methods by exposing the newtypes inner value where necessary

### DIFF
--- a/src/eth/consensus/server.rs
+++ b/src/eth/consensus/server.rs
@@ -384,7 +384,7 @@ impl AppendEntryService for AppendEntryServiceImpl {
             Status::internal("Failed to get pending transactions")
         })?;
 
-        let transaction_executions: Vec<LocalTransactionExecution> = pending_transactions.iter().filter_map(|tx| tx.inner_local()).collect();
+        let transaction_executions: Vec<LocalTransactionExecution> = pending_transactions.into_iter().filter_map(|tx| tx.as_local()).collect();
 
         //TODO move this logic into BlockMiner and add safety checks as consensus is or isnt on follower mode there
         let block_result = block_from_propagation(block_entry.clone(), transaction_executions);

--- a/src/eth/primitives/account.rs
+++ b/src/eth/primitives/account.rs
@@ -89,7 +89,7 @@ impl From<&Account> for RevmAccountInfo {
         Self {
             nonce: value.nonce.into(),
             balance: value.balance.into(),
-            code_hash: value.code_hash.inner().0.into(),
+            code_hash: value.code_hash.0 .0.into(),
             code: value.bytecode.as_ref().cloned().map_into(),
         }
     }

--- a/src/eth/primitives/code_hash.rs
+++ b/src/eth/primitives/code_hash.rs
@@ -12,7 +12,7 @@ use crate::gen_newtype_from;
 /// In the case of an externally-owned account (EOA), bytecode is null
 /// and the code hash is fixed as the keccak256 hash of an empty string
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub struct CodeHash(H256);
+pub struct CodeHash(pub H256);
 
 impl Dummy<Faker> for CodeHash {
     fn dummy_with_rng<R: ethers_core::rand::prelude::Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
@@ -30,10 +30,6 @@ impl CodeHash {
             Some(bytecode) => CodeHash(H256::from_slice(&keccak256(bytecode.as_ref()))),
             None => CodeHash::default(),
         }
-    }
-
-    pub fn inner(&self) -> H256 {
-        self.0
     }
 }
 

--- a/src/eth/primitives/log_topic.rs
+++ b/src/eth/primitives/log_topic.rs
@@ -9,15 +9,11 @@ use crate::gen_newtype_from;
 
 /// Topic is part of a [`Log`](super::Log) emitted by the EVM during contract execution.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize, Default, Hash)]
-pub struct LogTopic(H256);
+pub struct LogTopic(pub H256);
 
 impl LogTopic {
     pub fn new(inner: H256) -> Self {
         Self(inner)
-    }
-
-    pub fn inner(&self) -> H256 {
-        self.0
     }
 }
 

--- a/src/eth/primitives/transaction_execution.rs
+++ b/src/eth/primitives/transaction_execution.rs
@@ -38,9 +38,17 @@ pub enum TransactionExecution {
 }
 
 impl TransactionExecution {
-    /// Creates a new transaction execution from a local transaction.
+    /// Creates a new local transaction execution.
     pub fn new_local(tx: TransactionInput, result: EvmExecutionResult) -> Self {
         Self::Local(LocalTransactionExecution { input: tx, result })
+    }
+
+    /// Extracts the inner [`LocalTransactionExecution`] if the execution is a local execution.
+    pub fn as_local(self) -> Option<LocalTransactionExecution> {
+        match self {
+            Self::Local(inner) => Some(inner),
+            _ => None,
+        }
     }
 
     /// Checks if the current transaction was completed normally.
@@ -90,8 +98,8 @@ impl TransactionExecution {
             Self::Local(LocalTransactionExecution { input, result }) => append_entry::TransactionExecutionEntry {
                 hash: input.hash.as_fixed_bytes().to_vec(),
                 nonce: input.nonce.as_u64(),
-                value: u256_to_bytes(*input.value.inner()),
-                gas_price: u256_to_bytes(*input.gas_price.inner()),
+                value: u256_to_bytes(input.value.0),
+                gas_price: u256_to_bytes(input.gas_price.0),
                 input: input.input.to_vec(),
                 v: input.v.as_u64(),
                 r: u256_to_bytes(input.r),
@@ -108,10 +116,10 @@ impl TransactionExecution {
                     .map(|log| append_entry::Log {
                         address: log.address.as_bytes().to_vec(),
                         topics: vec![
-                            log.topic0.map_or_else(Vec::new, |t| t.inner().as_bytes().to_vec()),
-                            log.topic1.map_or_else(Vec::new, |t| t.inner().as_bytes().to_vec()),
-                            log.topic2.map_or_else(Vec::new, |t| t.inner().as_bytes().to_vec()),
-                            log.topic3.map_or_else(Vec::new, |t| t.inner().as_bytes().to_vec()),
+                            log.topic0.map_or_else(Vec::new, |t| t.0.as_bytes().to_vec()),
+                            log.topic1.map_or_else(Vec::new, |t| t.0.as_bytes().to_vec()),
+                            log.topic2.map_or_else(Vec::new, |t| t.0.as_bytes().to_vec()),
+                            log.topic3.map_or_else(Vec::new, |t| t.0.as_bytes().to_vec()),
                         ],
                         data: log.data.to_vec(),
                     })
@@ -184,13 +192,6 @@ impl TransactionExecution {
         };
 
         Ok(Self::Local(LocalTransactionExecution { input, result }))
-    }
-
-    pub fn inner_local(&self) -> Option<LocalTransactionExecution> {
-        match self {
-            Self::Local(inner) => Some(inner.clone()),
-            _ => None,
-        }
     }
 }
 

--- a/src/eth/primitives/wei.rs
+++ b/src/eth/primitives/wei.rs
@@ -19,7 +19,7 @@ use crate::gen_newtype_from;
 #[derive(
     Debug, derive_more::Display, Clone, Copy, Default, PartialOrd, Ord, PartialEq, Eq, derive_more::Add, derive_more::Sub, serde::Serialize, serde::Deserialize,
 )]
-pub struct Wei(U256);
+pub struct Wei(pub U256);
 
 impl Wei {
     pub const ZERO: Wei = Wei(U256::zero());
@@ -33,10 +33,6 @@ impl Wei {
     /// Checks if current value is zero.
     pub fn is_zero(&self) -> bool {
         self == &Self::ZERO
-    }
-
-    pub fn inner(&self) -> &U256 {
-        &self.0
     }
 }
 


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Replaced various `inner` methods with direct field access across multiple structs (`CodeHash`, `LogTopic`, `Wei`).
- Added `as_local` method to `TransactionExecution` for extracting `LocalTransactionExecution`.
- Simplified field access in `TransactionExecution` and `Account` conversions.
- Refactored transaction execution extraction in `AppendEntryServiceImpl`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server.rs</strong><dd><code>Refactor transaction execution extraction method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/consensus/server.rs

<li>Replaced <code>inner_local</code> method with <code>as_local</code> method.<br> <li> Changed <code>pending_transactions</code> to use <code>into_iter</code> instead of <code>iter</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1510/files#diff-b061cf8ea45a0e1d561be51cfddcd5ede9889eae8901632ed721b5953ddd470f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>account.rs</strong><dd><code>Simplify code hash field access in account conversion</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/account.rs

<li>Replaced <code>inner</code> method call with direct field access for <code>code_hash</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1510/files#diff-471f8d8754a2a5ad8f776fa90d4a3521d1c62a2ce68bce06d5a22becb191fddc">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>code_hash.rs</strong><dd><code>Make CodeHash field public and remove inner method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/code_hash.rs

- Made `CodeHash` struct field public.
- Removed `inner` method.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1510/files#diff-588f5e271548cdb222c974e0c5b540e707b96f69ce5f3d7bd36b9e0572f692d8">+1/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>log_topic.rs</strong><dd><code>Make LogTopic field public and remove inner method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/log_topic.rs

- Made `LogTopic` struct field public.
- Removed `inner` method.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1510/files#diff-ac0f3bf93665711c21efcc8f0e0516e58626d21f63b95753efdcb3eefd31f5c6">+1/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>transaction_execution.rs</strong><dd><code>Add as_local method and simplify field access in transaction execution</code></dd></summary>
<hr>

src/eth/primitives/transaction_execution.rs

<li>Added <code>as_local</code> method to extract <code>LocalTransactionExecution</code>.<br> <li> Replaced <code>inner</code> method calls with direct field access.<br> <li> Removed <code>inner_local</code> method.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1510/files#diff-363d860c6f773a2fea3a060866e15cdfa2fbe9e355b16a7567d9b2ed465fc987">+15/-14</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>wei.rs</strong><dd><code>Make Wei field public and remove inner method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/wei.rs

- Made `Wei` struct field public.
- Removed `inner` method.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1510/files#diff-457aeabe073254b540b036a4f4e776b56a3f12cccab2760838696e170b60424b">+1/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

