### PR TITLE
enha: adding from/to prometheus metrics

### DIFF
--- a/src/eth/rpc/rpc_middleware.rs
+++ b/src/eth/rpc/rpc_middleware.rs
@@ -219,8 +219,8 @@ impl<'a> RpcServiceT<'a> for RpcMiddleware {
                 &client,
                 &method,
                 tx.as_ref().and_then(|tx| tx.function.clone()),
-                tx.as_ref().and_then(|tx| tx.from.clone()),
-                tx.as_ref().and_then(|tx| tx.to.clone()),
+                tx.as_ref().and_then(|tx| tx.from),
+                tx.as_ref().and_then(|tx| tx.to),
             );
         }
         drop(middleware_enter);
@@ -314,8 +314,8 @@ impl<'a> Future for RpcResponse<'a> {
                     &*resp.client,
                     resp.method.clone(),
                     resp.tx.as_ref().and_then(|tx| tx.function.clone()),
-                    resp.tx.as_ref().and_then(|tx| tx.from.clone()),
-                    resp.tx.as_ref().and_then(|tx| tx.to.clone()),
+                    resp.tx.as_ref().and_then(|tx| tx.from),
+                    resp.tx.as_ref().and_then(|tx| tx.to),
                     rpc_result,
                     error_code,
                     response.is_success(),

--- a/src/eth/rpc/rpc_middleware.rs
+++ b/src/eth/rpc/rpc_middleware.rs
@@ -215,7 +215,13 @@ impl<'a> RpcServiceT<'a> for RpcMiddleware {
         #[cfg(feature = "metrics")]
         {
             active_requests::COUNTERS.inc(&client, &method);
-            metrics::inc_rpc_requests_started(&client, &method, tx.as_ref().and_then(|tx| tx.function.clone()));
+            metrics::inc_rpc_requests_started(
+                &client,
+                &method,
+                tx.as_ref().and_then(|tx| tx.function.clone()),
+                tx.as_ref().and_then(|tx| tx.from.clone()),
+                tx.as_ref().and_then(|tx| tx.to.clone()),
+            );
         }
         drop(middleware_enter);
 
@@ -308,6 +314,8 @@ impl<'a> Future for RpcResponse<'a> {
                     &*resp.client,
                     resp.method.clone(),
                     resp.tx.as_ref().and_then(|tx| tx.function.clone()),
+                    resp.tx.as_ref().and_then(|tx| tx.from.clone()),
+                    resp.tx.as_ref().and_then(|tx| tx.to.clone()),
                     rpc_result,
                     error_code,
                     response.is_success(),

--- a/src/infra/metrics/metrics_definitions.rs
+++ b/src/infra/metrics/metrics_definitions.rs
@@ -8,10 +8,10 @@ metrics! {
     gauge rpc_requests_active{client, method},
 
     "Number of JSON-RPC requests that started."
-    counter rpc_requests_started{client, method, function},
+    counter rpc_requests_started{client, method, function, from, to},
 
     "Number of JSON-RPC requests that finished."
-    histogram_duration rpc_requests_finished{client, method, function, result, result_code, success},
+    histogram_duration rpc_requests_finished{client, method, function, from, to, result, result_code, success},
 
     "Number of JSON-RPC subscriptions active right now."
     gauge rpc_subscriptions_active{subscription}

--- a/src/infra/metrics/metrics_types.rs
+++ b/src/infra/metrics/metrics_types.rs
@@ -5,6 +5,7 @@ use metrics::describe_counter;
 use metrics::describe_gauge;
 use metrics::describe_histogram;
 use metrics::Label;
+use crate::eth::primitives::Address;
 
 pub type HistogramInt = u32;
 pub type Sum = u64;
@@ -82,6 +83,15 @@ impl From<Option<&str>> for MetricLabelValue {
 impl From<String> for MetricLabelValue {
     fn from(value: String) -> Self {
         Self::Some(value)
+    }
+}
+
+impl From<Option<Address>> for MetricLabelValue {
+    fn from(value: Option<Address>) -> Self {
+        match value {
+            Some(value) => Self::Some(value.to_string()),
+            None => Self::None
+        }
     }
 }
 

--- a/src/infra/metrics/metrics_types.rs
+++ b/src/infra/metrics/metrics_types.rs
@@ -5,6 +5,7 @@ use metrics::describe_counter;
 use metrics::describe_gauge;
 use metrics::describe_histogram;
 use metrics::Label;
+
 use crate::eth::primitives::Address;
 
 pub type HistogramInt = u32;
@@ -90,7 +91,7 @@ impl From<Option<Address>> for MetricLabelValue {
     fn from(value: Option<Address>) -> Self {
         match value {
             Some(value) => Self::Some(value.to_string()),
-            None => Self::None
+            None => Self::None,
         }
     }
 }


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Added `from` and `to` fields to the `inc_rpc_requests_started` function calls in `rpc_middleware.rs` to enhance metrics tracking.
- Updated metrics definitions in `metrics_definitions.rs` to include `from` and `to` fields for `rpc_requests_started` and `rpc_requests_finished`.
- Implemented conversion from `Option<Address>` to `MetricLabelValue` in `metrics_types.rs`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rpc_middleware.rs</strong><dd><code>Add `from` and `to` fields to RPC metrics tracking</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/rpc/rpc_middleware.rs

<li>Added <code>from</code> and <code>to</code> fields to <code>inc_rpc_requests_started</code> function calls.<br> <li> Enhanced metrics tracking by including <code>from</code> and <code>to</code> fields.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1515/files#diff-31b7182aec4416845e60ec9ec16720ae97d31260e1a9c50d601d542dee8776f5">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>metrics_definitions.rs</strong><dd><code>Extend metrics definitions with `from` and `to` fields</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/infra/metrics/metrics_definitions.rs

<li>Added <code>from</code> and <code>to</code> fields to <code>rpc_requests_started</code> and <br><code>rpc_requests_finished</code> metrics.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1515/files#diff-2ca1adc579301e6de5f9e1d69eb1ed2f70aeee0f3b54fe113346040b4eab652b">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>metrics_types.rs</strong><dd><code>Add conversion from `Option<Address>` to `MetricLabelValue`</code></dd></summary>
<hr>

src/infra/metrics/metrics_types.rs

- Implemented conversion from `Option<Address>` to `MetricLabelValue`.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1515/files#diff-dd873afb70afd404a8e759c3935e6b7b13c10fd0391632adaf4e530b2944fd95">+11/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

