### PR TITLE
feat: support CF versions in RocksDB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5161,6 +5161,7 @@ dependencies = [
  "serde_urlencoded",
  "serde_with 3.8.1",
  "sqlx",
+ "static_assertions",
  "stringreader",
  "strum",
  "sugars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ phf = "=0.11.2"
 pin-project = "=1.1.5"
 quote = "=1.0.36"
 rand = { version = "=0.8.5", features = ["small_rng"] }
+static_assertions = "=1.1.0"
 strum = "=0.26.2"
 sugars = "=3.0.1"
 thiserror = "=1.0.61"

--- a/src/eth/executor/evm.rs
+++ b/src/eth/executor/evm.rs
@@ -291,7 +291,7 @@ fn parse_revm_execution(revm_result: RevmResultAndState, input: EvmInput, execut
         if changes.bytecode.is_modified() {
             deployed_contract_address = Some(changes.address);
         }
-    };
+    }
 
     EvmExecution {
         block_timestamp: input.block_timestamp,

--- a/src/eth/storage/rocks/cf_versions.rs
+++ b/src/eth/storage/rocks/cf_versions.rs
@@ -1,0 +1,77 @@
+use std::ops::Deref;
+use std::ops::DerefMut;
+
+use serde::Deserialize;
+use serde::Serialize;
+use strum::EnumCount;
+
+use super::types::AccountRocksdb;
+use super::types::BlockNumberRocksdb;
+use super::types::BlockRocksdb;
+use super::types::SlotValueRocksdb;
+use crate::eth::primitives::Account;
+use crate::eth::primitives::Block;
+use crate::eth::primitives::BlockNumber;
+use crate::eth::primitives::SlotValue;
+
+macro_rules! impl_single_version_cf_value {
+    ($name:ident, $inner_type:ty, $non_rocks_equivalent: ty) => {
+        #[derive(Debug, Clone, Serialize, Deserialize, EnumCount)]
+        pub enum $name {
+            V1($inner_type),
+        }
+
+        impl $name {
+            #[allow(dead_code)]
+            pub fn into_inner(self) -> $inner_type {
+                match self {
+                    Self::V1(v1) => v1,
+                }
+            }
+        }
+
+        // `From` conversion should only exist for values with a single version
+        static_assertions::const_assert_eq!($name::COUNT, 1);
+
+        // Implement `From` for the v1 type.
+        impl From<$inner_type> for $name {
+            fn from(v1: $inner_type) -> Self {
+                Self::V1(v1)
+            }
+        }
+
+        impl Deref for $name {
+            type Target = $inner_type;
+            fn deref(&self) -> &Self::Target {
+                match self {
+                    Self::V1(v1) => v1,
+                }
+            }
+        }
+
+        impl DerefMut for $name {
+            fn deref_mut(&mut self) -> &mut Self::Target {
+                match self {
+                    Self::V1(v1) => v1,
+                }
+            }
+        }
+
+        // Do `$non_rocks_equivalent -> $inner_type -> $name` in one conversion.
+        impl From<$non_rocks_equivalent> for $name {
+            fn from(value: $non_rocks_equivalent) -> Self {
+                let value = <$inner_type>::from(value);
+                Self::V1(value)
+            }
+        }
+    };
+}
+
+impl_single_version_cf_value!(CfAccountsValue, AccountRocksdb, Account);
+impl_single_version_cf_value!(CfAccountsHistoryValue, AccountRocksdb, Account);
+impl_single_version_cf_value!(CfAccountSlotsValue, SlotValueRocksdb, SlotValue);
+impl_single_version_cf_value!(CfAccountSlotsHistoryValue, SlotValueRocksdb, SlotValue);
+impl_single_version_cf_value!(CfTransactionsValue, BlockNumberRocksdb, BlockNumber);
+impl_single_version_cf_value!(CfBlocksByNumberValue, BlockRocksdb, Block);
+impl_single_version_cf_value!(CfBlocksByHashValue, BlockNumberRocksdb, BlockNumber);
+impl_single_version_cf_value!(CfLogsValue, BlockNumberRocksdb, BlockNumber);

--- a/src/eth/storage/rocks/mod.rs
+++ b/src/eth/storage/rocks/mod.rs
@@ -1,12 +1,18 @@
+// Layers (top-to-bottom): permanent -> state -> rest.
+
+/// Exposed API.
+pub mod rocks_permanent;
+
+/// State handler for DB and column families.
+mod rocks_state;
+
+/// CFs versionated by value variant.
+mod cf_versions;
 /// Data manipulation for column families.
 mod rocks_cf;
 /// Settings and tweaks for the database and column families.
 mod rocks_config;
 /// Functionalities related to the whole database.
 mod rocks_db;
-/// Exposed API.
-pub mod rocks_permanent;
-/// State handler for DB and column families.
-mod rocks_state;
 /// All types to be serialized and desserialized in the db.
 mod types;

--- a/src/eth/storage/rocks/types/account.rs
+++ b/src/eth/storage/rocks/types/account.rs
@@ -42,6 +42,16 @@ impl From<Account> for (AddressRocksdb, AccountRocksdb) {
     }
 }
 
