### PR TITLE
tweak: warn if RPC storage connection is unidentified

### DIFF
--- a/src/eth/storage/postgres_external_rpc/postgres_external_rpc.rs
+++ b/src/eth/storage/postgres_external_rpc/postgres_external_rpc.rs
@@ -15,6 +15,7 @@ use crate::eth::primitives::ExternalReceipt;
 use crate::eth::primitives::Hash;
 use crate::eth::primitives::Wei;
 use crate::eth::storage::ExternalRpcStorage;
+use crate::ext::not;
 use crate::ext::to_json_value;
 use crate::ext::traced_sleep;
 use crate::ext::SleepReason;
@@ -37,6 +38,10 @@ impl PostgresExternalRpcStorage {
     /// Creates a new [`PostgresExternalRpcStorage`].
     pub async fn new(config: PostgresExternalRpcStorageConfig) -> anyhow::Result<Self> {
         tracing::info!(?config, "creating postgres external rpc storage");
+
+        if not(config.url.contains('?')) {
+            tracing::warn!(url = config.url, "url isn't identified with '?app=NAME' query parameter");
+        }
 
         let result = PgPoolOptions::new()
             .min_connections(config.connections)


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Added a warning log in `PostgresExternalRpcStorage::new` to notify if the RPC storage connection URL does not contain the `?app=NAME` query parameter.
- Imported the `not` utility function to facilitate the new warning condition.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>postgres_external_rpc.rs</strong><dd><code>Add warning for unidentified RPC storage connection URL</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/postgres_external_rpc/postgres_external_rpc.rs

<li>Added a warning log if the RPC storage connection URL does not contain <br>a specific query parameter.<br> <li> Imported a new utility function <code>not</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1591/files#diff-faa79cbfb46cf46c342c70e132c2ab2e8b7011ec9e31eb9608f01a3f19f431db">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

