### PR TITLE
fix: computer external_transaction metrics only after transaction is persisted

### DIFF
--- a/src/eth/executor/evm.rs
+++ b/src/eth/executor/evm.rs
@@ -6,8 +6,6 @@
 //! facilitates flexible EVM integrations, enabling the project to adapt to different blockchain environments
 //! or requirements while maintaining a consistent execution interface.
 
-use std::borrow::Cow;
-
 use display_json::DebugAsJson;
 
 use crate::eth::primitives::Address;
@@ -23,14 +21,11 @@ use crate::eth::primitives::ExternalReceipt;
 use crate::eth::primitives::ExternalTransaction;
 use crate::eth::primitives::Gas;
 use crate::eth::primitives::Nonce;
-use crate::eth::primitives::Signature;
-use crate::eth::primitives::SoliditySignature;
 use crate::eth::primitives::StratusError;
 use crate::eth::primitives::TransactionInput;
 use crate::eth::primitives::UnixTime;
 use crate::eth::primitives::Wei;
 use crate::eth::storage::StoragePointInTime;
-use crate::ext::not;
 use crate::ext::OptionExt;
 use crate::if_else;
 use crate::log_and_err;
@@ -121,18 +116,6 @@ pub struct EvmInput {
 }
 
 impl EvmInput {
-    fn is_contract_deployment(&self) -> bool {
-        self.to.is_none() && not(self.data.is_empty())
-    }
-
-    pub fn extract_function(&self) -> Option<SoliditySignature> {
-        if self.is_contract_deployment() {
-            return Some(Cow::from("contract_deployment"));
-        }
-        let sig = Signature::Function(self.data.get(..4)?.try_into().ok()?);
-        Some(sig.extract())
-    }
-
     /// Creates from a transaction that was sent directly to Stratus with `eth_sendRawTransaction`.
     pub fn from_eth_transaction(input: TransactionInput, pending_block_number: BlockNumber) -> Self {
         Self {

--- a/src/eth/primitives/call_input.rs
+++ b/src/eth/primitives/call_input.rs
@@ -17,7 +17,10 @@ pub struct CallInput {
 }
 
 impl CallInput {
-    pub fn extract_function(&self) -> Option<SoliditySignature> {
+    /// Parses the Solidity function being called.
+    ///
+    /// TODO: unify and remove duplicate implementations.
+    pub fn solidity_signature(&self) -> Option<SoliditySignature> {
         let sig = Signature::Function(self.data.get(..4)?.try_into().ok()?);
         Some(sig.extract())
     }

--- a/src/eth/primitives/external_transaction.rs
+++ b/src/eth/primitives/external_transaction.rs
@@ -1,7 +1,12 @@
+use std::borrow::Cow;
+
 use ethers_core::types::Transaction as EthersTransaction;
 
 use crate::eth::primitives::BlockNumber;
 use crate::eth::primitives::Hash;
+use crate::eth::primitives::Signature;
+use crate::eth::primitives::SoliditySignature;
+use crate::ext::not;
 
 #[derive(Debug, Clone, Default, derive_more:: Deref, serde::Deserialize, serde::Serialize)]
 #[serde(transparent)]
@@ -16,6 +21,22 @@ impl ExternalTransaction {
     /// Returns the transaction hash.
     pub fn hash(&self) -> Hash {
         self.0.hash.into()
+    }
+
+    /// Checks if the current transaction is a contract deployment.
+    pub fn is_contract_deployment(&self) -> bool {
+        self.to.is_none() && not(self.input.is_empty())
+    }
+
+    /// Parses the Solidity function being called.
+    ///
+    /// TODO: unify and remove duplicate implementations.
+    pub fn solidity_signature(&self) -> Option<SoliditySignature> {
+        if self.is_contract_deployment() {
+            return Some(Cow::from("contract_deployment"));
+        }
+        let sig = Signature::Function(self.input.get(..4)?.try_into().ok()?);
+        Some(sig.extract())
     }
 }
 

--- a/src/eth/primitives/transaction_input.rs
+++ b/src/eth/primitives/transaction_input.rs
@@ -54,12 +54,15 @@ pub struct TransactionInput {
 }
 
 impl TransactionInput {
-    /// Checks if the current transaction is for a contract deployment.
+    /// Checks if the current transaction is a contract deployment.
     pub fn is_contract_deployment(&self) -> bool {
         self.to.is_none() && not(self.input.is_empty())
     }
 
-    pub fn extract_function(&self) -> Option<SoliditySignature> {
+    /// Parses the Solidity function being called.
+    ///
+    /// TODO: unify and remove duplicate implementations.
+    pub fn solidity_signature(&self) -> Option<SoliditySignature> {
         if self.is_contract_deployment() {
             return Some(Cow::from("contract_deployment"));
         }

--- a/src/eth/rpc/rpc_middleware.rs
+++ b/src/eth/rpc/rpc_middleware.rs
@@ -303,7 +303,7 @@ impl TransactionTracingIdentifiers {
         let tx = parse_rpc_rlp::<TransactionInput>(&data)?;
         Ok(Self {
             hash: Some(tx.hash),
-            function: tx.extract_function(),
+            function: tx.solidity_signature(),
             from: Some(tx.signer),
             to: tx.to,
             nonce: Some(tx.nonce),
@@ -314,7 +314,7 @@ impl TransactionTracingIdentifiers {
         let (_, call) = next_rpc_param::<CallInput>(params.sequence())?;
         Ok(Self {
             hash: None,
-            function: call.extract_function(),
+            function: call.solidity_signature(),
             from: call.from,
             to: call.to,
             nonce: None,


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Refactored the EVM executor to remove unused code and simplify transaction execution logic.
- Fixed the issue of computing external transaction metrics only after the transaction is persisted.
- Renamed `extract_function` to `solidity_signature` across multiple files for consistency.
- Added and documented new methods in `ExternalTransaction` for better code organization.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>evm.rs</strong><dd><code>Refactor EVM executor and remove unused code</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/executor/evm.rs

<li>Removed unused imports and functions.<br> <li> Simplified the <code>execute_external_transaction</code> function.<br> <li> Moved <code>solidity_signature</code> function to <code>ExternalTransaction</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1523/files#diff-7fabd204a68cff51c55ee1391074463fa8ac005dc8ba443218bc83a9dda96658">+0/-17</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>call_input.rs</strong><dd><code>Rename and document function signature extraction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/call_input.rs

<li>Renamed <code>extract_function</code> to <code>solidity_signature</code>.<br> <li> Added documentation for <code>solidity_signature</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1523/files#diff-8ff69cf5f70258699ae5a6906ec7c35c251f8c64e56bbfd8b2f35b1727dca054">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>external_transaction.rs</strong><dd><code>Add and refactor methods in ExternalTransaction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/external_transaction.rs

<li>Added <code>solidity_signature</code> and <code>is_contract_deployment</code> methods.<br> <li> Moved <code>solidity_signature</code> logic from <code>EvmInput</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1523/files#diff-a5bcf577600cee6a4844b4015797a92684df8ec490f06f66b4a556881a66032d">+21/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>transaction_input.rs</strong><dd><code>Rename and document function signature extraction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/transaction_input.rs

<li>Renamed <code>extract_function</code> to <code>solidity_signature</code>.<br> <li> Added documentation for <code>solidity_signature</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1523/files#diff-82805cb38a9fb8fc686e7186838bde829d2e092c13ec88636aa57a4129ffedde">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rpc_middleware.rs</strong><dd><code>Use unified function signature extraction in RPC middleware</code></dd></summary>
<hr>

src/eth/rpc/rpc_middleware.rs

- Replaced `extract_function` with `solidity_signature`.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1523/files#diff-31b7182aec4416845e60ec9ec16720ae97d31260e1a9c50d601d542dee8776f5">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>executor.rs</strong><dd><code>Fix and enhance external transaction execution and metrics</code></dd></summary>
<hr>

src/eth/executor/executor.rs

<li>Modified <code>execute_external_transaction</code> to persist state before <br>computing metrics.<br> <li> Updated metric tracking to use <code>solidity_signature</code>.<br> <li> Simplified transaction execution logic.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1523/files#diff-6b460d7dee8280c0287e8d9d9d59cf66a57ec9fed1bc003c6ede6fef60c7376b">+74/-60</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

