### PR TITLE
feat: stratus_reset instead of debug_setHead

### DIFF
--- a/e2e/cloudwalk-contracts/patches/brlc-yield-streamer.patch
+++ b/e2e/cloudwalk-contracts/patches/brlc-yield-streamer.patch
@@ -18,10 +18,10 @@ index 3bebd80..0f45a75 100644
 +      method: "evm_setNextBlockTimestamp",
 +      params: [0]
 +    });
-+    await network.provider.request({
-+      method: "debug_setHead",
-+      params: [`0x1`]
-+    });
++    // await network.provider.request({
++    //  method: "debug_setHead",
++    //  params: [`0x1`]
++    // });
      return func();
    }
  }
@@ -104,8 +104,8 @@ index 3bebd80..0f45a75 100644
 +      });
 +    } else {
 +      await network.provider.request({
-+        method: "debug_setHead",
-+        params: [`0x0`]
++        method: "stratus_reset",
++        params: []
 +      });
 +    }
      [deployer, attacker, user1, user2] = await ethers.getSigners();

--- a/e2e/test/automine/e2e-json-rpc.test.ts
+++ b/e2e/test/automine/e2e-json-rpc.test.ts
@@ -29,12 +29,9 @@ import {
 
 describe("JSON-RPC", () => {
     describe("State", () => {
-        it("debug_setHead / hardhat_reset", async () => {
-            if (isStratus) {
-                (await sendExpect("debug_setHead", [ZERO])).eq(ZERO);
-            } else {
-                (await sendExpect("hardhat_reset", [])).eq(true);
-            }
+        it("stratus_reset / hardhat_reset", async () => {
+            (await sendExpect("stratus_reset")).eq(true);
+            (await sendExpect("hardhat_reset")).eq(true);
         });
     });
 

--- a/e2e/test/external/e2e-json-rpc.test.ts
+++ b/e2e/test/external/e2e-json-rpc.test.ts
@@ -34,10 +34,9 @@ describe("JSON-RPC", () => {
     });
 
     describe("State", () => {
-        it("debug_setHead", async () => {
-            if (isStratus) {
-                (await sendExpect("debug_setHead", [ZERO])).eq(ZERO);
-            }
+        it("stratus_reset", async () => {
+            (await sendExpect("stratus_reset")).eq(true);
+            (await sendExpect("hardhat_reset")).eq(true);
         });
     });
 

--- a/e2e/test/helpers/rpc.ts
+++ b/e2e/test/helpers/rpc.ts
@@ -223,11 +223,7 @@ export async function sendRawTransactions(signedTxs: string[]): Promise<string[]
 
 /// Resets the blockchain state to the specified block number.
 export async function sendReset(): Promise<void> {
-    if (isStratus) {
-        await send("debug_setHead", [toHex(0)]);
-    } else {
-        await send("hardhat_reset");
-    }
+    await send("hardhat_reset");
 }
 
 /// Retrieves the current nonce of an account.

--- a/src/eth/rpc/rpc_server.rs
+++ b/src/eth/rpc/rpc_server.rs
@@ -29,8 +29,6 @@ use crate::eth::executor::Executor;
 use crate::eth::miner::Miner;
 use crate::eth::primitives::Address;
 use crate::eth::primitives::BlockFilter;
-#[cfg(feature = "dev")]
-use crate::eth::primitives::BlockNumber;
 use crate::eth::primitives::Bytes;
 use crate::eth::primitives::CallInput;
 use crate::eth::primitives::ChainId;
@@ -147,12 +145,13 @@ pub async fn serve_rpc(
 }
 
 fn register_methods(mut module: RpcModule<RpcContext>) -> anyhow::Result<RpcModule<RpcContext>> {
-    // debug
+    // dev mode methods
     #[cfg(feature = "dev")]
     {
         module.register_blocking_method("evm_setNextBlockTimestamp", evm_set_next_block_timestamp)?;
         module.register_blocking_method("evm_mine", evm_mine)?;
-        module.register_blocking_method("debug_setHead", debug_set_head)?;
+        module.register_blocking_method("hardhat_reset", stratus_reset)?;
+        module.register_blocking_method("stratus_reset", stratus_reset)?;
     }
 
     // stratus status
@@ -217,13 +216,6 @@ fn register_methods(mut module: RpcModule<RpcContext>) -> anyhow::Result<RpcModu
 // -----------------------------------------------------------------------------
 
 #[cfg(feature = "dev")]
-fn debug_set_head(params: Params<'_>, ctx: Arc<RpcContext>, _: Extensions) -> Result<JsonValue, StratusError> {
-    let (_, number) = next_rpc_param::<BlockNumber>(params.sequence())?;
-    ctx.storage.reset(number)?;
-    Ok(to_json_value(number))
-}
-
-#[cfg(feature = "dev")]
 fn evm_mine(_params: Params<'_>, ctx: Arc<RpcContext>, _: Extensions) -> Result<JsonValue, StratusError> {
     ctx.miner.mine_local_and_commit()?;
     Ok(to_json_value(true))
@@ -247,9 +239,6 @@ fn evm_set_next_block_timestamp(params: Params<'_>, ctx: Arc<RpcContext>, _: Ext
 // Status - Health checks
 // -----------------------------------------------------------------------------
 
-/// If stratus is ready and able to receive traffic.
-///
-/// This is an `AND` of `readiness` with `liveness`.
 async fn stratus_health(_params: Params<'_>, context: Arc<RpcContext>, _extensions: Extensions) -> Result<JsonValue, StratusError> {
     if GlobalState::is_shutdown() {
         tracing::warn!("liveness check failed because of shutdown");
@@ -270,6 +259,12 @@ async fn stratus_health(_params: Params<'_>, context: Arc<RpcContext>, _extensio
 // -----------------------------------------------------------------------------
 // Stratus - Admin
 // -----------------------------------------------------------------------------
+
+#[cfg(feature = "dev")]
+fn stratus_reset(_: Params<'_>, ctx: Arc<RpcContext>, _: Extensions) -> Result<JsonValue, StratusError> {
+    ctx.storage.reset()?;
+    Ok(to_json_value(true))
+}
 
 fn stratus_enable_unknown_clients(_: Params<'_>, _: &RpcContext, _: &Extensions) -> bool {
     GlobalState::set_unknown_client_enabled(true);

--- a/src/eth/storage/inmemory/inmemory_permanent.rs
+++ b/src/eth/storage/inmemory/inmemory_permanent.rs
@@ -279,7 +279,8 @@ impl PermanentStorage for InMemoryPermanentStorage {
         Ok(())
     }
 
-    fn reset_at(&self, block_number: BlockNumber) -> anyhow::Result<()> {
+    #[cfg(feature = "dev")]
+    fn reset(&self, block_number: BlockNumber) -> anyhow::Result<()> {
         // reset block number
         let block_number_u64: u64 = block_number.into();
         let _ = self.block_number.fetch_update(Ordering::SeqCst, Ordering::SeqCst, |current| {

--- a/src/eth/storage/permanent_storage.rs
+++ b/src/eth/storage/permanent_storage.rs
@@ -65,8 +65,9 @@ pub trait PermanentStorage: Send + Sync + 'static {
     // Global state
     // -------------------------------------------------------------------------
 
+    #[cfg(feature = "dev")]
     /// Resets all state to a specific block number.
-    fn reset_at(&self, number: BlockNumber) -> anyhow::Result<()>;
+    fn reset(&self, number: BlockNumber) -> anyhow::Result<()>;
 }
 
 // -----------------------------------------------------------------------------

--- a/src/eth/storage/redis/redis_permanent.rs
+++ b/src/eth/storage/redis/redis_permanent.rs
@@ -227,7 +227,8 @@ impl PermanentStorage for RedisPermanentStorage {
         }
     }
 
-    fn reset_at(&self, number: BlockNumber) -> anyhow::Result<()> {
+    #[cfg(feature = "dev")]
+    fn reset(&self, number: BlockNumber) -> anyhow::Result<()> {
         let mut conn = self.conn()?;
         let flush: RedisMutationResult = redis::cmd("FLUSHDB").exec(&mut conn);
         match flush {

--- a/src/eth/storage/rocks/rocks_permanent.rs
+++ b/src/eth/storage/rocks/rocks_permanent.rs
@@ -116,7 +116,8 @@ impl PermanentStorage for RocksPermanentStorage {
         self.state.save_accounts(accounts)
     }
 
-    fn reset_at(&self, block_number: BlockNumber) -> anyhow::Result<()> {
+    #[cfg(feature = "dev")]
+    fn reset(&self, block_number: BlockNumber) -> anyhow::Result<()> {
         let block_number_u64 = block_number.as_u64();
 
         // reset block number

--- a/src/eth/storage/stratus_storage.rs
+++ b/src/eth/storage/stratus_storage.rs
@@ -476,13 +476,14 @@ impl StratusStorage {
     // General state
     // -------------------------------------------------------------------------
 
-    pub fn reset(&self, number: BlockNumber) -> Result<(), StratusError> {
+    #[cfg(feature = "dev")]
+    pub fn reset(&self) -> Result<(), StratusError> {
         #[cfg(feature = "tracing")]
         let _span = tracing::info_span!("storage::reset").entered();
 
         // reset perm
         tracing::debug!(storage = %label::PERM, "reseting storage");
-        timed(|| self.perm.reset_at(number)).with(|m| {
+        timed(|| self.perm.reset(BlockNumber::ZERO)).with(|m| {
             metrics::inc_storage_reset(m.elapsed, label::PERM, m.result.is_ok());
             if let Err(ref e) = m.result {
                 tracing::error!(reason = ?e, "failed to reset permanent storage");


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Replaced `debug_setHead` with `stratus_reset` and `hardhat_reset` in the RPC server.
- Renamed `reset_at` to `reset` in various storage implementations and added `#[cfg(feature = "dev")]` attribute.
- Updated end-to-end tests to use `stratus_reset` instead of `debug_setHead`.
- Simplified `sendReset` function by removing conditional check for `isStratus`.
- Updated patch files to replace `debug_setHead` with `stratus_reset`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>rpc_server.rs</strong><dd><code>Replace debug_setHead with stratus_reset and hardhat_reset</code></dd></summary>
<hr>

src/eth/rpc/rpc_server.rs

<li>Replaced <code>debug_setHead</code> with <code>stratus_reset</code> and <code>hardhat_reset</code><br> <li> Removed <code>debug_set_head</code> function<br> <li> Added <code>stratus_reset</code> function<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1560/files#diff-835ba255c9a5c1fe0e13285bc39e058e1c74422e5e03ebba483c9d8a15c45405">+9/-14</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>inmemory_permanent.rs</strong><dd><code>Rename reset_at to reset with dev feature flag</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/inmemory/inmemory_permanent.rs

<li>Renamed <code>reset_at</code> to <code>reset</code><br> <li> Added <code>#[cfg(feature = "dev")]</code> attribute to <code>reset</code> function<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1560/files#diff-6cc83da72398cf1ba410cb7dd95e4e8f232f5db52c81bc92de5261dfe6d8e429">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>permanent_storage.rs</strong><dd><code>Rename reset_at to reset with dev feature flag</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/permanent_storage.rs

<li>Renamed <code>reset_at</code> to <code>reset</code><br> <li> Added <code>#[cfg(feature = "dev")]</code> attribute to <code>reset</code> function<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1560/files#diff-7b27a17201e5a4916214bb7bebbeaba2874cce309edd6f628018abe45f88a1c5">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>redis_permanent.rs</strong><dd><code>Rename reset_at to reset with dev feature flag</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/redis/redis_permanent.rs

<li>Renamed <code>reset_at</code> to <code>reset</code><br> <li> Added <code>#[cfg(feature = "dev")]</code> attribute to <code>reset</code> function<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1560/files#diff-068ece78c4a374a891db1f4759a7a035df7aa981bf04c3bffecfd44e94f5841b">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rocks_permanent.rs</strong><dd><code>Rename reset_at to reset with dev feature flag</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/rocks/rocks_permanent.rs

<li>Renamed <code>reset_at</code> to <code>reset</code><br> <li> Added <code>#[cfg(feature = "dev")]</code> attribute to <code>reset</code> function<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1560/files#diff-c129c50a85915e0c5154c4e048a4577bd45ce6ae9ec98e95acbcad09ff79b3c6">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>stratus_storage.rs</strong><dd><code>Update reset function to remove block number parameter</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/stratus_storage.rs

<li>Renamed <code>reset</code> function to remove block number parameter<br> <li> Added <code>#[cfg(feature = "dev")]</code> attribute to <code>reset</code> function<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1560/files#diff-3b2e36e47959decdfe26b2c4fab90b41f9242bfdad29cc43b2377ee851f4f40a">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rpc.ts</strong><dd><code>Simplify sendReset function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

e2e/test/helpers/rpc.ts

- Removed conditional check for `isStratus` in `sendReset` function



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1560/files#diff-de92f3345fb0b828a3a1af4938646038808ddee426127f029255c9c10bdaa1bb">+1/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>brlc-yield-streamer.patch</strong><dd><code>Replace debug_setHead with stratus_reset in patch</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

e2e/cloudwalk-contracts/patches/brlc-yield-streamer.patch

- Replaced `debug_setHead` with `stratus_reset` in patch



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1560/files#diff-122b8990fd27076ff31c06b43ae80167e5704a88ac6cb6ddc3bd41f86b97c84f">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>e2e-json-rpc.test.ts</strong><dd><code>Replace debug_setHead with stratus_reset in tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

e2e/test/automine/e2e-json-rpc.test.ts

- Replaced `debug_setHead` with `stratus_reset` in tests



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1560/files#diff-3d74b20bca5732bd9d71f766b668d339a52e53e6b7fd18ff8f9000c077184439">+3/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>e2e-json-rpc.test.ts</strong><dd><code>Replace debug_setHead with stratus_reset in tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

e2e/test/external/e2e-json-rpc.test.ts

- Replaced `debug_setHead` with `stratus_reset` in tests



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1560/files#diff-f5d1f06c4777826f9cbdcb4372d15c42f354177c83df65f3324cfd607da16004">+3/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

