### PR TITLE
enha: redis historical values

### DIFF
--- a/src/eth/storage/redis/redis_permanent.rs
+++ b/src/eth/storage/redis/redis_permanent.rs
@@ -328,7 +328,7 @@ impl PermanentStorage for RedisPermanentStorage {
                 match redis_account {
                     Ok(vec_json) => match vec_json.first() {
                         Some(json) => Ok(Some(from_json_str(json))),
-                        None => Ok(None)
+                        None => Ok(None),
                     },
                     Err(e) => log_and_err!(reason = e, "failed to read account from redis historical value"),
                 }


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added support for saving and retrieving historical values for accounts and slots in Redis storage.
- Introduced new functions `key_account_history` and `key_slot_history` for generating keys to access historical data.
- Modified the `save_block` function to use `zadd` for storing historical data in Redis.
- Enhanced the `read_account` and `read_slot` functions to handle historical data retrieval based on the `StoragePointInTime` parameter.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>redis_permanent.rs</strong><dd><code>Add support for historical values in Redis storage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/redis/redis_permanent.rs

<li>Added support for saving and retrieving historical values for accounts <br>and slots.<br> <li> Introduced new functions <code>key_account_history</code> and <code>key_slot_history</code> for <br>generating history keys.<br> <li> Modified <code>save_block</code> to use <code>zadd</code> for storing historical data.<br> <li> Enhanced <code>read_account</code> and <code>read_slot</code> to handle historical data <br>retrieval.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1564/files#diff-068ece78c4a374a891db1f4759a7a035df7aa981bf04c3bffecfd44e94f5841b">+106/-27</a></td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

