### PR TITLE
fix: force slot insertion

### DIFF
--- a/src/eth/storage/redis/redis_permanent.rs
+++ b/src/eth/storage/redis/redis_permanent.rs
@@ -19,6 +19,7 @@ use crate::eth::storage::PermanentStorage;
 use crate::eth::storage::StoragePointInTime;
 use crate::ext::from_json_str;
 use crate::ext::to_json_string;
+use crate::ext::to_json_value;
 use crate::log_and_err;
 
 type RedisVecOptString = RedisResult<Vec<Option<String>>>;
@@ -101,7 +102,7 @@ impl PermanentStorage for RedisPermanentStorage {
                 address: changes.address,
                 ..Account::default()
             };
-            if let Some(nonce) = changes.nonce.take() {
+            if let Some(nonce) = changes.nonce.take_modified() {
                 account.nonce = nonce;
             }
             if let Some(balance) = changes.balance.take() {
@@ -110,7 +111,6 @@ impl PermanentStorage for RedisPermanentStorage {
             if let Some(bytecode) = changes.bytecode.take() {
                 account.bytecode = bytecode;
             }
-
             let account_value = to_json_string(&account);
             mset_values.push((key_account(&account.address), account_value.clone()));
             zadd_values.push((key_account_history(&account.address), account_value, block.number().as_u64()));
@@ -118,7 +118,10 @@ impl PermanentStorage for RedisPermanentStorage {
             // slot
             for slot in changes.slots.into_values() {
                 if let Some(slot) = slot.take() {
-                    let slot_value = to_json_string(&slot);
+                    let mut slot_value = to_json_value(slot);
+                    slot_value.as_object_mut().unwrap().insert("block".to_owned(), to_json_value(block.number()));
+                    let slot_value = to_json_string(&slot_value);
+
                     mset_values.push((key_slot(&account.address, &slot.index), slot_value.clone()));
                     zadd_values.push((key_slot_history(&account.address, &slot.index), slot_value, block.number().as_u64()));
                 }

--- a/src/eth/storage/redis/redis_permanent.rs
+++ b/src/eth/storage/redis/redis_permanent.rs
@@ -102,7 +102,7 @@ impl PermanentStorage for RedisPermanentStorage {
                 address: changes.address,
                 ..Account::default()
             };
-            if let Some(nonce) = changes.nonce.take_modified() {
+            if let Some(nonce) = changes.nonce.take() {
                 account.nonce = nonce;
             }
             if let Some(balance) = changes.balance.take() {


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed slot insertion logic in `RedisPermanentStorage` to include the block number in the JSON value.
- Added the `to_json_value` import to support the new slot insertion logic.
- Updated the serialization process for slot values to ensure the block number is included.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>redis_permanent.rs</strong><dd><code>Fix slot insertion to include block number in Redis storage</code></dd></summary>
<hr>

src/eth/storage/redis/redis_permanent.rs

<li>Added import for <code>to_json_value</code>.<br> <li> Modified slot insertion to include block number in the JSON value.<br> <li> Updated serialization logic for slot values.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1575/files#diff-068ece78c4a374a891db1f4759a7a035df7aa981bf04c3bffecfd44e94f5841b">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

