### PR TITLE
tweak: infer transaction type from tx signature

### DIFF
--- a/config/importer-offline.env.local
+++ b/config/importer-offline.env.local
@@ -1,4 +1,4 @@
-RUST_LOG=info,stratus::eth::miner=warn,stratus::eth::executor=warn,importer_offline::rx=off
+RUST_LOG=info,stratus::eth::miner::miner=warn,stratus::eth::executor=warn
 
 CHAIN_ID=2008
 EVMS=8
@@ -9,3 +9,5 @@ TEMP_STORAGE=inmemory
 EXTERNAL_RPC_STORAGE=postgres://postgres:123@localhost:5432/stratus
 EXTERNAL_RPC_STORAGE_CONNECTIONS=3
 EXTERNAL_RPC_STORAGE_TIMEOUT=20000
+
+EXECUTOR_REJECT_NOT_CONTRACT=false

--- a/src/bin/importer_offline.rs
+++ b/src/bin/importer_offline.rs
@@ -24,6 +24,7 @@ use stratus::eth::primitives::BlockNumber;
 use stratus::eth::primitives::ExternalBlock;
 use stratus::eth::primitives::ExternalReceipt;
 use stratus::eth::primitives::ExternalReceipts;
+use stratus::eth::primitives::ExternalTransaction;
 use stratus::eth::storage::ExternalRpcStorage;
 use stratus::eth::storage::InMemoryPermanentStorage;
 use stratus::ext::spawn_named;
@@ -148,10 +149,13 @@ fn execute_block_importer(
         let mut transaction_count = 0;
         let instant_before_execution = Instant::now();
 
-        for block in blocks.into_iter() {
+        for mut block in blocks.into_iter() {
             if GlobalState::is_shutdown_warn(TASK_NAME) {
                 return Ok(());
             }
+
+            // fill missing transaction_type with `v`
+            block.transactions.iter_mut().for_each(ExternalTransaction::fill_missing_transaction_type);
 
             // re-execute (and import) block
             executor.execute_external_block(&block, &receipts)?;

--- a/src/eth/primitives/external_block.rs
+++ b/src/eth/primitives/external_block.rs
@@ -12,7 +12,7 @@ use crate::eth::primitives::Hash;
 use crate::eth::primitives::UnixTime;
 use crate::log_and_err;
 
-#[derive(Debug, Clone, derive_more:: Deref, serde::Deserialize, serde::Serialize)]
+#[derive(Debug, Clone, derive_more::Deref, derive_more::DerefMut, serde::Deserialize, serde::Serialize)]
 #[serde(transparent)]
 pub struct ExternalBlock(#[deref] pub EthersBlockExternalTransaction);
 

--- a/src/eth/primitives/external_transaction.rs
+++ b/src/eth/primitives/external_transaction.rs
@@ -16,6 +16,19 @@ impl ExternalTransaction {
     pub fn hash(&self) -> Hash {
         self.0.hash.into()
     }
+
+    /// Fills the field transaction_type based on `v`
+    pub fn fill_missing_transaction_type(&mut self) {
+        // Don't try overriding if it's already set
+        if self.0.transaction_type.is_some() {
+            return;
+        }
+
+        let v = self.0.v.as_u64();
+        if [0, 1].contains(&v) {
+            self.0.transaction_type = Some(2.into());
+        }
+    }
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Added a method to `ExternalTransaction` to infer and fill the `transaction_type` field based on the `v` value.
- Modified the block import loop to utilize the new method for filling missing `transaction_type`.
- Added `DerefMut` derive to `ExternalBlock` to allow mutable dereferencing.
- Simplified the match arm for `BlockFilter::Hash` in `RocksStorageState`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>importer_offline.rs</strong><dd><code>Fill missing transaction_type during block import</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/bin/importer_offline.rs

<li>Added import for <code>ExternalTransaction</code>.<br> <li> Modified block import loop to fill missing <code>transaction_type</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1585/files#diff-9fef7d584818c3db119ea1cd0952a57a953751f85f93ca813af861c4c737c53a">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>external_block.rs</strong><dd><code>Add DerefMut derive to ExternalBlock</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/external_block.rs

- Added `DerefMut` derive to `ExternalBlock`.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1585/files#diff-a9f4dfb1768eeb5161bd375436af42b8fbb82726916dd9c4cc1e7a08edd54388">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>external_transaction.rs</strong><dd><code>Add method to infer and fill missing transaction_type</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/external_transaction.rs

<li>Added <code>fill_missing_transaction_type</code> method.<br> <li> Implemented logic to infer <code>transaction_type</code> from <code>v</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1585/files#diff-a5bcf577600cee6a4844b4015797a92684df8ec490f06f66b4a556881a66032d">+22/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rocks_state.rs</strong><dd><code>Simplify match arm for BlockFilter::Hash</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/rocks/rocks_state.rs

- Simplified match arm for `BlockFilter::Hash`.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1585/files#diff-f7b822022d2c4fd93ec507cd6b5302dcf1646acbf0ee0dd077a047272b686009">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

