### PR TITLE
refactor: common type aliases in alias.rs

### DIFF
--- a/src/alias.rs
+++ b/src/alias.rs
@@ -1,0 +1,35 @@
+//! Type aliases for external crates types that conflict with our own types or are too verbose.
+
+use ethereum_types::H256;
+
+use crate::eth::primitives::ExternalTransaction;
+
+// -----------------------------------------------------------------------------
+// Serde
+// -----------------------------------------------------------------------------
+pub type JsonValue = serde_json::Value;
+
+// -----------------------------------------------------------------------------
+// Ethers
+// -----------------------------------------------------------------------------
+pub type EthersBlockVoid = ethers_core::types::Block<()>;
+pub type EthersBlockEthersTransaction = ethers_core::types::Block<ethers_core::types::Transaction>;
+pub type EthersBlockExternalTransaction = ethers_core::types::Block<ExternalTransaction>;
+pub type EthersBlockH256 = ethers_core::types::Block<H256>;
+pub type EthersBytes = ethers_core::types::Bytes;
+pub type EthersLog = ethers_core::types::Log;
+pub type EthersReceipt = ethers_core::types::TransactionReceipt;
+pub type EthersTransaction = ethers_core::types::Transaction;
+
+// -----------------------------------------------------------------------------
+// REVM
+// -----------------------------------------------------------------------------
+pub type RevmAccountInfo = revm::primitives::AccountInfo;
+pub type RevmAddress = revm::primitives::Address;
+pub type RevmB256 = revm::primitives::B256;
+pub type RevmBytecode = revm::primitives::Bytecode;
+pub type RevmBytes = revm::primitives::Bytes;
+pub type RevmLog = revm::primitives::Log;
+pub type RevmOutput = revm::primitives::Output;
+pub type RevmState = revm::primitives::State;
+pub type RevmU256 = revm::primitives::U256;

--- a/src/eth/executor/evm.rs
+++ b/src/eth/executor/evm.rs
@@ -4,8 +4,6 @@ use std::sync::Arc;
 use anyhow::anyhow;
 use itertools::Itertools;
 use revm::primitives::AccountInfo;
-use revm::primitives::Address as RevmAddress;
-use revm::primitives::Bytecode as RevmBytecode;
 use revm::primitives::EVMError;
 use revm::primitives::ExecutionResult as RevmExecutionResult;
 use revm::primitives::InvalidTransaction;
@@ -19,6 +17,8 @@ use revm::Database;
 use revm::Evm as RevmEvm;
 use revm::Handler;
 
+use crate::alias::RevmAddress;
+use crate::alias::RevmBytecode;
 use crate::eth::executor::EvmExecutionResult;
 use crate::eth::executor::EvmInput;
 use crate::eth::primitives::Account;

--- a/src/eth/primitives/account.rs
+++ b/src/eth/primitives/account.rs
@@ -1,7 +1,7 @@
 use display_json::DebugAsJson;
-use revm::primitives::AccountInfo as RevmAccountInfo;
-use revm::primitives::Address as RevmAddress;
 
+use crate::alias::RevmAccountInfo;
+use crate::alias::RevmAddress;
 use crate::eth::primitives::Address;
 use crate::eth::primitives::Bytes;
 use crate::eth::primitives::CodeHash;

--- a/src/eth/primitives/address.rs
+++ b/src/eth/primitives/address.rs
@@ -9,7 +9,6 @@ use ethers_core::types::NameOrAddress;
 use fake::Dummy;
 use fake::Faker;
 use hex_literal::hex;
-use revm::primitives::Address as RevmAddress;
 use sqlx::database::HasArguments;
 use sqlx::database::HasValueRef;
 use sqlx::encode::IsNull;
@@ -17,6 +16,7 @@ use sqlx::error::BoxDynError;
 use sqlx::postgres::PgHasArrayType;
 use sqlx::Decode;
 
+use crate::alias::RevmAddress;
 use crate::gen_newtype_from;
 
 /// Address of an Ethereum account (wallet or contract).
