### PR TITLE
test: improve external get logs test to test block ranges

### DIFF
--- a/e2e/test/external/e2e-json-rpc.test.ts
+++ b/e2e/test/external/e2e-json-rpc.test.ts
@@ -151,24 +151,33 @@ describe("JSON-RPC", () => {
                 const block = await sendGetBlockNumber();
 
                 async function sendNTransactions(n: number) {
-                    for(let i = 0; i < n; i++){
+                    for (let i = 0; i < n; i++) {
                         await contractOps.add(ALICE.address, 10);
                     }
                     await sendEvmMine();
                 }
 
-                await sendNTransactions(8)
-                await sendNTransactions(4)
-                await sendNTransactions(2)
-                await sendNTransactions(1)
+                await sendNTransactions(8);
+                await sendNTransactions(4);
+                await sendNTransactions(2);
+                await sendNTransactions(1);
 
                 // single block
-                expect(await send("eth_getLogs", [{ ...filter, fromBlock: toHex(block + 1), toBlock: toHex(block + 1)}])).length(8);
-                expect(await send("eth_getLogs", [{ ...filter, fromBlock: toHex(block + 2), toBlock: toHex(block + 2)}])).length(4);
-                expect(await send("eth_getLogs", [{ ...filter, fromBlock: toHex(block + 3), toBlock: toHex(block + 3)}])).length(2);
-                expect(await send("eth_getLogs", [{ ...filter, fromBlock: toHex(block + 4), toBlock: toHex(block + 4)}])).length(1);
-                expect(await send("eth_getLogs", [{ ...filter, fromBlock: toHex(block + 5), toBlock: toHex(block + 5)}])).length(0);
-
+                expect(
+                    await send("eth_getLogs", [{ ...filter, fromBlock: toHex(block + 1), toBlock: toHex(block + 1) }]),
+                ).length(8);
+                expect(
+                    await send("eth_getLogs", [{ ...filter, fromBlock: toHex(block + 2), toBlock: toHex(block + 2) }]),
+                ).length(4);
+                expect(
+                    await send("eth_getLogs", [{ ...filter, fromBlock: toHex(block + 3), toBlock: toHex(block + 3) }]),
+                ).length(2);
+                expect(
+                    await send("eth_getLogs", [{ ...filter, fromBlock: toHex(block + 4), toBlock: toHex(block + 4) }]),
+                ).length(1);
+                expect(
+                    await send("eth_getLogs", [{ ...filter, fromBlock: toHex(block + 5), toBlock: toHex(block + 5) }]),
+                ).length(0);
 
                 // block range (offset fromBlock)
                 expect(await send("eth_getLogs", [{ ...filter, fromBlock: toHex(block + 1) }])).length(15);
@@ -178,14 +187,26 @@ describe("JSON-RPC", () => {
                 expect(await send("eth_getLogs", [{ ...filter, fromBlock: toHex(block + 5) }])).length(0);
 
                 // block range (offset toBlock)
-                expect(await send("eth_getLogs", [{ ...filter, fromBlock: toHex(block), toBlock: toHex(block + 1) }])).length(8);
-                expect(await send("eth_getLogs", [{ ...filter, fromBlock: toHex(block), toBlock: toHex(block + 2) }])).length(12);
-                expect(await send("eth_getLogs", [{ ...filter, fromBlock: toHex(block), toBlock: toHex(block + 3) }])).length(14);
-                expect(await send("eth_getLogs", [{ ...filter, fromBlock: toHex(block), toBlock: toHex(block + 4) }])).length(15);
-                expect(await send("eth_getLogs", [{ ...filter, fromBlock: toHex(block), toBlock: toHex(block + 4) }])).length(15);
+                expect(
+                    await send("eth_getLogs", [{ ...filter, fromBlock: toHex(block), toBlock: toHex(block + 1) }]),
+                ).length(8);
+                expect(
+                    await send("eth_getLogs", [{ ...filter, fromBlock: toHex(block), toBlock: toHex(block + 2) }]),
+                ).length(12);
+                expect(
+                    await send("eth_getLogs", [{ ...filter, fromBlock: toHex(block), toBlock: toHex(block + 3) }]),
+                ).length(14);
+                expect(
+                    await send("eth_getLogs", [{ ...filter, fromBlock: toHex(block), toBlock: toHex(block + 4) }]),
+                ).length(15);
+                expect(
+                    await send("eth_getLogs", [{ ...filter, fromBlock: toHex(block), toBlock: toHex(block + 4) }]),
+                ).length(15);
 
                 // block range (middle blocks)
-                expect(await send("eth_getLogs", [{ ...filter, fromBlock: toHex(block + 2), toBlock: toHex(block + 3) }])).length(6);
+                expect(
+                    await send("eth_getLogs", [{ ...filter, fromBlock: toHex(block + 2), toBlock: toHex(block + 3) }]),
+                ).length(6);
             });
         });
 


### PR DESCRIPTION
### **PR Type**
Tests


___

### **Description**
- Added a new test case to the `eth_getLogs` suite to verify the correct number of logs returned for different block ranges.
- Introduced a helper function `sendNTransactions` to facilitate sending multiple transactions in tests.
- Ensured that `sendEvmMine` is awaited to maintain consistency and reliability in tests.
- Added multiple assertions to check log retrieval for single blocks and various block ranges.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>e2e-json-rpc.test.ts</strong><dd><code>Enhance `eth_getLogs` tests with block range scenarios</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

e2e/test/external/e2e-json-rpc.test.ts

<li>Added a new test case for <code>eth_getLogs</code> to verify log retrieval for <br>different block ranges.<br> <li> Introduced helper function <code>sendNTransactions</code> to send multiple <br>transactions.<br> <li> Ensured <code>sendEvmMine</code> is awaited for consistency.<br> <li> Added assertions for single block and block range log retrieval.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1548/files#diff-f5d1f06c4777826f9cbdcb4372d15c42f354177c83df65f3324cfd607da16004">+57/-4</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

