### PR TITLE
fix: test: e2e-external test not awating evm_mine

### DIFF
--- a/e2e/test/external/e2e-json-rpc.test.ts
+++ b/e2e/test/external/e2e-json-rpc.test.ts
@@ -262,7 +262,7 @@ describe("JSON-RPC", () => {
             it("Returns an expected result when a contract transaction fails", async () => {
                 // deploy
                 const contract = await deployTestContractBalances();
-                sendEvmMine();
+                await sendEvmMine();
                 contract.waitForDeployment();
 
                 // send a transaction that will fail
@@ -274,7 +274,7 @@ describe("JSON-RPC", () => {
                 });
                 const expectedTxHash = keccak256(signedTx);
                 const actualTxHash = await sendRawTransaction(signedTx);
-                sendEvmMine();
+                await sendEvmMine();
 
                 // validate
                 const txReceiptAfterMining = await ETHERJS.getTransactionReceipt(expectedTxHash);


### PR DESCRIPTION
### **PR Type**
Bug fix, Tests


___

### **Description**
- Added `await` to `sendEvmMine` calls in `eth_sendRawTransaction` test to ensure proper asynchronous handling.
- Fixed potential timing issues in the `eth_sendRawTransaction` test by awaiting `sendEvmMine`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>e2e-json-rpc.test.ts</strong><dd><code>Ensure asynchronous handling in JSON-RPC e2e tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

e2e/test/external/e2e-json-rpc.test.ts

<li>Added <code>await</code> to <code>sendEvmMine</code> calls to ensure proper asynchronous <br>handling.<br> <li> Fixed potential timing issues in <code>eth_sendRawTransaction</code> test.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1569/files#diff-f5d1f06c4777826f9cbdcb4372d15c42f354177c83df65f3324cfd607da16004">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

