### PR TITLE
enha: redis eth_getLogs

### DIFF
--- a/src/eth/storage/permanent_storage.rs
+++ b/src/eth/storage/permanent_storage.rs
@@ -46,6 +46,8 @@ pub trait PermanentStorage: Send + Sync + 'static {
     fn read_transaction(&self, hash: &Hash) -> anyhow::Result<Option<TransactionMined>>;
 
     /// Retrieves logs from the storage.
+    ///
+    /// TODO: `filter.to_block` is always populated, need to change the type to reflect that.
     fn read_logs(&self, filter: &LogFilter) -> anyhow::Result<Vec<LogMined>>;
 
     // -------------------------------------------------------------------------

--- a/src/eth/storage/redis/redis_permanent.rs
+++ b/src/eth/storage/redis/redis_permanent.rs
@@ -178,12 +178,12 @@ impl PermanentStorage for RedisPermanentStorage {
 
         // exit if no keys
         if block_keys.is_empty() {
-            return Ok(vec![])
+            return Ok(vec![]);
         }
 
         // execute command
         let mut conn = self.conn()?;
-        let blocks: RedisVecOptString =  conn.mget(block_keys);
+        let blocks: RedisVecOptString = conn.mget(block_keys);
 
         // parse
         let blocks: Vec<Block> = match blocks {


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Added a TODO comment in `src/eth/storage/permanent_storage.rs` to update the `filter.to_block` type in the `read_logs` method.
- Refactored type aliases for Redis result types in `src/eth/storage/redis/redis_permanent.rs` for better clarity.
- Updated various methods in `RedisPermanentStorage` to use the new type aliases.
- Implemented the `read_logs` method in `RedisPermanentStorage` to retrieve and filter logs from Redis.
- Refactored key generation functions for blocks, accounts, slots, and transactions for better readability and consistency.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>permanent_storage.rs</strong><dd><code>Add TODO comment for `filter.to_block` type update in `read_logs`</code></dd></summary>
<hr>

src/eth/storage/permanent_storage.rs

<li>Added a TODO comment to update the <code>filter.to_block</code> type in <code>read_logs</code> <br>method.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1563/files#diff-7b27a17201e5a4916214bb7bebbeaba2874cce309edd6f628018abe45f88a1c5">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>redis_permanent.rs</strong><dd><code>Refactor Redis storage and implement `read_logs` method</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/redis/redis_permanent.rs

<li>Renamed type aliases for Redis result types for better clarity.<br> <li> Updated methods to use new type aliases.<br> <li> Implemented the <code>read_logs</code> method to retrieve and filter logs from <br>Redis.<br> <li> Refactored key generation functions for better readability and <br>consistency.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1563/files#diff-068ece78c4a374a891db1f4759a7a035df7aa981bf04c3bffecfd44e94f5841b">+82/-32</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

