### PR TITLE
enha: ensure all primitives implement DebugAsJson

### DIFF
--- a/src/eth/primitives/address.rs
+++ b/src/eth/primitives/address.rs
@@ -3,6 +3,7 @@ use std::ops::Deref;
 use std::str::FromStr;
 
 use anyhow::anyhow;
+use display_json::DebugAsJson;
 use ethabi::Token;
 use ethereum_types::H160;
 use ethers_core::types::NameOrAddress;
@@ -20,7 +21,7 @@ use crate::alias::RevmAddress;
 use crate::gen_newtype_from;
 
 /// Address of an Ethereum account (wallet or contract).
-#[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Hash, serde::Serialize, serde::Deserialize)]
+#[derive(DebugAsJson, Clone, Copy, Default, Eq, PartialEq, Hash, serde::Serialize, serde::Deserialize)]
 pub struct Address(pub H160);
 
 impl Address {

--- a/src/eth/primitives/block_header.rs
+++ b/src/eth/primitives/block_header.rs
@@ -1,3 +1,4 @@
+use display_json::DebugAsJson;
 use ethereum_types::H160;
 use ethereum_types::H256;
 use ethereum_types::H64;
@@ -32,7 +33,7 @@ const HASH_EMPTY_UNCLES: Hash = Hash::new(hex!("1dcc4de8dec75d7aab85b567b6ccd41a
 /// Special hash used in block mining to indicate no transaction root and no receipts root.
 const HASH_EMPTY_TRIE: Hash = Hash::new(hex!("56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"));
 
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(DebugAsJson, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct BlockHeader {
     pub number: BlockNumber,
     pub hash: Hash,

--- a/src/eth/primitives/block_number.rs
+++ b/src/eth/primitives/block_number.rs
@@ -4,6 +4,7 @@ use std::ops::AddAssign;
 use std::str::FromStr;
 
 use anyhow::anyhow;
+use display_json::DebugAsJson;
 use ethereum_types::U64;
 use ethers_core::utils::keccak256;
 use fake::Dummy;
@@ -20,7 +21,7 @@ use crate::eth::primitives::Hash;
 use crate::gen_newtype_from;
 
 #[derive(
-    Debug,
+    DebugAsJson,
     derive_more::Display,
     Clone,
     Copy,

--- a/src/eth/primitives/bytes.rs
+++ b/src/eth/primitives/bytes.rs
@@ -1,8 +1,8 @@
-use std::fmt::Debug;
 use std::fmt::Display;
 use std::ops::Deref;
 use std::ops::DerefMut;
 
+use display_json::DebugAsJson;
 use revm::interpreter::analysis::to_analysed;
 
 use crate::alias::EthersBytes;
@@ -11,7 +11,7 @@ use crate::alias::RevmBytes;
 use crate::alias::RevmOutput;
 use crate::gen_newtype_from;
 
-#[derive(Clone, Default, Eq, PartialEq, fake::Dummy)]
+#[derive(DebugAsJson, Clone, Default, Eq, PartialEq, fake::Dummy)]
 pub struct Bytes(pub Vec<u8>);
 
 impl Display for Bytes {
@@ -21,12 +21,6 @@ impl Display for Bytes {
         } else {
             write!(f, "too long")
         }
-    }
-}
-
-impl Debug for Bytes {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_tuple("Bytes").field(&self.to_string()).finish()
     }
 }
 

--- a/src/eth/primitives/call_input.rs
+++ b/src/eth/primitives/call_input.rs
@@ -1,8 +1,10 @@
+use display_json::DebugAsJson;
+
 use crate::eth::primitives::Address;
 use crate::eth::primitives::Bytes;
 use crate::eth::primitives::Wei;
 
-#[derive(Debug, Clone, PartialEq, Eq, fake::Dummy, serde::Serialize, serde::Deserialize)]
+#[derive(DebugAsJson, Clone, PartialEq, Eq, fake::Dummy, serde::Serialize, serde::Deserialize)]
 pub struct CallInput {
     #[serde(rename = "from")]
     pub from: Option<Address>,

--- a/src/eth/primitives/chain_id.rs
+++ b/src/eth/primitives/chain_id.rs
@@ -1,4 +1,5 @@
 use anyhow::anyhow;
+use display_json::DebugAsJson;
 use ethereum_types::U256;
 use ethereum_types::U64;
 use fake::Dummy;
@@ -7,7 +8,7 @@ use fake::Faker;
 use crate::gen_newtype_from;
 use crate::gen_newtype_try_from;
 
-#[derive(Debug, derive_more::Display, Clone, Copy, Default, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(DebugAsJson, derive_more::Display, Clone, Copy, Default, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct ChainId(pub U64);
 
 impl ChainId {

--- a/src/eth/primitives/code_hash.rs
+++ b/src/eth/primitives/code_hash.rs
@@ -1,3 +1,4 @@
+use display_json::DebugAsJson;
 use ethereum_types::H256;
 use ethers_core::utils::keccak256;
 use fake::Dummy;
@@ -11,7 +12,7 @@ use crate::gen_newtype_from;
 /// Digest of the bytecode of a contract.
 /// In the case of an externally-owned account (EOA), bytecode is null
 /// and the code hash is fixed as the keccak256 hash of an empty string
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(DebugAsJson, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct CodeHash(pub H256);
 
 impl Dummy<Faker> for CodeHash {

--- a/src/eth/primitives/difficulty.rs
+++ b/src/eth/primitives/difficulty.rs
@@ -1,10 +1,11 @@
+use display_json::DebugAsJson;
 use ethereum_types::U256;
 use fake::Dummy;
 use fake::Faker;
 
 use crate::gen_newtype_from;
 
-#[derive(Debug, derive_more::Display, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(DebugAsJson, derive_more::Display, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(transparent)]
 pub struct Difficulty(U256);
 

--- a/src/eth/primitives/execution_result.rs
+++ b/src/eth/primitives/execution_result.rs
@@ -1,5 +1,7 @@
+use display_json::DebugAsJson;
+
 /// Indicates how a transaction execution was finished.
-#[derive(Debug, strum::Display, Clone, PartialEq, Eq, fake::Dummy, derive_new::new, serde::Serialize, serde::Deserialize, strum::EnumString)]
+#[derive(DebugAsJson, strum::Display, Clone, PartialEq, Eq, fake::Dummy, derive_new::new, serde::Serialize, serde::Deserialize, strum::EnumString)]
 #[serde(rename_all = "snake_case")]
 pub enum ExecutionResult {
     /// Finished normally (RETURN opcode).

--- a/src/eth/primitives/execution_value_change.rs
+++ b/src/eth/primitives/execution_value_change.rs
@@ -1,54 +1,35 @@
+// -----------------------------------------------------------------------------
+// Value Change
+// -----------------------------------------------------------------------------
+
+use std::fmt::Debug;
+
+use display_json::DebugAsJson;
+
+use crate::ext::to_json_string;
+
 /// Changes that happened to an account value during a transaction.
-#[derive(Debug, Clone, PartialEq, Eq, fake::Dummy, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, Eq, fake::Dummy, serde::Serialize, serde::Deserialize)]
 pub struct ExecutionValueChange<T>
 where
-    T: PartialEq,
+    T: PartialEq + serde::Serialize,
 {
     original: ValueState<T>,
     modified: ValueState<T>,
 }
 
-impl<T: PartialEq> Default for ExecutionValueChange<T> {
-    fn default() -> Self {
-        Self {
-            original: ValueState::NotSet,
-            modified: ValueState::NotSet,
-        }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, fake::Dummy, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum ValueState<T> {
-    Set(T),
-    NotSet,
-}
-
-impl<T> ValueState<T> {
-    pub fn is_set(&self) -> bool {
-        matches!(self, Self::Set(_))
-    }
-
-    pub fn take(self) -> Option<T> {
-        if let Self::Set(value) = self {
-            Some(value)
-        } else {
-            None
-        }
-    }
-
-    pub fn take_ref(&self) -> Option<&T> {
-        if let Self::Set(value) = self {
-            Some(value)
-        } else {
-            None
-        }
+impl<T> Debug for ExecutionValueChange<T>
+where
+    T: PartialEq + serde::Serialize,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&to_json_string(self))
     }
 }
 
 impl<T> ExecutionValueChange<T>
 where
-    T: PartialEq,
+    T: PartialEq + serde::Serialize,
 {
     /// Creates a new [`ExecutionValueChange`] only with original value.
     pub fn from_original(value: T) -> Self {
@@ -109,5 +90,38 @@ where
     /// Check if the value was modified.
     pub fn is_modified(&self) -> bool {
         self.modified.is_set() && (self.original != self.modified)
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Value State
+// -----------------------------------------------------------------------------
+
+#[derive(DebugAsJson, Clone, PartialEq, Eq, fake::Dummy, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ValueState<T> {
+    Set(T),
+    NotSet,
+}
+
+impl<T> ValueState<T> {
+    pub fn is_set(&self) -> bool {
+        matches!(self, Self::Set(_))
+    }
+
+    pub fn take(self) -> Option<T> {
+        if let Self::Set(value) = self {
+            Some(value)
+        } else {
+            None
+        }
+    }
+
+    pub fn take_ref(&self) -> Option<&T> {
+        if let Self::Set(value) = self {
+            Some(value)
+        } else {
+            None
+        }
     }
 }

--- a/src/eth/primitives/gas.rs
+++ b/src/eth/primitives/gas.rs
@@ -1,4 +1,5 @@
 use anyhow::anyhow;
+use display_json::DebugAsJson;
 use ethereum_types::U256;
 use ethereum_types::U64;
 use fake::Dummy;
@@ -7,7 +8,7 @@ use fake::Faker;
 use crate::gen_newtype_from;
 use crate::gen_newtype_try_from;
 
-#[derive(Debug, derive_more::Display, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(DebugAsJson, derive_more::Display, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(transparent)]
 pub struct Gas(U64);
 

--- a/src/eth/primitives/hash.rs
+++ b/src/eth/primitives/hash.rs
@@ -2,6 +2,7 @@ use std::fmt::Display;
 use std::str::FromStr;
 
 use anyhow::anyhow;
+use display_json::DebugAsJson;
 use ethereum_types::H256;
 use fake::Dummy;
 use fake::Faker;
@@ -11,7 +12,7 @@ use sqlx::postgres::PgHasArrayType;
 
 use crate::gen_newtype_from;
 
-#[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Hash, serde::Serialize, serde::Deserialize)]
+#[derive(DebugAsJson, Clone, Copy, Default, Eq, PartialEq, Hash, serde::Serialize, serde::Deserialize)]
 #[serde(transparent)]
 pub struct Hash(pub H256);
 

--- a/src/eth/primitives/index.rs
+++ b/src/eth/primitives/index.rs
@@ -1,5 +1,6 @@
 use std::num::TryFromIntError;
 
+use display_json::DebugAsJson;
 use ethereum_types::U256;
 use ethereum_types::U64;
 
@@ -8,7 +9,7 @@ use crate::gen_newtype_try_from;
 
 /// Represents a transaction index or log index.
 #[derive(
-    Debug, derive_more::Display, Clone, Copy, PartialEq, Eq, fake::Dummy, serde::Serialize, serde::Deserialize, derive_more::Add, Hash, PartialOrd, Ord,
+    DebugAsJson, derive_more::Display, Clone, Copy, PartialEq, Eq, fake::Dummy, serde::Serialize, serde::Deserialize, derive_more::Add, Hash, PartialOrd, Ord,
 )]
 pub struct Index(pub u64);
 

--- a/src/eth/primitives/log.rs
+++ b/src/eth/primitives/log.rs
@@ -1,3 +1,5 @@
+use display_json::DebugAsJson;
+
 use crate::alias::EthersLog;
 use crate::alias::RevmLog;
 use crate::eth::primitives::Address;
@@ -5,7 +7,7 @@ use crate::eth::primitives::Bytes;
 use crate::eth::primitives::LogTopic;
 
 /// Log is an event emitted by the EVM during contract execution.
-#[derive(Debug, Clone, Default, PartialEq, Eq, fake::Dummy, serde::Serialize, serde::Deserialize)]
+#[derive(DebugAsJson, Clone, Default, PartialEq, Eq, fake::Dummy, serde::Serialize, serde::Deserialize)]
 pub struct Log {
     /// Address that emitted the log.
     pub address: Address,

--- a/src/eth/primitives/log_mined.rs
+++ b/src/eth/primitives/log_mined.rs
@@ -1,3 +1,4 @@
+use display_json::DebugAsJson;
 use itertools::Itertools;
 use jsonrpsee::SubscriptionMessage;
 
@@ -12,7 +13,7 @@ use crate::eth::primitives::LogTopic;
 use crate::ext::to_json_value;
 
 /// Log that was emitted by the EVM and added to a block.
-#[derive(Debug, Clone, PartialEq, Eq, fake::Dummy, serde::Serialize, serde::Deserialize)]
+#[derive(DebugAsJson, Clone, PartialEq, Eq, fake::Dummy, serde::Serialize, serde::Deserialize)]
 pub struct LogMined {
     /// Original log emitted by the EVM.
     pub log: Log,

--- a/src/eth/primitives/log_topic.rs
+++ b/src/eth/primitives/log_topic.rs
@@ -1,5 +1,6 @@
 use std::fmt::Display;
 
+use display_json::DebugAsJson;
 use ethereum_types::H256;
 use fake::Dummy;
 use fake::Faker;
@@ -8,7 +9,7 @@ use crate::alias::RevmB256;
 use crate::gen_newtype_from;
 
 /// Topic is part of a [`Log`](super::Log) emitted by the EVM during contract execution.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize, Default, Hash)]
+#[derive(DebugAsJson, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize, Default, Hash)]
 pub struct LogTopic(pub H256);
 
 impl LogTopic {

--- a/src/eth/primitives/miner_nonce.rs
+++ b/src/eth/primitives/miner_nonce.rs
@@ -1,3 +1,4 @@
+use display_json::DebugAsJson;
 use ethereum_types::H64;
 use fake::Dummy;
 use fake::Faker;
@@ -5,7 +6,7 @@ use fake::Faker;
 use crate::gen_newtype_from;
 
 /// The nonce of an Ethereum block.
-#[derive(Debug, derive_more::Display, Clone, Copy, Default, Eq, PartialEq, Hash, serde::Serialize, serde::Deserialize)]
+#[derive(DebugAsJson, derive_more::Display, Clone, Copy, Default, Eq, PartialEq, Hash, serde::Serialize, serde::Deserialize)]
 pub struct MinerNonce(H64);
 
 impl MinerNonce {

--- a/src/eth/primitives/nonce.rs
+++ b/src/eth/primitives/nonce.rs
@@ -1,14 +1,7 @@
-//! Nonce Module
-//!
-//! Manages nonces in Ethereum, which are crucial for preventing transaction
-//! replay attacks. A nonce is a unique number assigned to each transaction sent
-//! by an account, ensuring each transaction is processed once. This module
-//! offers functionalities to create, manage, and convert nonces, maintaining
-//! the integrity and uniqueness of transactions in the network.
-
 use std::str::FromStr;
 
 use anyhow::anyhow;
+use display_json::DebugAsJson;
 use ethereum_types::U256;
 use ethereum_types::U64;
 use fake::Dummy;
@@ -17,7 +10,7 @@ use fake::Faker;
 use crate::gen_newtype_from;
 use crate::gen_newtype_try_from;
 
-#[derive(Debug, derive_more::Display, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(DebugAsJson, derive_more::Display, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct Nonce(U64);
 
 impl Nonce {

--- a/src/eth/primitives/size.rs
+++ b/src/eth/primitives/size.rs
@@ -1,4 +1,5 @@
 use anyhow::anyhow;
+use display_json::DebugAsJson;
 use ethereum_types::U256;
 use ethereum_types::U64;
 use fake::Dummy;
@@ -6,7 +7,7 @@ use fake::Faker;
 
 use crate::gen_newtype_from;
 
-#[derive(Debug, derive_more::Display, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(DebugAsJson, derive_more::Display, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(transparent)]
 pub struct Size(U64);
 

--- a/src/eth/primitives/slot_index.rs
+++ b/src/eth/primitives/slot_index.rs
@@ -1,8 +1,8 @@
-use std::fmt::Debug;
 use std::fmt::Display;
 use std::io::Read;
 use std::str::FromStr;
 
+use display_json::DebugAsJson;
 use ethereum_types::U256;
 use ethers_core::utils::keccak256;
 use fake::Dummy;
@@ -17,7 +17,7 @@ use sqlx::Decode;
 use crate::alias::RevmU256;
 use crate::gen_newtype_from;
 
-#[derive(Clone, Copy, Default, Hash, Eq, PartialEq, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]
+#[derive(DebugAsJson, Clone, Copy, Default, Hash, Eq, PartialEq, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]
 pub struct SlotIndex(U256);
 
 impl SlotIndex {
@@ -58,12 +58,6 @@ impl Dummy<Faker> for SlotIndex {
 impl Display for SlotIndex {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:#x}", self.0)
-    }
-}
-
-impl Debug for SlotIndex {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "SlotIndex({:#x})", self.0)
     }
 }
 

--- a/src/eth/primitives/slot_value.rs
+++ b/src/eth/primitives/slot_value.rs
@@ -1,6 +1,7 @@
 use std::fmt::Display;
 use std::str::FromStr;
 
+use display_json::DebugAsJson;
 use ethereum_types::U256;
 use fake::Dummy;
 use fake::Faker;
@@ -14,7 +15,7 @@ use sqlx::Decode;
 use crate::alias::RevmU256;
 use crate::gen_newtype_from;
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(DebugAsJson, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct SlotValue(U256);
 
 impl SlotValue {

--- a/src/eth/primitives/unix_time.rs
+++ b/src/eth/primitives/unix_time.rs
@@ -3,13 +3,14 @@ use std::ops::Deref;
 use std::str::FromStr;
 
 use chrono::Utc;
+use display_json::DebugAsJson;
 use ethereum_types::U256;
 use fake::Dummy;
 use fake::Faker;
 
 use crate::alias::RevmU256;
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(DebugAsJson, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct UnixTime(u64);
 
 impl UnixTime {

--- a/src/eth/primitives/wei.rs
+++ b/src/eth/primitives/wei.rs
@@ -1,5 +1,6 @@
 use std::str::FromStr;
 
+use display_json::DebugAsJson;
 use ethabi::Token;
 use ethereum_types::U256;
 use fake::Dummy;
@@ -17,7 +18,19 @@ use crate::gen_newtype_from;
 
 /// Native token amount in wei.
 #[derive(
-    Debug, derive_more::Display, Clone, Copy, Default, PartialOrd, Ord, PartialEq, Eq, derive_more::Add, derive_more::Sub, serde::Serialize, serde::Deserialize,
+    DebugAsJson,
+    derive_more::Display,
+    Clone,
+    Copy,
+    Default,
+    PartialOrd,
+    Ord,
+    PartialEq,
+    Eq,
+    derive_more::Add,
+    derive_more::Sub,
+    serde::Serialize,
+    serde::Deserialize,
 )]
 pub struct Wei(pub U256);
 

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -305,6 +305,14 @@ macro_rules! gen_test_serde {
     ($type:ty) => {
         paste::paste! {
             #[test]
+            pub fn [<serde_debug_json_ $type:snake>]() {
+                let original = <fake::Faker as fake::Fake>::fake::<$type>(&fake::Faker);
+                let encoded_json = serde_json::to_string(&original).unwrap();
+                let encoded_debug = format!("{:?}", original);
+                assert_eq!(encoded_json, encoded_debug);
+            }
+
+            #[test]
             pub fn [<serde_json_ $type:snake>]() {
                 // encode
                 let original = <fake::Faker as fake::Fake>::fake::<$type>(&fake::Faker);


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Implemented `DebugAsJson` for various Ethereum primitive structs and enums.
- Removed custom `Debug` implementations where applicable.
- Added `serde_debug_json` test macro to ensure JSON serialization matches `Debug` output.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>23 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>address.rs</strong><dd><code>Implement `DebugAsJson` for `Address` struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/address.rs

- Added `DebugAsJson` derive to `Address` struct.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1570/files#diff-43c180e22a2858040d18def981f15acd2fbe7f76fe1b59b76121e9aceeead96d">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>block_header.rs</strong><dd><code>Implement `DebugAsJson` for `BlockHeader` struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/block_header.rs

- Added `DebugAsJson` derive to `BlockHeader` struct.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1570/files#diff-b8e75472f4443e9f0d8349bcf88f50a0210d72cd86abcacccc8aa89919e746d9">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>block_number.rs</strong><dd><code>Implement `DebugAsJson` for `BlockNumber` struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/block_number.rs

- Added `DebugAsJson` derive to `BlockNumber` struct.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1570/files#diff-23597a90086820357b399bf33f2db790baaf7f0d4617a74a134c4d200022bb93">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>bytes.rs</strong><dd><code>Implement `DebugAsJson` for `Bytes` struct and remove custom `Debug`</code></dd></summary>
<hr>

src/eth/primitives/bytes.rs

<li>Added <code>DebugAsJson</code> derive to <code>Bytes</code> struct.<br> <li> Removed custom <code>Debug</code> implementation for <code>Bytes</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1570/files#diff-e2007d1ed9fa6978ef516d7b6abeb65ef67f8e856ad26f0efb9e9a1b46840677">+2/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>call_input.rs</strong><dd><code>Implement `DebugAsJson` for `CallInput` struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/call_input.rs

- Added `DebugAsJson` derive to `CallInput` struct.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1570/files#diff-8ff69cf5f70258699ae5a6906ec7c35c251f8c64e56bbfd8b2f35b1727dca054">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>chain_id.rs</strong><dd><code>Implement `DebugAsJson` for `ChainId` struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/chain_id.rs

- Added `DebugAsJson` derive to `ChainId` struct.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1570/files#diff-978961769008df4bebfd5a1b182a3393a14662062aca34cf09846d1109dcc0ec">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>code_hash.rs</strong><dd><code>Implement `DebugAsJson` for `CodeHash` struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/code_hash.rs

- Added `DebugAsJson` derive to `CodeHash` struct.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1570/files#diff-588f5e271548cdb222c974e0c5b540e707b96f69ce5f3d7bd36b9e0572f692d8">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>difficulty.rs</strong><dd><code>Implement `DebugAsJson` for `Difficulty` struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/difficulty.rs

- Added `DebugAsJson` derive to `Difficulty` struct.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1570/files#diff-bf668748ee9655e1e726e81ab88afd96cc99bc4308818d2107e2b32424926ae2">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>execution_result.rs</strong><dd><code>Implement `DebugAsJson` for `ExecutionResult` enum</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/execution_result.rs

- Added `DebugAsJson` derive to `ExecutionResult` enum.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1570/files#diff-cdbf6e0857a8660a5a50a197f56ce8fb93d7d8d748b5feb81c5b32dc31e848e0">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>execution_value_change.rs</strong><dd><code>Implement <code>DebugAsJson</code> for <code>ValueState</code> and <code>Debug</code> for <br><code>ExecutionValueChange</code></code></dd></summary>
<hr>

src/eth/primitives/execution_value_change.rs

<li>Added <code>DebugAsJson</code> derive to <code>ValueState</code> enum.<br> <li> Added <code>Debug</code> implementation for <code>ExecutionValueChange</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1570/files#diff-f12d5836feb7b6337f034d36c79d4235cb266f15fc203bc142e984e0e10940d9">+52/-38</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>gas.rs</strong><dd><code>Implement `DebugAsJson` for `Gas` struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/gas.rs

- Added `DebugAsJson` derive to `Gas` struct.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1570/files#diff-bfe6206e817b783c7e222a5724a01a419246791bcc0c753819a0ef9fce0df957">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>hash.rs</strong><dd><code>Implement `DebugAsJson` for `Hash` struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/hash.rs

- Added `DebugAsJson` derive to `Hash` struct.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1570/files#diff-aaa0979af0896a585e49e9531c826d3dae201577fa9630a01d79fe80d23f42f3">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>index.rs</strong><dd><code>Implement `DebugAsJson` for `Index` struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/index.rs

- Added `DebugAsJson` derive to `Index` struct.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1570/files#diff-7948334d6b8ee12539c59e1b74a232841e15538ff454e5d2a31be87f46e1a64a">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>log.rs</strong><dd><code>Implement `DebugAsJson` for `Log` struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/log.rs

- Added `DebugAsJson` derive to `Log` struct.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1570/files#diff-c886f14c171107da82c777d17266657e495a804d331b3e4f0ce2f5ddafdb0a69">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>log_mined.rs</strong><dd><code>Implement `DebugAsJson` for `LogMined` struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/log_mined.rs

- Added `DebugAsJson` derive to `LogMined` struct.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1570/files#diff-0ce210a69394a14d9a6424cf5ddf8b84c10a535b9ecae1dd34c0dbcff4beaf07">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>log_topic.rs</strong><dd><code>Implement `DebugAsJson` for `LogTopic` struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/log_topic.rs

- Added `DebugAsJson` derive to `LogTopic` struct.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1570/files#diff-ac0f3bf93665711c21efcc8f0e0516e58626d21f63b95753efdcb3eefd31f5c6">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>miner_nonce.rs</strong><dd><code>Implement `DebugAsJson` for `MinerNonce` struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/miner_nonce.rs

- Added `DebugAsJson` derive to `MinerNonce` struct.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1570/files#diff-7efed1484a70a654bbcf05956b66a84aac6e4dbf0fda2a3d13b8471975baa452">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>nonce.rs</strong><dd><code>Implement `DebugAsJson` for `Nonce` struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/nonce.rs

- Added `DebugAsJson` derive to `Nonce` struct.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1570/files#diff-024228fa48e154f6b90198759a990de8b2e6eb3b05353a1b182e82413589ab78">+2/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>size.rs</strong><dd><code>Implement `DebugAsJson` for `Size` struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/size.rs

- Added `DebugAsJson` derive to `Size` struct.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1570/files#diff-69410604c961a203d6b489abc7e67d630f33ccf467ace75cc5709ed1b6870155">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>slot_index.rs</strong><dd><code>Implement <code>DebugAsJson</code> for <code>SlotIndex</code> struct and remove custom <code>Debug</code></code></dd></summary>
<hr>

src/eth/primitives/slot_index.rs

<li>Added <code>DebugAsJson</code> derive to <code>SlotIndex</code> struct.<br> <li> Removed custom <code>Debug</code> implementation for <code>SlotIndex</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1570/files#diff-a6d393b2415c8601795717188a4bb54f9b1b1f74578eb722cacfb71021815ae6">+2/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>slot_value.rs</strong><dd><code>Implement `DebugAsJson` for `SlotValue` struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/slot_value.rs

- Added `DebugAsJson` derive to `SlotValue` struct.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1570/files#diff-e8bdc6406b44d637e87cc4719fa6f166240c6f85bd9c23512faba18496e7e463">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>unix_time.rs</strong><dd><code>Implement `DebugAsJson` for `UnixTime` struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/unix_time.rs

- Added `DebugAsJson` derive to `UnixTime` struct.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1570/files#diff-8c55a886f7862a6abfe41aed8803659e33c07a1aea4d1ac7ebe87b7492a284f9">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>wei.rs</strong><dd><code>Implement `DebugAsJson` for `Wei` struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/wei.rs

- Added `DebugAsJson` derive to `Wei` struct.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1570/files#diff-457aeabe073254b540b036a4f4e776b56a3f12cccab2760838696e170b60424b">+14/-1</a>&nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>ext.rs</strong><dd><code>Add `serde_debug_json` test macro</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/ext.rs

<li>Added <code>serde_debug_json</code> test macro to verify JSON serialization matches <br><code>Debug</code> output.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1570/files#diff-4ff673578dd06edb71da19750f05cb48bbbd3c78ded3dbeda59409354c35cef6">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

