### PR TITLE
enha: make tokio-console optional

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -79,7 +79,7 @@ pub struct CommonConfig {
     pub metrics_exporter_address: SocketAddr,
 
     // Address where Tokio Console GRPC server will be exposed.
-    #[arg(long = "tokio-console-address", env = "TRACING_TOKIO_CONSOLE_ADDRESS", default_value = "0.0.0.0:6669")]
+    #[arg(long = "tokio-console-address", env = "TRACING_TOKIO_CONSOLE_ADDRESS")]
     pub tokio_console_address: Option<SocketAddr>,
 
     /// Sentry URL where error events will be pushed.

--- a/src/config.rs
+++ b/src/config.rs
@@ -80,7 +80,7 @@ pub struct CommonConfig {
 
     // Address where Tokio Console GRPC server will be exposed.
     #[arg(long = "tokio-console-address", env = "TRACING_TOKIO_CONSOLE_ADDRESS", default_value = "0.0.0.0:6669")]
-    pub tokio_console_address: SocketAddr,
+    pub tokio_console_address: Option<SocketAddr>,
 
     /// Sentry URL where error events will be pushed.
     #[arg(long = "sentry-url", env = "SENTRY_URL")]

--- a/src/infra/tracing/tracing.rs
+++ b/src/infra/tracing/tracing.rs
@@ -137,7 +137,7 @@ pub async fn init_tracing(config: &TracingConfig, sentry_url: Option<&str>, toki
             Some(console_layer)
         }
         None => {
-            println!("tracing registry: skipping tokio-console");
+            println!("tracing registry: skipping tokio-console exporter");
             None
         }
     };

--- a/src/infra/tracing/tracing.rs
+++ b/src/infra/tracing/tracing.rs
@@ -125,12 +125,12 @@ pub async fn init_tracing(config: &TracingConfig, sentry_url: Option<&str>, toki
 
     // configure tokio-console layer
     println!("tracing registry: enabling tokio console exporter | address={}", tokio_console_address);
-    let (console_layer, console_server) = ConsoleLayer::builder().with_default_env().server_addr(tokio_console_address).build();
-    spawn_named("console::grpc-server", async move {
-        if let Err(e) = console_server.serve().await {
-            tracing::error!(reason = ?e, address = %tokio_console_address, "failed to create tokio-console server");
-        };
-    });
+    //let (console_layer, console_server) = ConsoleLayer::builder().with_default_env().server_addr(tokio_console_address).build();
+    //spawn_named("console::grpc-server", async move {
+    //    if let Err(e) = console_server.serve().await {
+    //        tracing::error!(reason = ?e, address = %tokio_console_address, "failed to create tokio-console server");
+    //    };
+    //});
 
     // init registry
     let result = tracing_subscriber::registry()
@@ -138,7 +138,7 @@ pub async fn init_tracing(config: &TracingConfig, sentry_url: Option<&str>, toki
         .with(stdout_layer)
         .with(opentelemetry_layer)
         .with(sentry_layer)
-        .with(console_layer)
+        //.with(console_layer)
         .try_init();
 
     match result {

--- a/src/infra/tracing/tracing.rs
+++ b/src/infra/tracing/tracing.rs
@@ -57,7 +57,7 @@ use crate::infra::tracing::TracingLogFormat;
 use crate::infra::tracing::TracingProtocol;
 
 /// Init application tracing.
-pub async fn init_tracing(config: &TracingConfig, sentry_url: Option<&str>, tokio_console_address: SocketAddr) -> anyhow::Result<()> {
+pub async fn init_tracing(config: &TracingConfig, sentry_url: Option<&str>, tokio_console_address: Option<SocketAddr>) -> anyhow::Result<()> {
     println!("creating tracing registry");
 
     // configure tracing context layer
@@ -123,23 +123,26 @@ pub async fn init_tracing(config: &TracingConfig, sentry_url: Option<&str>, toki
         }
     };
 
-    // configure tokio-console layer
-    println!("tracing registry: enabling tokio console exporter | address={}", tokio_console_address);
-    //let (console_layer, console_server) = ConsoleLayer::builder().with_default_env().server_addr(tokio_console_address).build();
-    //spawn_named("console::grpc-server", async move {
-    //    if let Err(e) = console_server.serve().await {
-    //        tracing::error!(reason = ?e, address = %tokio_console_address, "failed to create tokio-console server");
-    //    };
-    //});
-
-    // init registry
-    let result = tracing_subscriber::registry()
+    let subscriber_builder = tracing_subscriber::registry()
         .with(tracing_context_layer)
         .with(stdout_layer)
         .with(opentelemetry_layer)
-        .with(sentry_layer)
-        //.with(console_layer)
-        .try_init();
+        .with(sentry_layer);
+
+    // configure tokio-console layer
+    let result = if let Some(tokio_console_address) = tokio_console_address {
+        println!("tracing registry: enabling tokio console exporter | address={}", tokio_console_address);
+
+        let (console_layer, console_server) = ConsoleLayer::builder().with_default_env().server_addr(tokio_console_address).build();
+        spawn_named("console::grpc-server", async move {
+            if let Err(e) = console_server.serve().await {
+                tracing::error!(reason = ?e, address = %tokio_console_address, "failed to create tokio-console server");
+            };
+        });
+        subscriber_builder.with(console_layer).try_init()
+    } else {
+        subscriber_builder.try_init()
+    };
 
     match result {
         Ok(()) => Ok(()),


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Made `tokio_console_address` an optional configuration parameter in `CommonConfig`.
- Updated `init_tracing` function to handle the optional `tokio_console_address`.
- Conditional initialization of the Tokio Console layer based on the presence of `tokio_console_address`.
- Adjusted tracing subscriber initialization to support the optional Tokio Console layer.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.rs</strong><dd><code>Make `tokio_console_address` optional in configuration</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/config.rs

<li>Made <code>tokio_console_address</code> an optional configuration.<br> <li> Removed default value for <code>tokio_console_address</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1554/files#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecd">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>tracing.rs</strong><dd><code>Conditional initialization of Tokio Console layer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/infra/tracing/tracing.rs

<li>Updated <code>init_tracing</code> function to handle optional <br><code>tokio_console_address</code>.<br> <li> Conditional initialization of Tokio Console layer based on the <br>presence of <code>tokio_console_address</code>.<br> <li> Adjusted tracing subscriber initialization to support optional Tokio <br>Console layer.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1554/files#diff-96fd30e1704c6f81158c63eea46561666a6b05c594b0cf999f35b86e881283d1">+18/-15</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