+impl From<Account> for AccountRocksdb {
+    fn from(value: Account) -> Self {
+        AccountRocksdb {
+            balance: value.balance.into(),
+            nonce: value.nonce.into(),
+            bytecode: value.bytecode.map_into(),
+        }
+    }
+}
+
 impl Default for AccountRocksdb {
     fn default() -> Self {
         Self {

--- a/src/eth/storage/rocks/types/execution.rs
+++ b/src/eth/storage/rocks/types/execution.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use super::address::AddressRocksdb;
 use super::bytes::BytesRocksdb;
 use super::execution_result::ExecutionResultRocksdb;


### PR DESCRIPTION
### **User description**
Currently, we need to re-compute the entire database after any type change.

This PR lets a Column Family store an enum as a value, this enables us to change data that is stored and support multiple types. 

We are relying on `bincode` serialization of enums, as a consequence, we can't reorder variants in an enum or remove previous versions because `bincode` marks the variants an `i32` discriminant in order of declaration, by changing the declaration it will try using different types to deserialize, with different sizes and paddings.


___

### **PR Type**
Enhancement, Other


___

### **Description**
- Introduced a macro to implement versioned column family values and added new enums for different column family values.
- Updated `RocksStorageState` to use new versioned column family values, modifying methods to handle new enum types and adjusting data insertion and retrieval logic.
- Reorganized module imports and added a new module for versioned column family values.
- Added `From<Account>` implementation for `AccountRocksdb`.
- Removed unused import `HashMap` from `execution.rs`.
- Added `static_assertions` dependency to `Cargo.toml`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cf_versions.rs</strong><dd><code>Add versioned column family values with macros and enums</code>&nbsp; </dd></summary>
<hr>

src/eth/storage/rocks/cf_versions.rs

<li>Introduced a macro to implement versioned column family values.<br> <li> Added new enums for different column family values.<br> <li> Implemented <code>Deref</code> and <code>DerefMut</code> traits for these enums.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1524/files#diff-1473a2d7080c82c2140a86d44fb6b2dda19b4cb2d1c99f9ae68b9ccbe0d80de4">+77/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Reorganize modules and add versioned CF values module</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/rocks/mod.rs

<li>Reorganized module imports.<br> <li> Added new module for versioned column family values.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1524/files#diff-38613469ff37344dd2d68aa4da8280b321c01993e312518834dbf4834f9422bc">+10/-4</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rocks_state.rs</strong><dd><code>Update RocksStorageState to use versioned CF values</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/rocks/rocks_state.rs

<li>Updated references to use new versioned column family values.<br> <li> Modified methods to handle new enum types.<br> <li> Adjusted data insertion and retrieval logic.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1524/files#diff-f7b822022d2c4fd93ec507cd6b5302dcf1646acbf0ee0dd077a047272b686009">+52/-37</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>account.rs</strong><dd><code>Implement From<Account> for AccountRocksdb</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/rocks/types/account.rs

- Added `From<Account>` implementation for `AccountRocksdb`.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1524/files#diff-a99fca83b40fbe7fd034258e4c038636f4f38120de63c8b0cbb828cafbfaa416">+10/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>execution.rs</strong><dd><code>Remove unused HashMap import</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/rocks/types/execution.rs

- Removed unused import `HashMap`.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1524/files#diff-52ffd030152c2c6865f50aa2a2622f81f78a6e46605afc6458feb4058ecaffa6">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Add static_assertions dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Cargo.toml

- Added `static_assertions` dependency.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1524/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