@@ -162,7 +162,7 @@ impl From<Address> for H160 {
 
 impl From<Address> for RevmAddress {
     fn from(value: Address) -> Self {
-        RevmAddress(value.0 .0.into())
+        revm::primitives::Address(value.0 .0.into())
     }
 }
 

--- a/src/eth/primitives/block.rs
+++ b/src/eth/primitives/block.rs
@@ -1,13 +1,14 @@
 use std::collections::HashMap;
 
 use ethereum_types::H256;
-use ethers_core::types::Block as EthersBlock;
-use ethers_core::types::Transaction as EthersTransaction;
 use itertools::Itertools;
 use serde::Deserialize;
 
 use super::LogMined;
 use super::TransactionInput;
+use crate::alias::EthersBlockEthersTransaction;
+use crate::alias::EthersBlockH256;
+use crate::alias::EthersTransaction;
 use crate::eth::executor::EvmExecutionResult;
 use crate::eth::primitives::Address;
 use crate::eth::primitives::BlockHeader;
@@ -104,13 +105,13 @@ impl Block {
 
     /// Serializes itself to JSON-RPC block format with full transactions included.
     pub fn to_json_rpc_with_full_transactions(self) -> JsonValue {
-        let ethers_block: EthersBlock<EthersTransaction> = self.into();
+        let ethers_block: EthersBlockEthersTransaction = self.into();
         to_json_value(ethers_block)
     }
 
     /// Serializes itself to JSON-RPC block format with only transactions hashes included.
     pub fn to_json_rpc_with_transactions_hashes(self) -> JsonValue {
-        let ethers_block: EthersBlock<H256> = self.into();
+        let ethers_block: EthersBlockH256 = self.into();
         to_json_value(ethers_block)
     }
 
@@ -161,9 +162,9 @@ impl Block {
 // -----------------------------------------------------------------------------
 // Conversions: Self -> Other
 // -----------------------------------------------------------------------------
-impl From<Block> for EthersBlock<EthersTransaction> {
+impl From<Block> for EthersBlockEthersTransaction {
     fn from(block: Block) -> Self {
-        let ethers_block = EthersBlock::<EthersTransaction>::from(block.header.clone());
+        let ethers_block = EthersBlockEthersTransaction::from(block.header.clone());
         let ethers_block_transactions: Vec<EthersTransaction> = block.transactions.clone().into_iter().map_into().collect();
         Self {
             transactions: ethers_block_transactions,
@@ -172,9 +173,9 @@ impl From<Block> for EthersBlock<EthersTransaction> {
     }
 }
 
-impl From<Block> for EthersBlock<H256> {
+impl From<Block> for EthersBlockH256 {
     fn from(block: Block) -> Self {
-        let ethers_block = EthersBlock::<H256>::from(block.header);
+        let ethers_block = EthersBlockH256::from(block.header);
         let ethers_block_transactions: Vec<H256> = block.transactions.into_iter().map(|x| x.input.hash).map_into().collect();
         Self {
             transactions: ethers_block_transactions,

--- a/src/eth/primitives/block_header.rs
+++ b/src/eth/primitives/block_header.rs
@@ -10,6 +10,7 @@ use fake::Faker;
 use hex_literal::hex;
 use jsonrpsee::SubscriptionMessage;
 
+use crate::alias::EthersBlockVoid;
 use crate::eth::consensus::append_entry;
 use crate::eth::primitives::logs_bloom::LogsBloom;
 use crate::eth::primitives::Address;
@@ -22,6 +23,7 @@ use crate::eth::primitives::Hash;
 use crate::eth::primitives::MinerNonce;
 use crate::eth::primitives::Size;
 use crate::eth::primitives::UnixTime;
+use crate::ext::ResultExt;
 
 /// Special hash used in block mining to indicate no uncle blocks.
 const HASH_EMPTY_UNCLES: Hash = Hash::new(hex!("1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"));
@@ -232,7 +234,7 @@ impl TryFrom<&ExternalBlock> for BlockHeader {
 
 impl From<BlockHeader> for SubscriptionMessage {
     fn from(value: BlockHeader) -> Self {
-        let ethers_block: EthersBlock<()> = EthersBlock::from(value);
-        Self::from_json(&ethers_block).unwrap()
+        let ethers_block = EthersBlockVoid::from(value);
+        Self::from_json(&ethers_block).expect_infallible()
     }
 }

--- a/src/eth/primitives/block_number.rs
+++ b/src/eth/primitives/block_number.rs
@@ -9,7 +9,6 @@ use ethereum_types::U64;
 use ethers_core::utils::keccak256;
 use fake::Dummy;
 use fake::Faker;
-use revm::primitives::U256 as RevmU256;
 use sqlx::database::HasArguments;
 use sqlx::database::HasValueRef;
 use sqlx::encode::IsNull;
@@ -17,6 +16,7 @@ use sqlx::error::BoxDynError;
 use sqlx::postgres::PgHasArrayType;
 use sqlx::types::BigDecimal;
 
+use crate::alias::RevmU256;
 use crate::eth::primitives::Hash;
 use crate::gen_newtype_from;
 

--- a/src/eth/primitives/bytes.rs
+++ b/src/eth/primitives/bytes.rs
@@ -3,12 +3,12 @@ use std::fmt::Display;
 use std::ops::Deref;
 use std::ops::DerefMut;
 
-use ethers_core::types::Bytes as EthersBytes;
 use revm::interpreter::analysis::to_analysed;
-use revm::primitives::Bytecode as RevmBytecode;
-use revm::primitives::Bytes as RevmBytes;
-use revm::primitives::Output as RevmOutput;
 
+use crate::alias::EthersBytes;
+use crate::alias::RevmBytecode;
+use crate::alias::RevmBytes;
+use crate::alias::RevmOutput;
 use crate::gen_newtype_from;
 
 #[derive(Clone, Default, Eq, PartialEq, fake::Dummy)]

--- a/src/eth/primitives/external_block.rs
+++ b/src/eth/primitives/external_block.rs
@@ -1,7 +1,7 @@
-use ethers_core::types::Block as EthersBlock;
-use ethers_core::types::Transaction as EthersTransaction;
 use serde::Deserialize;
 
+use crate::alias::EthersBlockEthersTransaction;
+use crate::alias::EthersBlockExternalTransaction;
 use crate::eth::primitives::Address;
 use crate::eth::primitives::Block;
 use crate::eth::primitives::BlockNumber;
@@ -14,7 +14,7 @@ use crate::log_and_err;
 
 #[derive(Debug, Clone, derive_more:: Deref, serde::Deserialize, serde::Serialize)]
 #[serde(transparent)]
-pub struct ExternalBlock(#[deref] pub EthersBlock<ExternalTransaction>);
+pub struct ExternalBlock(#[deref] pub EthersBlockExternalTransaction);
 
 impl ExternalBlock {
     /// Returns the block hash.
@@ -47,7 +47,7 @@ impl ExternalBlock {
 // Conversions: Self -> Other
 // -----------------------------------------------------------------------------
 
-impl From<ExternalBlock> for EthersBlock<ExternalTransaction> {
+impl From<ExternalBlock> for EthersBlockExternalTransaction {
     fn from(value: ExternalBlock) -> Self {
         value.0
     }
@@ -77,12 +77,12 @@ impl TryFrom<JsonValue> for ExternalBlock {
     }
 }
 
-impl From<EthersBlock<EthersTransaction>> for ExternalBlock {
-    fn from(value: EthersBlock<EthersTransaction>) -> Self {
+impl From<EthersBlockEthersTransaction> for ExternalBlock {
+    fn from(value: EthersBlockEthersTransaction) -> Self {
         let txs: Vec<ExternalTransaction> = value.transactions.into_iter().map(ExternalTransaction::from).collect();
 
         // Is there a better way to do this?
-        let block = EthersBlock {
+        let block = EthersBlockExternalTransaction {
             transactions: txs,
             hash: value.hash,
             parent_hash: value.parent_hash,

--- a/src/eth/primitives/external_receipt.rs
+++ b/src/eth/primitives/external_receipt.rs
@@ -1,7 +1,7 @@
 use ethereum_types::U256;
-use ethers_core::types::TransactionReceipt as EthersReceipt;
 use serde::Deserialize;
 
+use crate::alias::EthersReceipt;
 use crate::eth::primitives::BlockNumber;
 use crate::eth::primitives::Hash;
 use crate::eth::primitives::Wei;

--- a/src/eth/primitives/external_transaction.rs
+++ b/src/eth/primitives/external_transaction.rs
@@ -1,7 +1,6 @@
 use std::borrow::Cow;
 
-use ethers_core::types::Transaction as EthersTransaction;
-
+use crate::alias::EthersTransaction;
 use crate::eth::primitives::BlockNumber;
 use crate::eth::primitives::Hash;
 use crate::eth::primitives::Signature;

--- a/src/eth/primitives/log.rs
+++ b/src/eth/primitives/log.rs
@@ -1,6 +1,5 @@
-use ethers_core::types::Log as EthersLog;
-use revm::primitives::Log as RevmLog;
-
+use crate::alias::EthersLog;
+use crate::alias::RevmLog;
 use crate::eth::primitives::Address;
 use crate::eth::primitives::Bytes;
 use crate::eth::primitives::LogTopic;

--- a/src/eth/primitives/log_mined.rs
+++ b/src/eth/primitives/log_mined.rs
@@ -1,7 +1,7 @@
-use ethers_core::types::Log as EthersLog;
 use itertools::Itertools;
 use jsonrpsee::SubscriptionMessage;
 
+use crate::alias::EthersLog;
 use crate::eth::primitives::Address;
 use crate::eth::primitives::BlockNumber;
 use crate::eth::primitives::Hash;

--- a/src/eth/primitives/log_topic.rs
+++ b/src/eth/primitives/log_topic.rs
@@ -3,8 +3,8 @@ use std::fmt::Display;
 use ethereum_types::H256;
 use fake::Dummy;
 use fake::Faker;
-use revm::primitives::B256 as RevmB256;
 
+use crate::alias::RevmB256;
 use crate::gen_newtype_from;
 
 /// Topic is part of a [`Log`](super::Log) emitted by the EVM during contract execution.

--- a/src/eth/primitives/slot_index.rs
+++ b/src/eth/primitives/slot_index.rs
@@ -7,7 +7,6 @@ use ethereum_types::U256;
 use ethers_core::utils::keccak256;
 use fake::Dummy;
 use fake::Faker;
-use revm::primitives::U256 as RevmU256;
 use sqlx::database::HasArguments;
 use sqlx::database::HasValueRef;
 use sqlx::encode::IsNull;
@@ -15,6 +14,7 @@ use sqlx::error::BoxDynError;
 use sqlx::postgres::PgHasArrayType;
 use sqlx::Decode;
 
+use crate::alias::RevmU256;
 use crate::gen_newtype_from;
 
 #[derive(Clone, Copy, Default, Hash, Eq, PartialEq, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]

--- a/src/eth/primitives/slot_value.rs
+++ b/src/eth/primitives/slot_value.rs
@@ -4,7 +4,6 @@ use std::str::FromStr;
 use ethereum_types::U256;
 use fake::Dummy;
 use fake::Faker;
-use revm::primitives::U256 as RevmU256;
 use sqlx::database::HasArguments;
 use sqlx::database::HasValueRef;
 use sqlx::encode::IsNull;
@@ -12,6 +11,7 @@ use sqlx::error::BoxDynError;
 use sqlx::postgres::PgHasArrayType;
 use sqlx::Decode;
 
+use crate::alias::RevmU256;
 use crate::gen_newtype_from;
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]

--- a/src/eth/primitives/transaction_input.rs
+++ b/src/eth/primitives/transaction_input.rs
@@ -5,7 +5,6 @@ use display_json::DebugAsJson;
 use ethereum_types::U256;
 use ethereum_types::U64;
 use ethers_core::types::NameOrAddress;
-use ethers_core::types::Transaction as EthersTransaction;
 use ethers_core::types::TransactionRequest;
 use fake::Dummy;
 use fake::Fake;
@@ -13,6 +12,7 @@ use fake::Faker;
 use rlp::Decodable;
 use serde::Deserialize;
 
+use crate::alias::EthersTransaction;
 use crate::eth::primitives::Address;
 use crate::eth::primitives::Bytes;
 use crate::eth::primitives::ChainId;

--- a/src/eth/primitives/transaction_mined.rs
+++ b/src/eth/primitives/transaction_mined.rs
@@ -1,9 +1,9 @@
 use std::hash::Hash as HashTrait;
 
-use ethers_core::types::Transaction as EthersTransaction;
-use ethers_core::types::TransactionReceipt as EthersReceipt;
 use itertools::Itertools;
 
+use crate::alias::EthersReceipt;
+use crate::alias::EthersTransaction;
 use crate::eth::primitives::logs_bloom::LogsBloom;
 use crate::eth::primitives::BlockNumber;
 use crate::eth::primitives::EvmExecution;

--- a/src/eth/primitives/transaction_stage.rs
+++ b/src/eth/primitives/transaction_stage.rs
@@ -1,6 +1,5 @@
-use ethers_core::types::Transaction as EthersTransaction;
-use ethers_core::types::TransactionReceipt as EthersReceipt;
-
+use crate::alias::EthersReceipt;
+use crate::alias::EthersTransaction;
 use crate::eth::primitives::TransactionExecution;
 use crate::eth::primitives::TransactionMined;
 use crate::ext::to_json_value;

--- a/src/eth/primitives/unix_time.rs
+++ b/src/eth/primitives/unix_time.rs
@@ -6,7 +6,8 @@ use chrono::Utc;
 use ethereum_types::U256;
 use fake::Dummy;
 use fake::Faker;
-use revm::primitives::U256 as RevmU256;
+
+use crate::alias::RevmU256;
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct UnixTime(u64);

--- a/src/eth/primitives/wei.rs
+++ b/src/eth/primitives/wei.rs
@@ -4,7 +4,6 @@ use ethabi::Token;
 use ethereum_types::U256;
 use fake::Dummy;
 use fake::Faker;
-use revm::primitives::U256 as RevmU256;
 use sqlx::database::HasArguments;
 use sqlx::database::HasValueRef;
 use sqlx::encode::IsNull;
@@ -13,6 +12,7 @@ use sqlx::postgres::PgHasArrayType;
 use sqlx::types::BigDecimal;
 use sqlx::Decode;
 
+use crate::alias::RevmU256;
 use crate::gen_newtype_from;
 
 /// Native token amount in wei.

--- a/src/infra/blockchain_client/blockchain_client.rs
+++ b/src/infra/blockchain_client/blockchain_client.rs
@@ -1,8 +1,6 @@
 use std::time::Duration;
 
 use anyhow::Context;
-use ethers_core::types::Bytes;
-use ethers_core::types::Transaction;
 use jsonrpsee::core::client::ClientT;
 use jsonrpsee::core::client::Subscription;
 use jsonrpsee::core::client::SubscriptionClientT;
@@ -15,6 +13,8 @@ use tokio::sync::RwLock;
 use tokio::sync::RwLockReadGuard;
 
 use super::pending_transaction::PendingTransaction;
+use crate::alias::EthersBytes;
+use crate::alias::EthersTransaction;
 use crate::eth::primitives::Address;
 use crate::eth::primitives::BlockNumber;
 use crate::eth::primitives::ExternalBlock;
@@ -159,14 +159,14 @@ impl BlockchainClient {
     }
 
     /// Fetches a transaction by hash.
-    pub async fn fetch_transaction(&self, tx_hash: Hash) -> anyhow::Result<Option<Transaction>> {
+    pub async fn fetch_transaction(&self, tx_hash: Hash) -> anyhow::Result<Option<EthersTransaction>> {
         tracing::debug!(%tx_hash, "fetching transaction");
 
         let hash = to_json_value(tx_hash);
 
         let result = self
             .http
-            .request::<Option<Transaction>, Vec<JsonValue>>("eth_getTransactionByHash", vec![hash])
+            .request::<Option<EthersTransaction>, Vec<JsonValue>>("eth_getTransactionByHash", vec![hash])
             .await;
 
         match result {
@@ -210,7 +210,7 @@ impl BlockchainClient {
     // -------------------------------------------------------------------------
 
     /// Sends a signed transaction.
-    pub async fn send_raw_transaction(&self, tx: Bytes) -> anyhow::Result<PendingTransaction<'_>> {
+    pub async fn send_raw_transaction(&self, tx: EthersBytes) -> anyhow::Result<PendingTransaction<'_>> {
         tracing::debug!("sending raw transaction");
 
         let tx = to_json_value(tx);

--- a/src/infra/blockchain_client/pending_transaction.rs
+++ b/src/infra/blockchain_client/pending_transaction.rs
@@ -4,7 +4,6 @@ use std::task::Context;
 use std::task::Poll;
 use std::time::Duration;
 
-use ethers_core::types::Transaction;
 use futures::Future;
 use futures::Stream;
 use futures_timer::Delay;
@@ -14,6 +13,7 @@ use futures_util::StreamExt;
 use pin_project::pin_project;
 
 use super::BlockchainClient;
+use crate::alias::EthersTransaction;
 use crate::eth::primitives::ExternalReceipt;
 use crate::eth::primitives::Hash;
 
@@ -32,7 +32,7 @@ enum PendingTxState<'a> {
     PausedGettingTx,
 
     /// Polling The blockchain to see if the Tx has confirmed or dropped
-    GettingTx(PinBoxFut<'a, Option<Transaction>>),
+    GettingTx(PinBoxFut<'a, Option<EthersTransaction>>),
 
     /// Waiting for interval to elapse before calling API again
     PausedGettingReceipt,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod alias;
 pub mod config;
 pub mod eth;
 pub mod ext;


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Introduced a new module `alias.rs` to define common type aliases for external crates such as Serde, Ethers, and REVM.
- Replaced direct imports of external crate types with the newly defined aliases across multiple modules.
- Improved code readability and maintainability by using type aliases.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>24 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>alias.rs</strong><dd><code>Introduce common type aliases for external crates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/alias.rs

<li>Added type aliases for external crate types.<br> <li> Included aliases for Serde, Ethers, and REVM types.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1535/files#diff-3cf18e04f93918404833d4b77c55a1f81ca812c2af173952345c9ed6ec367f6b">+35/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>evm.rs</strong><dd><code>Use type aliases for REVM types in EVM executor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/executor/evm.rs

- Replaced direct imports of REVM types with aliases.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1535/files#diff-7fabd204a68cff51c55ee1391074463fa8ac005dc8ba443218bc83a9dda96658">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>account.rs</strong><dd><code>Use type aliases for REVM types in account module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/account.rs

- Replaced direct imports of REVM types with aliases.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1535/files#diff-471f8d8754a2a5ad8f776fa90d4a3521d1c62a2ce68bce06d5a22becb191fddc">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>address.rs</strong><dd><code>Use type aliases for REVM types in address module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/address.rs

- Replaced direct imports of REVM types with aliases.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1535/files#diff-43c180e22a2858040d18def981f15acd2fbe7f76fe1b59b76121e9aceeead96d">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>block.rs</strong><dd><code>Use type aliases for Ethers types in block module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/block.rs

- Replaced direct imports of Ethers types with aliases.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1535/files#diff-1713a99b45fd64ac0570786603a3a17edc97657646bd333e5e214e4a531def10">+9/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>block_header.rs</strong><dd><code>Use type aliases for Ethers types in block header module</code>&nbsp; </dd></summary>
<hr>

src/eth/primitives/block_header.rs

- Replaced direct imports of Ethers types with aliases.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1535/files#diff-b8e75472f4443e9f0d8349bcf88f50a0210d72cd86abcacccc8aa89919e746d9">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>block_number.rs</strong><dd><code>Use type aliases for REVM types in block number module</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/block_number.rs

- Replaced direct imports of REVM types with aliases.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1535/files#diff-23597a90086820357b399bf33f2db790baaf7f0d4617a74a134c4d200022bb93">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>bytes.rs</strong><dd><code>Use type aliases for Ethers and REVM types in bytes module</code></dd></summary>
<hr>

src/eth/primitives/bytes.rs

- Replaced direct imports of Ethers and REVM types with aliases.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1535/files#diff-e2007d1ed9fa6978ef516d7b6abeb65ef67f8e856ad26f0efb9e9a1b46840677">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>external_block.rs</strong><dd><code>Use type aliases for Ethers types in external block module</code></dd></summary>
<hr>

src/eth/primitives/external_block.rs

- Replaced direct imports of Ethers types with aliases.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1535/files#diff-a9f4dfb1768eeb5161bd375436af42b8fbb82726916dd9c4cc1e7a08edd54388">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>external_receipt.rs</strong><dd><code>Use type aliases for Ethers types in external receipt module</code></dd></summary>
<hr>

src/eth/primitives/external_receipt.rs

- Replaced direct imports of Ethers types with aliases.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1535/files#diff-861198f134c8476294e25bf5d885dcf2229eeca24af73506e223ca2f0cc13dd5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>external_transaction.rs</strong><dd><code>Use type aliases for Ethers types in external transaction module</code></dd></summary>
<hr>

src/eth/primitives/external_transaction.rs

- Replaced direct imports of Ethers types with aliases.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1535/files#diff-a5bcf577600cee6a4844b4015797a92684df8ec490f06f66b4a556881a66032d">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>log.rs</strong><dd><code>Use type aliases for Ethers and REVM types in log module</code>&nbsp; </dd></summary>
<hr>

src/eth/primitives/log.rs

- Replaced direct imports of Ethers and REVM types with aliases.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1535/files#diff-c886f14c171107da82c777d17266657e495a804d331b3e4f0ce2f5ddafdb0a69">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>log_mined.rs</strong><dd><code>Use type aliases for Ethers types in log mined module</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/log_mined.rs

- Replaced direct imports of Ethers types with aliases.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1535/files#diff-0ce210a69394a14d9a6424cf5ddf8b84c10a535b9ecae1dd34c0dbcff4beaf07">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>log_topic.rs</strong><dd><code>Use type aliases for REVM types in log topic module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/log_topic.rs

- Replaced direct imports of REVM types with aliases.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1535/files#diff-ac0f3bf93665711c21efcc8f0e0516e58626d21f63b95753efdcb3eefd31f5c6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>slot_index.rs</strong><dd><code>Use type aliases for REVM types in slot index module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/slot_index.rs

- Replaced direct imports of REVM types with aliases.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1535/files#diff-a6d393b2415c8601795717188a4bb54f9b1b1f74578eb722cacfb71021815ae6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>slot_value.rs</strong><dd><code>Use type aliases for REVM types in slot value module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/slot_value.rs

- Replaced direct imports of REVM types with aliases.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1535/files#diff-e8bdc6406b44d637e87cc4719fa6f166240c6f85bd9c23512faba18496e7e463">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>transaction_input.rs</strong><dd><code>Use type aliases for Ethers types in transaction input module</code></dd></summary>
<hr>

src/eth/primitives/transaction_input.rs

- Replaced direct imports of Ethers types with aliases.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1535/files#diff-82805cb38a9fb8fc686e7186838bde829d2e092c13ec88636aa57a4129ffedde">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>transaction_mined.rs</strong><dd><code>Use type aliases for Ethers types in transaction mined module</code></dd></summary>
<hr>

src/eth/primitives/transaction_mined.rs

- Replaced direct imports of Ethers types with aliases.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1535/files#diff-79809f5ea2cc1e67126d745072125f6992cb5857ac9abf5c0d21b1f67879359b">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>transaction_stage.rs</strong><dd><code>Use type aliases for Ethers types in transaction stage module</code></dd></summary>
<hr>

src/eth/primitives/transaction_stage.rs

- Replaced direct imports of Ethers types with aliases.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1535/files#diff-01decfef18b1279624031c329be1473400de3c0edad3e0b196a2acc3fbc73a30">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>unix_time.rs</strong><dd><code>Use type aliases for REVM types in unix time module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/unix_time.rs

- Replaced direct imports of REVM types with aliases.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1535/files#diff-8c55a886f7862a6abfe41aed8803659e33c07a1aea4d1ac7ebe87b7492a284f9">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>wei.rs</strong><dd><code>Use type aliases for REVM types in wei module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/wei.rs

- Replaced direct imports of REVM types with aliases.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1535/files#diff-457aeabe073254b540b036a4f4e776b56a3f12cccab2760838696e170b60424b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>blockchain_client.rs</strong><dd><code>Use type aliases for Ethers types in blockchain client</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/infra/blockchain_client/blockchain_client.rs

- Replaced direct imports of Ethers types with aliases.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1535/files#diff-05af32e93a38a2ab966d4c4c633284d19cada2fa11c1962fabf9c981ff7fd3e6">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>pending_transaction.rs</strong><dd><code>Use type aliases for Ethers types in pending transaction</code>&nbsp; </dd></summary>
<hr>

src/infra/blockchain_client/pending_transaction.rs

- Replaced direct imports of Ethers types with aliases.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1535/files#diff-7bca952ff2fb341656ac01bea60eb5e11e3309ab2eaa18e20b185ba178a0d627">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Add alias module to library</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib.rs

- Added new module for type aliases.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1535/files#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

