### PR TITLE
enha: use helper functions for keys

### DIFF
--- a/src/eth/storage/redis/redis_permanent.rs
+++ b/src/eth/storage/redis/redis_permanent.rs
@@ -87,9 +87,9 @@ impl PermanentStorage for RedisPermanentStorage {
 
         // transactions
         for tx in &block.transactions {
-            let key = tx_key(&tx.input.hash);
-            let value = to_json_string(&tx);
-            redis_values.push((key, value));
+            let tx_key = tx_key(&tx.input.hash);
+            let tx_value = to_json_string(&tx);
+            redis_values.push((tx_key, tx_value));
         }
 
         // changes


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Replaced inline key formatting with dedicated helper functions for better code readability and maintainability.
- Added `account_key`, `slot_key`, and `tx_key` helper functions to generate keys for accounts, slots, and transactions respectively.
- Updated key generation in methods like `read_block`, `read_transaction`, `read_account`, and `read_slot` to use the new helper functions.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>redis_permanent.rs</strong><dd><code>Refactor key generation using helper functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/redis/redis_permanent.rs

<li>Replaced inline key formatting with helper functions.<br> <li> Added <code>account_key</code>, <code>slot_key</code>, and <code>tx_key</code> helper functions.<br> <li> Updated key generation in various methods to use the new helper <br>functions.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1556/files#diff-068ece78c4a374a891db1f4759a7a035df7aa981bf04c3bffecfd44e94f5841b">+33/-14</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

