### PR TITLE
enha: force block changes to redis

### DIFF
--- a/src/eth/primitives/execution_account_changes.rs
+++ b/src/eth/primitives/execution_account_changes.rs
@@ -95,13 +95,8 @@ impl ExecutionAccountChanges {
         }
     }
 
-    /// Checks if the account was created by this transaction.
-    pub fn is_creation(&self) -> bool {
-        self.new_account
-    }
-
-    /// Checks if nonce, balance or bytecode were modified.
-    pub fn is_changed(&self) -> bool {
+    /// Checks if account nonce, balance or bytecode were modified.
+    pub fn is_account_modified(&self) -> bool {
         self.nonce.is_modified() || self.balance.is_modified() || self.bytecode.is_modified()
     }
 }


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Renamed the `is_changed` method to `is_account_modified` in `ExecutionAccountChanges` to better reflect its purpose.
- Enhanced Redis storage logic to include block number in account and slot modifications, ensuring forced updates.
- Updated JSON serialization to include block number for both accounts and slots.
- Modified logic to only process accounts if they are modified, optimizing storage operations.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>execution_account_changes.rs</strong><dd><code>Rename and update account modification check method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/execution_account_changes.rs

<li>Renamed <code>is_changed</code> method to <code>is_account_modified</code>.<br> <li> Updated method documentation to reflect the new name.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1576/files#diff-2f8319711f3b8bc5b706dcbb93ad7aeb7fc461b3416f6e5adcd715852a88c619">+2/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>redis_permanent.rs</strong><dd><code>Force block number inclusion in Redis account and slot updates</code></dd></summary>
<hr>

src/eth/storage/redis/redis_permanent.rs

<li>Added block number to account and slot modifications to force updates.<br> <li> Modified logic to only process accounts if they are modified.<br> <li> Updated JSON serialization to include block number.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1576/files#diff-068ece78c4a374a891db1f4759a7a035df7aa981bf04c3bffecfd44e94f5841b">+26/-18</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

