### PR TITLE
fix: ignore error when removing file on e2e

### DIFF
--- a/chaos/experiments/main.sh
+++ b/chaos/experiments/main.sh
@@ -60,11 +60,11 @@ cleanup() {
 
   sleep 2
   if [ $exit_code -eq 0 ]; then
-    rm instance_*.log || true
-    find . -type d -name "instance_*" -print0 | xargs -0 rm -rf || true
+    rm instance_*.log 2>/dev/null || true
+    find . -type d -name "instance_*" -print0 | xargs -0 rm -rf 2>/dev/null || true
   fi
-  rm -rf tmp_rocks_* || true
-  find . -type d -name "tmp_rocks_*" -print0 | xargs -0 rm -rf || true
+  rm -rf tmp_rocks_* 2>/dev/null || true
+  find . -type d -name "tmp_rocks_*" -print0 | xargs -0 rm -rf 2>/dev/null || true
   echo "Job is done. With exit code $exit_code"
 }
 trap cleanup EXIT INT TERM


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Redirected error output to `/dev/null` for file removal commands in `cleanup` function.
- Ensured cleanup commands do not fail if files or directories do not exist.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.sh</strong><dd><code>Ignore errors when removing files in cleanup script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

chaos/experiments/main.sh

<li>Redirected error output to <code>/dev/null</code> for file removal commands.<br> <li> Ensured cleanup commands do not fail if files or directories do not <br>exist.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1526/files#diff-244c0f1739d9a0f01ac254c5adbd74230e18cda380ccd8406f385e9c69286cd2">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

