### PR TITLE
enha: more serde tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1467,6 +1467,7 @@ version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c25829bde82205da46e1823b2259db6273379f626fc211f126f65654a2669be"
 dependencies = [
+ "chrono",
  "deunicode",
  "dummy",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,7 @@ testcontainers = "=0.15.0"
 testcontainers-modules = { version = "=0.3.5", features = ["postgres"] }
 
 # test
-fake = { version = "=2.9.2", features = ["derive"] }
+fake = { version = "=2.9.2", features = ["chrono", "derive"] }
 
 # ------------------------------------------------------------------------------
 # Platform specific dependencies

--- a/src/eth/primitives/call_input.rs
+++ b/src/eth/primitives/call_input.rs
@@ -2,14 +2,17 @@ use crate::eth::primitives::Address;
 use crate::eth::primitives::Bytes;
 use crate::eth::primitives::Wei;
 
-#[derive(Debug, Clone, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, fake::Dummy, serde::Serialize, serde::Deserialize)]
 pub struct CallInput {
+    #[serde(rename = "from")]
     pub from: Option<Address>,
+
+    #[serde(rename = "to")]
     pub to: Option<Address>,
 
-    #[serde(default)]
+    #[serde(rename = "value", default)]
     pub value: Wei,
 
-    #[serde(alias = "input", default)]
+    #[serde(rename = "data", alias = "input", default)]
     pub data: Bytes,
 }

--- a/src/eth/primitives/ecdsa_rs.rs
+++ b/src/eth/primitives/ecdsa_rs.rs
@@ -1,10 +1,12 @@
+use display_json::DebugAsJson;
 use ethereum_types::U256;
+use fake::Dummy;
+use fake::Faker;
 
 use crate::gen_newtype_from;
 
-// Type representing `r` and `s` variables
-// from the ECDSA signature
-#[derive(Clone, Copy)]
+// Type representing `r` and `s` variables from the ECDSA signature.
+#[derive(DebugAsJson, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct EcdsaRs(U256);
 
 impl From<EcdsaRs> for U256 {
@@ -13,7 +15,13 @@ impl From<EcdsaRs> for U256 {
     }
 }
 
+impl Dummy<Faker> for EcdsaRs {
+    fn dummy_with_rng<R: rand::prelude::Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+        Self(U256([rng.next_u64(), rng.next_u64(), rng.next_u64(), rng.next_u64()]))
+    }
+}
+
 // -----------------------------------------------------------------------------
 // Conversions: Self -> Other
 // -----------------------------------------------------------------------------
-gen_newtype_from!(self = EcdsaRs, other = i64, [u8; 32]);
+gen_newtype_from!(self = EcdsaRs, other = u8, u16, u32, u64, u128, U256, i8, i16, i32, i64, i128, [u8; 32]);

--- a/src/eth/primitives/ecdsa_v.rs
+++ b/src/eth/primitives/ecdsa_v.rs
@@ -1,10 +1,12 @@
+use display_json::DebugAsJson;
 use ethereum_types::U64;
+use fake::Dummy;
+use fake::Faker;
 
 use crate::gen_newtype_from;
 
-// Type representing `v` variable
-// from the ECDSA signature
-#[derive(Clone, Copy)]
+// Type representing `v` variable from the ECDSA signature.
+#[derive(DebugAsJson, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct EcdsaV(U64);
 
 impl From<EcdsaV> for U64 {
@@ -13,7 +15,13 @@ impl From<EcdsaV> for U64 {
     }
 }
 
+impl Dummy<Faker> for EcdsaV {
+    fn dummy_with_rng<R: rand::prelude::Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+        Self::from(rng.next_u64())
+    }
+}
+
 // -----------------------------------------------------------------------------
 // Conversions: Self -> Other
 // -----------------------------------------------------------------------------
-gen_newtype_from!(self = EcdsaV, other = i32, [u8; 8]);
+gen_newtype_from!(self = EcdsaV, other = u8, u16, u32, u64, U64, i8, i16, i32, [u8; 8]);

--- a/src/eth/primitives/execution_metrics.rs
+++ b/src/eth/primitives/execution_metrics.rs
@@ -1,6 +1,6 @@
 use display_json::DebugAsJson;
 
