### PR TITLE
test: contract availability after deployment

### DIFF
--- a/e2e/test/automine/e2e-json-rpc.test.ts
+++ b/e2e/test/automine/e2e-json-rpc.test.ts
@@ -86,7 +86,6 @@ describe("JSON-RPC", () => {
             it("contract code is available in the block it was deployed", async () => {
                 await sendReset();
                 const contract = await deployTestContractBalances();
-                await sendEvmMine();
                 (await sendExpect("eth_getCode", [contract.target, "latest"])).not.eq("0x");
                 (await sendExpect("eth_getCode", [contract.target, "0x1"])).not.eq("0x");
             });

--- a/e2e/test/automine/e2e-json-rpc.test.ts
+++ b/e2e/test/automine/e2e-json-rpc.test.ts
@@ -82,7 +82,14 @@ describe("JSON-RPC", () => {
             (await sendExpect("eth_getBalance", [ALICE])).eq(TEST_BALANCE);
             (await sendExpect("eth_getBalance", [ALICE, "latest"])).eq(TEST_BALANCE);
         });
-        it("eth_getCode", () => {
+        describe("eth_getCode", () => {
+            it("contract code is available in the block it was deployed", async () => {
+                await sendReset();
+                const contract = await deployTestContractBalances();
+                await sendEvmMine();
+                (await sendExpect("eth_getCode", [contract.target, "latest"])).not.eq("0x");
+                (await sendExpect("eth_getCode", [contract.target, "0x1"])).not.eq("0x");
+            });
             it("code for non-existent contract is 0x", async () => {
                 (await sendExpect("eth_getCode", [ALICE.address, "latest"])).eq("0x");
             });
@@ -91,6 +98,7 @@ describe("JSON-RPC", () => {
 
     describe("Block", () => {
         it("eth_blockNumber", async function () {
+            await sendReset();
             (await sendExpect("eth_blockNumber")).eq(ZERO);
             await sendEvmMine();
             (await sendExpect("eth_blockNumber")).eq(ONE);

--- a/e2e/test/external/e2e-json-rpc.test.ts
+++ b/e2e/test/external/e2e-json-rpc.test.ts
@@ -89,7 +89,16 @@ describe("JSON-RPC", () => {
             (await sendExpect("eth_getBalance", [ALICE])).eq(TEST_BALANCE);
             (await sendExpect("eth_getBalance", [ALICE, "latest"])).eq(TEST_BALANCE);
         });
-        it("eth_getCode", () => {
+
+        describe("eth_getCode", () => {
+            it("contract code is available in the block it was deployed", async () => {
+                await sendReset();
+                const contract = await deployTestContractBalances();
+                await sendEvmMine();
+                (await sendExpect("eth_getCode", [contract.target, "latest"])).not.eq("0x");
+                (await sendExpect("eth_getCode", [contract.target, "0x1"])).not.eq("0x");
+            });
+
             it("code for non-existent contract is 0x", async () => {
                 (await sendExpect("eth_getCode", [ALICE.address, "latest"])).eq("0x");
             });
@@ -98,6 +107,7 @@ describe("JSON-RPC", () => {
 
     describe("Block", () => {
         it("eth_blockNumber", async function () {
+            await sendReset();
             (await sendExpect("eth_blockNumber")).eq(ZERO);
             await sendEvmMine();
             (await sendExpect("eth_blockNumber")).eq(ONE);


### PR DESCRIPTION
### **PR Type**
Tests


___

### **Description**
- Added tests to check that contract code is available in the block it was deployed.
- Wrapped `eth_getCode` related tests in a `describe` block for better organization.
- Included `sendReset` calls before `eth_blockNumber` tests to ensure a clean state.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>e2e-json-rpc.test.ts</strong><dd><code>Add tests for contract code availability and block number reset</code></dd></summary>
<hr>

e2e/test/automine/e2e-json-rpc.test.ts

<li>Added a test to check contract code availability in the block it was <br>deployed.<br> <li> Wrapped <code>eth_getCode</code> tests in a <code>describe</code> block.<br> <li> Added <code>sendReset</code> before <code>eth_blockNumber</code> test.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1572/files#diff-3d74b20bca5732bd9d71f766b668d339a52e53e6b7fd18ff8f9000c077184439">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>e2e-json-rpc.test.ts</strong><dd><code>Add tests for contract code availability and block number reset</code></dd></summary>
<hr>

e2e/test/external/e2e-json-rpc.test.ts

<li>Added a test to check contract code availability in the block it was <br>deployed.<br> <li> Wrapped <code>eth_getCode</code> tests in a <code>describe</code> block.<br> <li> Added <code>sendReset</code> before <code>eth_blockNumber</code> test.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1572/files#diff-f5d1f06c4777826f9cbdcb4372d15c42f354177c83df65f3324cfd607da16004">+11/-1</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

