### PR TITLE
feat: redis configuration url

### DIFF
--- a/src/eth/storage/redis/redis_permanent.rs
+++ b/src/eth/storage/redis/redis_permanent.rs
@@ -33,8 +33,11 @@ pub struct RedisPermanentStorage {
 }
 
 impl RedisPermanentStorage {
-    pub fn new() -> anyhow::Result<Self> {
-        let client = RedisClient::open("redis://127.0.0.1/")?;
+    pub fn new(url: &str) -> anyhow::Result<Self> {
+        let client = match RedisClient::open(url) {
+            Ok(client) => client,
+            Err(e) => return log_and_err!(reason = e, "failed to create redis client"),
+        };
         Ok(Self { client })
     }
 


### PR DESCRIPTION
### **PR Type**
Enhancement, Error handling


___

### **Description**
- Enhanced `PermanentStorageConfig` to require `perm_storage_url` when `perm_storage_kind` is set to `redis`.
- Improved error handling for missing Redis URL in `PermanentStorageConfig`.
- Modified `RedisPermanentStorage::new` to accept a URL parameter.
- Added error handling for Redis client creation failure in `RedisPermanentStorage`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>permanent_storage.rs</strong><dd><code>Require and validate Redis URL in `PermanentStorageConfig`</code></dd></summary>
<hr>

src/eth/storage/permanent_storage.rs

<li>Added <code>log_and_err</code> import.<br> <li> Updated <code>PermanentStorageConfig</code> to require <code>perm_storage_url</code> if <br><code>perm_storage_kind</code> is <code>redis</code>.<br> <li> Enhanced error handling for missing Redis URL.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1577/files#diff-7b27a17201e5a4916214bb7bebbeaba2874cce309edd6f628018abe45f88a1c5">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>redis_permanent.rs</strong><dd><code>Accept URL parameter and handle errors in Redis client creation</code></dd></summary>
<hr>

src/eth/storage/redis/redis_permanent.rs

<li>Modified <code>RedisPermanentStorage::new</code> to accept a URL parameter.<br> <li> Added error handling for Redis client creation failure.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1577/files#diff-068ece78c4a374a891db1f4759a7a035df7aa981bf04c3bffecfd44e94f5841b">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

