### PR TITLE
update nightly and fix new warnings

### DIFF
--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Set up Rust Nightly and Rust Docs
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain nightly-2024-02-29
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain nightly-2024-07-19
           rustup component add rust-docs
 
       - name: Rust Cache
@@ -51,7 +51,7 @@ jobs:
 
       - name: Generate docs
         run: |
-          just doc -2024-02-29
+          just doc -2024-07-19
           echo "<meta http-equiv='refresh' content='0; URL=./stratus/'>" >> target/doc/index.html
           chmod -c -R +rX target/doc/
 

--- a/.github/workflows/lint-check.yml
+++ b/.github/workflows/lint-check.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Rust Nightly
-        run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain nightly-2024-02-29
+        run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain nightly-2024-07-19
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
@@ -59,7 +59,7 @@ jobs:
         uses: extractions/setup-just@v2
 
       - name: Just lint-check
-        run: just lint-check -2024-02-29
+        run: just lint-check -2024-07-19
 
   e2e_lint:
     name: E2E Lint

--- a/src/eth/miner/miner.rs
+++ b/src/eth/miner/miner.rs
@@ -153,9 +153,7 @@ impl Miner {
         let mined_txs = mine_external_transactions(block.number, external_txs)?;
         let block = block_from_external(external_block, mined_txs);
 
-        block.inspect(|block| {
-            Span::with(|s| s.rec_str("block_number", &block.number()))
-        })
+        block.inspect(|block| Span::with(|s| s.rec_str("block_number", &block.number())))
     }
 
     /// Same as [`Self::mine_external_mixed`], but automatically commits the block instead of returning it.
@@ -240,9 +238,7 @@ impl Miner {
             None => Ok(Block::new_at_now(block.number)),
         };
 
-        block.inspect(|block| {
-            Span::with(|s| s.rec_str("block_number", &block.number()))
-        })
+        block.inspect(|block| Span::with(|s| s.rec_str("block_number", &block.number())))
     }
 
     /// Persists a mined block to permanent storage and prepares new block.

--- a/src/eth/miner/miner.rs
+++ b/src/eth/miner/miner.rs
@@ -153,9 +153,8 @@ impl Miner {
         let mined_txs = mine_external_transactions(block.number, external_txs)?;
         let block = block_from_external(external_block, mined_txs);
 
-        block.map(|block| {
-            Span::with(|s| s.rec_str("block_number", &block.number()));
-            block
+        block.inspect(|block| {
+            Span::with(|s| s.rec_str("block_number", &block.number()))
         })
     }
 
@@ -241,9 +240,8 @@ impl Miner {
             None => Ok(Block::new_at_now(block.number)),
         };
 
-        block.map(|block| {
-            Span::with(|s| s.rec_str("block_number", &block.number()));
-            block
+        block.inspect(|block| {
+            Span::with(|s| s.rec_str("block_number", &block.number()))
         })
     }
 

--- a/src/eth/primitives/transaction_mined.rs
+++ b/src/eth/primitives/transaction_mined.rs
@@ -161,6 +161,10 @@ mod tests {
         }
     }
 
+    fn is_sorted<T: Ord>(vec: &[T]) -> bool {
+        vec.windows(2).all(|w| w[0] <= w[1])
+    }
+
     #[test]
     fn sort_transactions() {
         let mut rng = rand::thread_rng();
@@ -169,8 +173,6 @@ mod tests {
             .sorted()
             .map(|tx| (tx.block_number.as_u64(), tx.transaction_index.0))
             .collect_vec();
-        for pair in v {
-            format!("{:?}", pair);
-        }
+        assert!(is_sorted(&v));
     }
 }


### PR DESCRIPTION
### **User description**
closes #1232


___

### **PR Type**
Enhancement, Tests, Configuration changes


___

### **Description**
- Refactored block processing in `miner.rs` by replacing `map` with `inspect` for better readability and performance.
- Enhanced transaction sorting test by adding an `is_sorted` function and replacing manual checks with assertions.
- Updated Rust Nightly version to 2024-07-19 in GitHub workflows for docs release and lint checks.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>miner.rs</strong><dd><code>Refactor block processing with `inspect` method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/miner/miner.rs

<li>Replaced <code>map</code> with <code>inspect</code> for better readability and performance.<br> <li> Simplified block processing logic.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1552/files#diff-16f448afc7dae3e8e802f676a86dbd7051e19f6c17cbbeb53eb730d726372629">+2/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>transaction_mined.rs</strong><dd><code>Improve transaction sorting test with `is_sorted` function</code></dd></summary>
<hr>

src/eth/primitives/transaction_mined.rs

<li>Added <code>is_sorted</code> function to check if transactions are sorted.<br> <li> Replaced manual sorting check with an assertion.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1552/files#diff-79809f5ea2cc1e67126d745072125f6992cb5857ac9abf5c0d21b1f67879359b">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docs-release.yml</strong><dd><code>Update Rust Nightly version in docs-release workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/docs-release.yml

<li>Updated Rust Nightly version to 2024-07-19.<br> <li> Adjusted related commands to use the new version.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1552/files#diff-b6f2546d438fa8cf000fdf5fb9409857d1cd8f24a70fab05725d3501a7a4c753">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>lint-check.yml</strong><dd><code>Update Rust Nightly version in lint-check workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/lint-check.yml

<li>Updated Rust Nightly version to 2024-07-19.<br> <li> Adjusted related commands to use the new version.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1552/files#diff-dda267615bb53af994fa659ec8de11a5c4855ee18b1922370924f65759d8cae1">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

