### PR TITLE
enha: improve error handling of eth_call, eth_estimateGas and eth_sendRawTransaction

### DIFF
--- a/src/eth/rpc/rpc_server.rs
+++ b/src/eth/rpc/rpc_server.rs
@@ -539,8 +539,10 @@ fn eth_estimate_gas(params: Params<'_>, ctx: Arc<RpcContext>, ext: Extensions) -
 
         // internal error
         Err(e) => {
-            tracing::error!(reason = ?e, "failed to execute eth_estimateGas because of unexpected error");
-            Err(StratusError::Unexpected(e.context("failed to execute eth_estimateGas")))
+            if e.is_internal() {
+                tracing::error!(reason = ?e, "failed to execute eth_estimateGas");
+            }
+            Err(e)
         }
     }
 }
@@ -580,8 +582,10 @@ fn eth_call(params: Params<'_>, ctx: Arc<RpcContext>, ext: Extensions) -> Result
 
         // internal error
         Err(e) => {
-            tracing::error!(reason = ?e, "failed to execute eth_call because of unexpected error");
-            Err(StratusError::Unexpected(e.context("failed to execute eth_call")))
+            if e.is_internal() {
+                tracing::error!(reason = ?e, "failed to execute eth_call");
+            }
+            Err(e)
         }
     }
 }
@@ -645,8 +649,10 @@ fn eth_send_raw_transaction(params: Params<'_>, ctx: Arc<RpcContext>, ext: Exten
             Ok(hex_data(tx_hash))
         }
         Err(e) => {
-            tracing::error!(reason = ?e, "failed to execute eth_sendRawTransaction because of unexpected error");
-            Err(StratusError::Unexpected(e.context("failed to execute eth_sendRawTransaction")))
+            if e.is_internal() {
+                tracing::error!(reason = ?e, "failed to execute eth_sendRawTransaction");
+            }
+            Err(e)
         }
     }
 }


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Changed return types of several transaction execution methods to use `Result` with `StratusError` for better error handling.
- Added new error variants in `StratusError` for transaction nonce mismatches and zero address transactions.
- Improved error parsing and logging in EVM execution.
- Enhanced error handling in RPC methods `eth_estimateGas`, `eth_call`, and `eth_sendRawTransaction`, including internal error checks.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>executor.rs</strong><dd><code>Enhanced error handling in transaction execution methods</code>&nbsp; </dd></summary>
<hr>

src/eth/executor/executor.rs

<li>Changed return type of <code>execute_local_transaction</code> and <br><code>execute_local_call</code> to <code>Result</code> with <code>StratusError</code>.<br> <li> Improved error handling for transaction conflicts and zero address <br>transactions.<br> <li> Replaced <code>anyhow::Result</code> with <code>Result</code> using <code>StratusError</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1521/files#diff-6b460d7dee8280c0287e8d9d9d59cf66a57ec9fed1bc003c6ede6fef60c7376b">+13/-9</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>revm.rs</strong><dd><code>Added nonce error handling in EVM execution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/executor/revm.rs

<li>Added handling for nonce errors in EVM execution.<br> <li> Improved error parsing and logging.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1521/files#diff-df0e94ee7f99149e390ec5c59716e7db7df7e9581d0adc962d6d6afd4a88683e">+16/-1</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>stratus_error.rs</strong><dd><code>Introduced new error types and internal error check</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/stratus_error.rs

<li>Added new error variants for transaction nonce and zero address <br>errors.<br> <li> Implemented <code>is_internal</code> method to check for internal errors.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1521/files#diff-301cded01d772388e3e5c08ede093b91c3e4478c08e11a48f70e3d44351385fb">+14/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rpc_server.rs</strong><dd><code>Enhanced error handling in RPC methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/rpc/rpc_server.rs

<li>Improved error handling for <code>eth_estimateGas</code>, <code>eth_call</code>, and <br><code>eth_sendRawTransaction</code>.<br> <li> Added internal error logging condition.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1521/files#diff-835ba255c9a5c1fe0e13285bc39e058e1c74422e5e03ebba483c9d8a15c45405">+12/-6</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

