### PR TITLE
test: block_modes can receive multiple modes

### DIFF
--- a/justfile
+++ b/justfile
@@ -136,7 +136,7 @@ test-int name="'*'":
 # ------------------------------------------------------------------------------
 
 # E2E: Execute Hardhat tests in the specified network
-e2e network="stratus" block-mode="automine" test="":
+e2e network="stratus" block_modes="automine" test="":
     #!/bin/bash
     if [ -d e2e ]; then
         cd e2e
@@ -145,11 +145,16 @@ e2e network="stratus" block-mode="automine" test="":
         npm install
     fi
 
-    if [ -z "{{test}}" ]; then
-        BLOCK_MODE={{block-mode}} npx hardhat test test/{{block-mode}}/*.test.ts --network {{network}}
-    else
-        BLOCK_MODE={{block-mode}} npx hardhat test test/{{block-mode}}/*.test.ts --network {{network}} --grep "{{test}}"
-    fi
+    block_modes_split=$(echo {{block_modes}} | sed "s/,/ /g")
+    for block_mode in $block_modes_split
+    do
+        just _log "Executing: $block_mode"
+        if [ -z "{{test}}" ]; then
+            BLOCK_MODE=$block_mode npx hardhat test test/$block_mode/*.test.ts --network {{network}}
+        else
+            BLOCK_MODE=$block_mode npx hardhat test test/$block_mode/*.test.ts --network {{network}} --grep "{{test}}"
+        fi
+    done
 
 # E2E: Starts and execute Hardhat tests in Stratus
 e2e-stratus block-mode="automine" test="":


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Enhanced the E2E testing script to support multiple block modes by renaming `block-mode` to `block_modes`.
- Added logic to split the `block_modes` variable and iterate over each mode.
- Updated the test execution commands to handle multiple block modes, allowing for more flexible testing configurations.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>justfile</strong><dd><code>Support multiple block modes in E2E tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

justfile

<li>Renamed <code>block-mode</code> to <code>block_modes</code> to support multiple modes.<br> <li> Added logic to split and iterate over multiple block modes.<br> <li> Updated test execution commands to handle multiple block modes.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1571/files#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1">+11/-6</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

