### PR TITLE
feat: compute rpc active connections metrics from jsonrpsee logs

### DIFF
--- a/config/stratus.env.local
+++ b/config/stratus.env.local
@@ -1,4 +1,4 @@
-RUST_LOG=info,stratus::eth::rpc::rpc_subscriptions::rx=off,stratus::eth::consensus::rx=off,stratus::eth::consensus=off
+RUST_LOG=info,stratus::eth::rpc::rpc_subscriptions::rx=off,stratus::eth::consensus::rx=off,stratus::eth::consensus=off,jsonrpsee-server=debug
 
 CHAIN_ID=2008
 EVMS=1

--- a/src/infra/metrics/metrics_definitions.rs
+++ b/src/infra/metrics/metrics_definitions.rs
@@ -5,7 +5,7 @@ metrics! {
     group: json_rpc,
 
     "Number of JSON-RPC requests active right now."
-    gauge rpc_requests_active{client, method},
+    gauge rpc_requests_active{},
 
     "Number of JSON-RPC requests that started."
     counter rpc_requests_started{client, method, contract, function},


### PR DESCRIPTION
### **PR Type**
Enhancement, Configuration changes


___

### **Description**
- Simplified the `rpc_requests_active` gauge definition by removing labels.
- Added temporary metrics collection from tracing events, including a new `event_to_metrics` function to parse and set metrics.
- Modified the `TracingLog` struct to use `JsonValue` for fields instead of `SerializeFieldMap`.
- Updated the `RUST_LOG` configuration to include `jsonrpsee-server=debug` for better logging visibility.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>metrics_definitions.rs</strong><dd><code>Simplified `rpc_requests_active` gauge definition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/infra/metrics/metrics_definitions.rs

- Modified `rpc_requests_active` gauge to remove labels.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1590/files#diff-2ca1adc579301e6de5f9e1d69eb1ed2f70aeee0f3b54fe113346040b4eab652b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>tracing.rs</strong><dd><code>Added metrics collection from tracing events</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/infra/tracing/tracing.rs

<li>Added temporary metrics collection from events.<br> <li> Introduced <code>event_to_metrics</code> function to parse and set metrics.<br> <li> Modified <code>TracingLog</code> struct to use <code>JsonValue</code> for fields.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1590/files#diff-96fd30e1704c6f81158c63eea46561666a6b05c594b0cf999f35b86e881283d1">+27/-3</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>stratus.env.local</strong><dd><code>Updated logging configuration for jsonrpsee-server</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

config/stratus.env.local

<li>Updated <code>RUST_LOG</code> configuration to include <code>jsonrpsee-server=debug</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1590/files#diff-c9989f8b14cda489b8b6b3713e7931fdc41cabcabbf3022f26b64a39e9f38ab8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

