### PR TITLE
chore: restore test commentaries

### DIFF
--- a/src/eth/primitives/mod.rs
+++ b/src/eth/primitives/mod.rs
@@ -114,6 +114,28 @@ mod tests {
     type TransactionExecutionValueChangeSlot = ExecutionValueChange<Slot>;
     type TransactionExecutionValueChangeWei = ExecutionValueChange<Wei>;
 
+    // FIX: gen_test_serde!(Block);
+    // FIX: gen_test_serde!(EvmExecution);
+    // FIX: gen_test_serde!(ExecutionAccountChanges);
+    // FIX: gen_test_serde!(ExecutionChanges);
+    // FIX: gen_test_serde!(TransactionMined);
+    // TODO: gen_test_serde!(BlockFilter);
+    // TODO: gen_test_serde!(ExecutionConflict);
+    // TODO: gen_test_serde!(ExecutionConflicts);
+    // TODO: gen_test_serde!(ExecutionConflictsBuilder);
+    // TODO: gen_test_serde!(ExternalBlock);
+    // TODO: gen_test_serde!(ExternalReceipt);
+    // TODO: gen_test_serde!(ExternalReceipts);
+    // TODO: gen_test_serde!(ExternalTransaction);
+    // TODO: gen_test_serde!(ExternalTransactionExecution);
+    // TODO: gen_test_serde!(LocalTransactionExecution);
+    // TODO: gen_test_serde!(LogFilter);
+    // TODO: gen_test_serde!(LogFilterInput);
+    // TODO: gen_test_serde!(LogFilterInputTopic);
+    // TODO: gen_test_serde!(PendingBlock);
+    // TODO: gen_test_serde!(StratusError);
+    // TODO: gen_test_serde!(TransactionExecution);
+    // TODO: gen_test_serde!(TransactionStage);
     gen_test_serde!(Account);
     gen_test_serde!(Address);
     gen_test_serde!(BlockHeader);


### PR DESCRIPTION
### **User description**
I removed those commentaries by mistake 😅


___

### **PR Type**
documentation


___

### **Description**
- Restored previously removed test commentaries in `src/eth/primitives/mod.rs`.
- Added `FIX` and `TODO` markers for various test cases to indicate required fixes and pending implementations.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Restore and annotate test commentaries in `mod.rs`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/mod.rs

<li>Restored previously removed test commentaries.<br> <li> Added <code>FIX</code> and <code>TODO</code> markers for various test cases.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1582/files#diff-0519ffc32191c9229d8b7672cd29638b49891c486a10d62379772dce98f1947c">+22/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

