### PR TITLE
enha: always enable test-accounts in dev mode

### DIFF
--- a/chaos/experiments/main.sh
+++ b/chaos/experiments/main.sh
@@ -98,7 +98,6 @@ start_instance() {
 
     RUST_LOG=info RUST_BACKTRACE=1 cargo run --release --bin $binary --features dev -- \
         --block-mode=1s \
-        --enable-test-accounts \
         --candidate-peers="$candidate_peers" \
         -a=$address \
         --grpc-server-address=$grpc_address \

--- a/docker/Dockerfile.run_with_importer_cached
+++ b/docker/Dockerfile.run_with_importer_cached
@@ -39,7 +39,6 @@ COPY Cargo.lock /app/Cargo.lock
 ENV CARGO_PROFILE_RELEASE_DEBUG=1
 ENV TRACING_LOG_FORMAT=json
 ENV NO_COLOR=1
-ENV ENABLE_TEST_ACCOUNTS=1
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/app/target \
     cargo build --release --bin run-with-importer --features dev

--- a/justfile
+++ b/justfile
@@ -13,7 +13,7 @@ wait_service_timeout := env("WAIT_SERVICE_TIMEOUT", "60")
 
 # Cargo flags.
 build_flags := nightly_flag + " " + release_flag + " --bin stratus --features " + feature_flags
-run_flags := "--enable-genesis --enable-test-accounts"
+run_flags := "--enable-genesis"
 
 # Project: Show available tasks
 default:
@@ -319,13 +319,13 @@ e2e-importer-online-up:
     mkdir e2e_logs
 
     # Start Stratus binary
-    RUST_LOG=info cargo run --release --bin stratus --features dev -- --block-mode 1s --enable-genesis --enable-test-accounts --perm-storage=rocks --rocks-path-prefix=temp_3000 --tokio-console-address=0.0.0.0:6668 --metrics-exporter-address=0.0.0.0:9000 -a 0.0.0.0:3000 > e2e_logs/stratus.log &
+    RUST_LOG=info cargo run --release --bin stratus --features dev -- --block-mode 1s --enable-genesis --perm-storage=rocks --rocks-path-prefix=temp_3000 --tokio-console-address=0.0.0.0:6668 --metrics-exporter-address=0.0.0.0:9000 -a 0.0.0.0:3000 > e2e_logs/stratus.log &
 
     # Wait for Stratus to start
     wait-service --tcp 0.0.0.0:3000 -t {{ wait_service_timeout }} -- echo
 
     # Start Run With Importer binary
-    RUST_LOG=info cargo run --release --bin run-with-importer --features dev -- --block-mode 1s --enable-test-accounts --perm-storage=rocks --rocks-path-prefix=temp_3001 --tokio-console-address=0.0.0.0:6669 --metrics-exporter-address=0.0.0.0:9001 -a 0.0.0.0:3001 -r http://0.0.0.0:3000/ -w ws://0.0.0.0:3000/ > e2e_logs/run_with_importer.log &
+    RUST_LOG=info cargo run --release --bin run-with-importer --features dev -- --block-mode 1s --perm-storage=rocks --rocks-path-prefix=temp_3001 --tokio-console-address=0.0.0.0:6669 --metrics-exporter-address=0.0.0.0:9001 -a 0.0.0.0:3001 -r http://0.0.0.0:3000/ -w ws://0.0.0.0:3000/ > e2e_logs/run_with_importer.log &
 
     # Wait for Run With Importer to start
     wait-service --tcp 0.0.0.0:3001 -t {{ wait_service_timeout }} -- echo

--- a/src/eth/miner/miner_config.rs
+++ b/src/eth/miner/miner_config.rs
@@ -27,11 +27,6 @@ pub struct MinerConfig {
     /// Generates genesis block on startup when it does not exist.
     #[arg(long = "enable-genesis", env = "ENABLE_GENESIS", default_value = "false")]
     pub enable_genesis: bool,
-
-    /// Enables test accounts with max wei on startup.
-    #[cfg(feature = "dev")]
-    #[arg(long = "enable-test-accounts", env = "ENABLE_TEST_ACCOUNTS", default_value = "false")]
-    pub enable_test_accounts: bool,
 }
 
 impl MinerConfig {
@@ -63,7 +58,7 @@ impl MinerConfig {
 
         // enable test accounts
         #[cfg(feature = "dev")]
-        if self.enable_test_accounts {
+        {
             let test_accounts = test_accounts();
             tracing::info!(accounts = ?test_accounts, "enabling test accounts");
             storage.save_accounts(test_accounts)?;

--- a/src/eth/miner/miner_config.rs
+++ b/src/eth/miner/miner_config.rs
@@ -7,7 +7,7 @@ use display_json::DebugAsJson;
 
 use crate::eth::miner::Miner;
 #[cfg(feature = "dev")]
-use crate::eth::primitives::test_accounts;
+use crate::eth::primitives::dev_accounts;
 use crate::eth::primitives::Block;
 use crate::eth::primitives::BlockFilter;
 use crate::eth::primitives::BlockNumber;

--- a/src/eth/miner/miner_config.rs
+++ b/src/eth/miner/miner_config.rs
@@ -7,7 +7,7 @@ use display_json::DebugAsJson;
 
 use crate::eth::miner::Miner;
 #[cfg(feature = "dev")]
-use crate::eth::primitives::dev_accounts;
+use crate::eth::primitives::test_accounts;
 use crate::eth::primitives::Block;
 use crate::eth::primitives::BlockFilter;
 use crate::eth::primitives::BlockNumber;

--- a/src/eth/primitives/account.rs
+++ b/src/eth/primitives/account.rs
@@ -100,7 +100,7 @@ impl From<&Account> for RevmAccountInfo {
 // -----------------------------------------------------------------------------
 
 /// Accounts to be used only in development-mode.
-pub fn dev_accounts() -> Vec<Account> {
+pub fn test_accounts() -> Vec<Account> {
     use hex_literal::hex;
 
     [

--- a/src/eth/primitives/account.rs
+++ b/src/eth/primitives/account.rs
@@ -99,8 +99,8 @@ impl From<&Account> for RevmAccountInfo {
 // Utilities
 // -----------------------------------------------------------------------------
 
-/// Test accounts.
-pub fn test_accounts() -> Vec<Account> {
+/// Accounts to be used only in development-mode.
+pub fn dev_accounts() -> Vec<Account> {
     use hex_literal::hex;
 
     [

--- a/src/eth/primitives/account.rs
+++ b/src/eth/primitives/account.rs
@@ -99,18 +99,18 @@ impl From<&Account> for RevmAccountInfo {
 // Utilities
 // -----------------------------------------------------------------------------
 
-/// Retrieves test accounts.
+/// Test accounts.
 pub fn test_accounts() -> Vec<Account> {
     use hex_literal::hex;
 
     [
-        hex!("f39fd6e51aad88f6f4ce6ab8827279cfffb92266"),
-        hex!("70997970c51812dc3a010c7d01b50e0d17dc79c8"),
-        hex!("3c44cdddb6a900fa2b585dd299e03d12fa4293bc"),
-        hex!("15d34aaf54267db7d7c367839aaf71a00a2c6a65"),
-        hex!("9965507d1a55bcc2695c58ba16fb37d819b0a4dc"),
-        hex!("976ea74026e726554db657fa54763abd0c3a0aa9"),
-        hex!("e45b176cad7090a5cf70b69a73b6def9296ba6a2"),
+        hex!("f39fd6e51aad88f6f4ce6ab8827279cfffb92266"), // ALICE
+        hex!("70997970c51812dc3a010c7d01b50e0d17dc79c8"), // BOB
+        hex!("3c44cdddb6a900fa2b585dd299e03d12fa4293bc"), // CHARLIE
+        hex!("15d34aaf54267db7d7c367839aaf71a00a2c6a65"), // DAVE
+        hex!("9965507d1a55bcc2695c58ba16fb37d819b0a4dc"), // EVE
+        hex!("976ea74026e726554db657fa54763abd0c3a0aa9"), // FERDIE
+        hex!("e45b176cad7090a5cf70b69a73b6def9296ba6a2"), // ?
     ]
     .into_iter()
     .map(|address| Account {

--- a/src/eth/primitives/mod.rs
+++ b/src/eth/primitives/mod.rs
@@ -46,7 +46,7 @@ mod transaction_stage;
 mod unix_time;
 mod wei;
 
-pub use account::dev_accounts;
+pub use account::test_accounts;
 pub use account::Account;
 pub use address::Address;
 pub use block::Block;

--- a/src/eth/primitives/mod.rs
+++ b/src/eth/primitives/mod.rs
@@ -46,7 +46,7 @@ mod transaction_stage;
 mod unix_time;
 mod wei;
 
-pub use account::test_accounts;
+pub use account::dev_accounts;
 pub use account::Account;
 pub use address::Address;
 pub use block::Block;


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Removed the `enable_test_accounts` configuration option and always enable test accounts in development mode.
- Added comments with names for test accounts in `src/eth/primitives/account.rs`.
- Removed `--enable-test-accounts` flag from `chaos/experiments/main.sh`.
- Removed `ENABLE_TEST_ACCOUNTS` environment variable from `docker/Dockerfile.run_with_importer_cached`.
- Removed `--enable-test-accounts` flag from various commands in `justfile`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>miner_config.rs</strong><dd><code>Always enable test accounts in development mode</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/miner/miner_config.rs

<li>Removed the <code>enable_test_accounts</code> configuration option.<br> <li> Always enable test accounts in development mode.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1557/files#diff-ea3a8597b909e696993f7e791ab04e5ad784da8077b87088d9c78c804e1ef69d">+1/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>account.rs</strong><dd><code>Add names to test accounts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/account.rs

- Added comments with names for test accounts.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1557/files#diff-471f8d8754a2a5ad8f776fa90d4a3521d1c62a2ce68bce06d5a22becb191fddc">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>main.sh</strong><dd><code>Remove test accounts flag from chaos experiment script</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

chaos/experiments/main.sh

- Removed `--enable-test-accounts` flag from the script.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1557/files#diff-244c0f1739d9a0f01ac254c5adbd74230e18cda380ccd8406f385e9c69286cd2">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Dockerfile.run_with_importer_cached</strong><dd><code>Remove test accounts environment variable from Dockerfile</code></dd></summary>
<hr>

docker/Dockerfile.run_with_importer_cached

- Removed `ENABLE_TEST_ACCOUNTS` environment variable.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1557/files#diff-c43ac7e06d8f744891fead9c2d92c4d5d185f5482da8ec6cecc45af2b4482054">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>justfile</strong><dd><code>Remove test accounts flag from justfile commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

justfile

- Removed `--enable-test-accounts` flag from various commands.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1557/files#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

