### PR TITLE
feat: configure if transactions to non-contracts should be rejected

### DIFF
--- a/src/eth/executor/executor_config.rs
+++ b/src/eth/executor/executor_config.rs
@@ -16,12 +16,18 @@ pub struct ExecutorConfig {
     pub chain_id: u64,
 
     /// Number of EVM instances to run.
+    ///
+    /// TODO: should be configured for each kind of EvmRoute instead of being a single value.
     #[arg(long = "evms", env = "EVMS")]
     pub num_evms: usize,
 
     /// EVM execution strategy.
     #[arg(long = "strategy", env = "STRATEGY", default_value = "serial")]
     pub strategy: ExecutorStrategy,
+
+    /// Should reject contract transactions and calls to accounts that are not contracts?
+    #[arg(long = "reject-not-contract", env = "REJECT_NOT_CONTRACT", default_value = "true")]
+    pub reject_not_contract: bool,
 }
 
 impl ExecutorConfig {


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Integrated `ExecutorConfig` into the `Evm` and `RevmSession` structs to centralize configuration.
- Modified `Evm::new` and `RevmSession::new` constructors to accept `ExecutorConfig` instead of `ChainId`.
- Added a new configuration option `reject_not_contract` to `ExecutorConfig` to control whether transactions to non-contract accounts should be rejected.
- Updated logging to reflect the inclusion of `ExecutorConfig`.
- Adjusted the EVM spawning logic to utilize the new `ExecutorConfig`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>evm.rs</strong><dd><code>Integrate `ExecutorConfig` into EVM and RevmSession</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/executor/evm.rs

<li>Added <code>ExecutorConfig</code> to <code>Evm</code> and <code>RevmSession</code> structs.<br> <li> Modified <code>Evm::new</code> and <code>RevmSession::new</code> to accept <code>ExecutorConfig</code>.<br> <li> Added logic to handle <code>reject_not_contract</code> configuration.<br> <li> Updated logging to include <code>ExecutorConfig</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1578/files#diff-7fabd204a68cff51c55ee1391074463fa8ac005dc8ba443218bc83a9dda96658">+16/-7</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>executor.rs</strong><dd><code>Use `ExecutorConfig` in EVM spawning and execution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/executor/executor.rs

<li>Modified <code>Evms::spawn</code> and <code>evm_loop</code> to use <code>ExecutorConfig</code>.<br> <li> Removed <code>ChainId</code> parameter in favor of <code>ExecutorConfig</code>.<br> <li> Updated thread spawning logic to clone <code>ExecutorConfig</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1578/files#diff-6b460d7dee8280c0287e8d9d9d59cf66a57ec9fed1bc003c6ede6fef60c7376b">+6/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>executor_config.rs</strong><dd><code>Add `reject_not_contract` option to `ExecutorConfig`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/executor/executor_config.rs

<li>Added <code>reject_not_contract</code> field to <code>ExecutorConfig</code>.<br> <li> Updated <code>ExecutorConfig</code> initialization to include <code>reject_not_contract</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1578/files#diff-6cf7fa175d8d21c44043aca3b3690957542a08dc37446bf33cc7e5cf5c330024">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

