### PR TITLE
chore: remove BUG tag from the slack comment notifier

### DIFF
--- a/utils/slack-notifiers/comments.rb
+++ b/utils/slack-notifiers/comments.rb
@@ -47,7 +47,7 @@ end
 def report_tag_comments
   raise "Please provide SLACK_WEBHOOK_URL" if ENV['SLACK_WEBHOOK_URL'].nil?
 
-  tags = %w[TODO FIXME HACK XXX OPTIMIZE BUG]
+  tags = %w[TODO FIXME HACK XXX OPTIMIZE]
 
   tags.each do |tag|
     generate_tag_file(tag)


### PR DESCRIPTION
We're not using this tag in code and it's also giving false positives.

Bugs should probably go into issues.