### PR TITLE
feat: reject transactions that are calling a contract, but does not have a bytecode

### DIFF
--- a/src/eth/executor/evm_input.rs
+++ b/src/eth/executor/evm_input.rs
@@ -15,6 +15,7 @@ use crate::eth::primitives::TransactionInput;
 use crate::eth::primitives::UnixTime;
 use crate::eth::primitives::Wei;
 use crate::eth::storage::StoragePointInTime;
+use crate::ext::not;
 use crate::ext::OptionExt;
 use crate::if_else;
 use crate::log_and_err;
@@ -148,5 +149,12 @@ impl EvmInput {
                 None => None,
             },
         })
+    }
+
+    /// Checks if the input is a contract call.
+    ///
+    /// It is when there is a `to` address and the `data` field is also populated.
+    pub fn is_contract_call(&self) -> bool {
+        self.to.is_some() && not(self.data.is_empty())
     }
 }

--- a/src/eth/primitives/stratus_error.rs
+++ b/src/eth/primitives/stratus_error.rs
@@ -4,10 +4,10 @@ use jsonrpsee::types::error::INVALID_PARAMS_CODE;
 use jsonrpsee::types::error::INVALID_REQUEST_CODE;
 use jsonrpsee::types::error::SERVER_IS_BUSY_CODE;
 use jsonrpsee::types::ErrorObjectOwned;
-use revm::primitives::EVMError;
 use strum::EnumProperty;
 
 use crate::alias::JsonValue;
+use crate::eth::primitives::Address;
 use crate::eth::primitives::BlockFilter;
 use crate::eth::primitives::BlockNumber;
 use crate::eth::primitives::Bytes;
@@ -65,6 +65,10 @@ pub enum StratusError {
     // -------------------------------------------------------------------------
     // Transaction
     // -------------------------------------------------------------------------
+    #[error("Account at {address} it is not a contract.")]
+    #[strum(props(kind = "execution"))]
+    TransactionAccountNotContract { address: Address },
+
     #[error("Transaction execution conflicts: {0:?}.")]
     #[strum(props(kind = "execution"))]
     TransactionConflict(Box<ExecutionConflicts>),
@@ -75,7 +79,7 @@ pub enum StratusError {
 
     #[error("Failed to executed transaction in EVM: {0:?}.")]
     #[strum(props(kind = "execution"))]
-    TransactionFailed(EVMError<anyhow::Error>), // split this in multiple errors
+    TransactionFailed(String), // split this in multiple errors
 
     #[error("Failed to forward transaction to leader node.")]
     #[strum(props(kind = "execution"))]

--- a/src/eth/primitives/stratus_error.rs
+++ b/src/eth/primitives/stratus_error.rs
@@ -65,7 +65,7 @@ pub enum StratusError {
     // -------------------------------------------------------------------------
     // Transaction
     // -------------------------------------------------------------------------
-    #[error("Account at {address} it is not a contract.")]
+    #[error("Account at {address} is not a contract.")]
     #[strum(props(kind = "execution"))]
     TransactionAccountNotContract { address: Address },
 


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Enhanced error handling in EVM execution by adding specific handling for storage errors and converting errors to strings before returning.
- Changed the error type in the `Database` trait implementation from `anyhow::Error` to `StratusError`.
- Added a check in the `basic` method of `RevmSession` to ensure the `to` account has bytecode if it is a contract call, returning a specific error if not.
- Introduced a new method `is_contract_call` in `EvmInput` to determine if the input is a contract call.
- Extended the `StratusError` enum with a new variant `TransactionAccountNotContract` and modified the `TransactionFailed` variant to accept a string.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>evm.rs</strong><dd><code>Enhance error handling and contract bytecode validation in EVM </code><br><code>execution</code></dd></summary>
<hr>

src/eth/executor/evm.rs

<li>Added handling for <code>EVMError::Database</code> to log and return storage <br>errors.<br> <li> Changed error type in <code>Database</code> trait implementation from <code>anyhow::Error</code> <br>to <code>StratusError</code>.<br> <li> Added check for contract bytecode presence and return a specific error <br>if missing.<br> <li> Updated error handling to convert errors to strings before returning.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1573/files#diff-7fabd204a68cff51c55ee1391074463fa8ac005dc8ba443218bc83a9dda96658">+19/-10</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>evm_input.rs</strong><dd><code>Add method to check for contract calls in EVM input</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/executor/evm_input.rs

<li>Added <code>is_contract_call</code> method to <code>EvmInput</code> to check if the input is a <br>contract call.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1573/files#diff-9dbdf7472d01464e439067cbd23dfe3648c7fb38a307bee0cf8642ad16a1a252">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>stratus_error.rs</strong><dd><code>Extend `StratusError` enum with new error variants</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/stratus_error.rs

<li>Added <code>TransactionAccountNotContract</code> variant to <code>StratusError</code> enum.<br> <li> Changed <code>TransactionFailed</code> variant to accept a string instead of <br><code>EVMError<anyhow::Error></code>.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1573/files#diff-301cded01d772388e3e5c08ede093b91c3e4478c08e11a48f70e3d44351385fb">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

