### PR TITLE
chore: remove obsolete commentaries

### DIFF
--- a/src/eth/consensus/mod.rs
+++ b/src/eth/consensus/mod.rs
@@ -499,7 +499,7 @@ impl Consensus {
         #[cfg(feature = "metrics")]
         metrics::inc_consensus_forward(start.elapsed());
 
-        Ok((result.tx_hash, blockchain_client.http_url.clone())) //XXX HEX
+        Ok((result.tx_hash, blockchain_client.http_url.clone()))
     }
 
     pub async fn should_serve(&self) -> bool {

--- a/src/eth/consensus/tests/factories.rs
+++ b/src/eth/consensus/tests/factories.rs
@@ -119,10 +119,7 @@ pub fn create_mock_consensus() -> Arc<Consensus> {
     let tmpdir_log_entries_path = tmpdir_log_entries.path().to_str().map(|s| s.to_owned());
     let storage = Arc::new(storage);
 
-    let miner = Miner::new(
-        Arc::clone(&storage),
-        crate::eth::miner::MinerMode::External,
-    );
+    let miner = Miner::new(Arc::clone(&storage), crate::eth::miner::MinerMode::External);
 
     Consensus::new(
         Arc::clone(&storage),

--- a/src/eth/consensus/tests/factories.rs
+++ b/src/eth/consensus/tests/factories.rs
@@ -121,7 +121,7 @@ pub fn create_mock_consensus() -> Arc<Consensus> {
 
     let miner = Miner::new(
         Arc::clone(&storage),
-        crate::eth::miner::MinerMode::External, //XXX this should be passed as an argument, leaders start with interval, followers with the soon to be implemented follower mode
+        crate::eth::miner::MinerMode::External,
     );
 
     Consensus::new(

--- a/src/eth/executor/evm_input.rs
+++ b/src/eth/executor/evm_input.rs
@@ -89,7 +89,7 @@ impl EvmInput {
             value: input.value,
             data: input.input,
             gas_limit: Gas::MAX,
-            gas_price: Wei::ZERO, // XXX: use value from input?
+            gas_price: Wei::ZERO,
             nonce: Some(input.nonce),
             block_number: pending_block_number,
             block_timestamp: UnixTime::now(),
@@ -110,8 +110,8 @@ impl EvmInput {
             to: input.to.map_into(),
             value: input.value,
             data: input.data,
-            gas_limit: Gas::MAX,  // XXX: use value from input?
-            gas_price: Wei::ZERO, // XXX: use value from input?
+            gas_limit: Gas::MAX,
+            gas_price: Wei::ZERO,
             nonce: None,
             block_number: match point_in_time {
                 StoragePointInTime::Mined | StoragePointInTime::Pending => pending_block_number,

--- a/src/eth/primitives/log_mined.rs
+++ b/src/eth/primitives/log_mined.rs
@@ -81,14 +81,14 @@ impl From<LogMined> for EthersLog {
             data: value.log.data.into(),
             log_index: Some(value.log_index.into()),
             removed: Some(false),
-            log_type: None, // TODO: what is this?,
+            log_type: None,
 
             // block / transaction
             block_hash: Some(value.block_hash.into()),
             block_number: Some(value.block_number.into()),
             transaction_hash: Some(value.transaction_hash.into()),
             transaction_index: Some(value.transaction_index.into()),
-            transaction_log_index: None, // TODO: what is this?
+            transaction_log_index: None,
         }
     }
 }

--- a/src/eth/primitives/mod.rs
+++ b/src/eth/primitives/mod.rs
@@ -114,28 +114,6 @@ mod tests {
     type TransactionExecutionValueChangeSlot = ExecutionValueChange<Slot>;
     type TransactionExecutionValueChangeWei = ExecutionValueChange<Wei>;
 
-    // FIX: gen_test_serde!(Block);
-    // FIX: gen_test_serde!(EvmExecution);
-    // FIX: gen_test_serde!(ExecutionAccountChanges);
-    // FIX: gen_test_serde!(ExecutionChanges);
-    // FIX: gen_test_serde!(TransactionMined);
-    // TODO: gen_test_serde!(BlockFilter);
-    // TODO: gen_test_serde!(ExecutionConflict);
-    // TODO: gen_test_serde!(ExecutionConflicts);
-    // TODO: gen_test_serde!(ExecutionConflictsBuilder);
-    // TODO: gen_test_serde!(ExternalBlock);
-    // TODO: gen_test_serde!(ExternalReceipt);
-    // TODO: gen_test_serde!(ExternalReceipts);
-    // TODO: gen_test_serde!(ExternalTransaction);
-    // TODO: gen_test_serde!(ExternalTransactionExecution);
-    // TODO: gen_test_serde!(LocalTransactionExecution);
-    // TODO: gen_test_serde!(LogFilter);
-    // TODO: gen_test_serde!(LogFilterInput);
-    // TODO: gen_test_serde!(LogFilterInputTopic);
-    // TODO: gen_test_serde!(PendingBlock);
-    // TODO: gen_test_serde!(StratusError);
-    // TODO: gen_test_serde!(TransactionExecution);
-    // TODO: gen_test_serde!(TransactionStage);
     gen_test_serde!(Account);
     gen_test_serde!(Address);
     gen_test_serde!(BlockHeader);


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Removed obsolete comments in `Consensus` implementation.
- Removed obsolete comments in `create_mock_consensus` function.
- Removed obsolete comments in `EvmInput` implementation.
- Removed obsolete comments in `LogMined` implementation.
- Removed multiple obsolete comments in `primitives` module tests.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Remove obsolete comment in `Consensus` implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/consensus/mod.rs

- Removed obsolete comment.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1581/files#diff-f7df3d82112cd8c1758b7ccd906775c78e1cf8860f0d2ac7c0d6e5ad9ab92f80">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>factories.rs</strong><dd><code>Remove obsolete comment in `create_mock_consensus` function</code></dd></summary>
<hr>

src/eth/consensus/tests/factories.rs

- Removed obsolete comment.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1581/files#diff-dc3958476429a151fdcfc4b8e0fdd56fe03abdd8a988bbbf301b8ff11a4d83fd">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>evm_input.rs</strong><dd><code>Remove obsolete comments in `EvmInput` implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/executor/evm_input.rs

- Removed obsolete comments.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1581/files#diff-9dbdf7472d01464e439067cbd23dfe3648c7fb38a307bee0cf8642ad16a1a252">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>log_mined.rs</strong><dd><code>Remove obsolete comments in `LogMined` implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/log_mined.rs

- Removed obsolete comments.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1581/files#diff-0ce210a69394a14d9a6424cf5ddf8b84c10a535b9ecae1dd34c0dbcff4beaf07">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Remove obsolete comments in `primitives` module tests</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/mod.rs

- Removed multiple obsolete comments.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1581/files#diff-0519ffc32191c9229d8b7672cd29638b49891c486a10d62379772dce98f1947c">+0/-22</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