-#[derive(DebugAsJson, Clone, Copy, Default, derive_more::Add, derive_more::AddAssign, serde::Serialize)]
+#[derive(DebugAsJson, Clone, Copy, Default, PartialEq, Eq, derive_more::Add, derive_more::AddAssign, fake::Dummy, serde::Serialize, serde::Deserialize)]
 pub struct EvmExecutionMetrics {
     /// Number of account reads during EVM execution.
     pub account_reads: usize,

--- a/src/eth/primitives/mod.rs
+++ b/src/eth/primitives/mod.rs
@@ -120,11 +120,6 @@ mod tests {
     // FIX: gen_test_serde!(ExecutionChanges);
     // FIX: gen_test_serde!(TransactionMined);
     // TODO: gen_test_serde!(BlockFilter);
-    // TODO: gen_test_serde!(CallInput);
-    // TODO: gen_test_serde!(DateTimeNow);
-    // TODO: gen_test_serde!(EcdsaRs);
-    // TODO: gen_test_serde!(EcdsaV);
-    // TODO: gen_test_serde!(EvmExecutionMetrics);
     // TODO: gen_test_serde!(ExecutionConflict);
     // TODO: gen_test_serde!(ExecutionConflicts);
     // TODO: gen_test_serde!(ExecutionConflictsBuilder);
@@ -141,15 +136,19 @@ mod tests {
     // TODO: gen_test_serde!(StratusError);
     // TODO: gen_test_serde!(TransactionExecution);
     // TODO: gen_test_serde!(TransactionStage);
-    // Type aliases
     gen_test_serde!(Account);
     gen_test_serde!(Address);
     gen_test_serde!(BlockHeader);
     gen_test_serde!(BlockNumber);
     gen_test_serde!(Bytes);
+    gen_test_serde!(CallInput);
     gen_test_serde!(ChainId);
     gen_test_serde!(CodeHash);
+    gen_test_serde!(DateTimeNow);
     gen_test_serde!(Difficulty);
+    gen_test_serde!(EcdsaRs);
+    gen_test_serde!(EcdsaV);
+    gen_test_serde!(EvmExecutionMetrics);
     gen_test_serde!(ExecutionResult);
     gen_test_serde!(Gas);
     gen_test_serde!(Hash);

--- a/src/eth/primitives/now.rs
+++ b/src/eth/primitives/now.rs
@@ -1,8 +1,9 @@
 use chrono::DateTime;
 use chrono::Utc;
+use display_json::DebugAsJson;
 
 /// DateTime that automatically sets the current time when created.
-#[derive(Debug, Clone, derive_more::Deref, serde::Serialize)]
+#[derive(DebugAsJson, Clone, PartialEq, Eq, derive_more::Deref, fake::Dummy, serde::Serialize, serde::Deserialize)]
 pub struct DateTimeNow(#[deref] DateTime<Utc>);
 
 impl Default for DateTimeNow {


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Enhanced multiple structs (`CallInput`, `EcdsaRs`, `EcdsaV`, `EvmExecutionMetrics`, `DateTimeNow`) with additional derives including `PartialEq`, `Eq`, `fake::Dummy`, and `serde::Serialize`/`Deserialize`.
- Implemented `Dummy<Faker>` for `EcdsaRs` and `EcdsaV`.
- Added `gen_test_serde!` macros for several structs to generate serde tests.
- Updated `fake` dependency in `Cargo.toml` to include the `chrono` feature.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>call_input.rs</strong><dd><code>Enhance <code>CallInput</code> struct with additional derives and serde attributes</code></dd></summary>
<hr>

src/eth/primitives/call_input.rs

<li>Added <code>PartialEq</code>, <code>Eq</code>, <code>fake::Dummy</code>, and <code>serde::Serialize</code> derives to <br><code>CallInput</code>.<br> <li> Renamed fields using <code>serde</code> attributes.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1568/files#diff-8ff69cf5f70258699ae5a6906ec7c35c251f8c64e56bbfd8b2f35b1727dca054">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ecdsa_rs.rs</strong><dd><code>Enhance <code>EcdsaRs</code> struct with additional derives and dummy <br>implementation</code></dd></summary>
<hr>

src/eth/primitives/ecdsa_rs.rs

<li>Added <code>DebugAsJson</code>, <code>PartialEq</code>, <code>Eq</code>, <code>serde::Serialize</code>, and <br><code>serde::Deserialize</code> derives to <code>EcdsaRs</code>.<br> <li> Implemented <code>Dummy<Faker></code> for <code>EcdsaRs</code>.<br> <li> Extended <code>gen_newtype_from</code> macro for additional types.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1568/files#diff-9650b02ee217885e024a96cd439d0d466735379fb227bc55a649564690b72029">+12/-4</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ecdsa_v.rs</strong><dd><code>Enhance <code>EcdsaV</code> struct with additional derives and dummy implementation</code></dd></summary>
<hr>

src/eth/primitives/ecdsa_v.rs

<li>Added <code>DebugAsJson</code>, <code>PartialEq</code>, <code>Eq</code>, <code>serde::Serialize</code>, and <br><code>serde::Deserialize</code> derives to <code>EcdsaV</code>.<br> <li> Implemented <code>Dummy<Faker></code> for <code>EcdsaV</code>.<br> <li> Extended <code>gen_newtype_from</code> macro for additional types.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1568/files#diff-1fea1d0ab1829f175a2441e36ce0e80496bf7ff530573d59d4b235394cdb379d">+12/-4</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>execution_metrics.rs</strong><dd><code>Enhance `EvmExecutionMetrics` struct with additional derives</code></dd></summary>
<hr>

src/eth/primitives/execution_metrics.rs

<li>Added <code>PartialEq</code>, <code>Eq</code>, <code>fake::Dummy</code>, and <code>serde::Deserialize</code> derives to <br><code>EvmExecutionMetrics</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1568/files#diff-442f0bb63f7b99b40e2c8f59912e9e86dcb80761ace9bc89488cc692199a075d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>now.rs</strong><dd><code>Enhance `DateTimeNow` struct with additional derives</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/now.rs

<li>Added <code>DebugAsJson</code>, <code>PartialEq</code>, <code>Eq</code>, <code>fake::Dummy</code>, and <code>serde::Deserialize</code> <br>derives to <code>DateTimeNow</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1568/files#diff-f3a5f45a8bd7dd4cbb821ded664f2253e7fd976b2d983c6c13df3cf76dd491e7">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Add serde test generation for multiple structs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/mod.rs

- Added `gen_test_serde!` macros for multiple structs.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1568/files#diff-0519ffc32191c9229d8b7672cd29638b49891c486a10d62379772dce98f1947c">+5/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Update `fake` dependency to include `chrono` feature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Cargo.toml

- Added `chrono` feature to `fake` dependency.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1568/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

