### PR TITLE
chore: solve warnings

### DIFF
--- a/src/eth/executor/executor.rs
+++ b/src/eth/executor/executor.rs
@@ -7,6 +7,7 @@ use anyhow::anyhow;
 use tracing::info_span;
 use tracing::Span;
 
+#[cfg(feature = "metrics")]
 use crate::eth::codegen;
 use crate::eth::executor::Evm;
 use crate::eth::executor::EvmExecutionResult;

--- a/src/eth/rpc/rpc_context.rs
+++ b/src/eth/rpc/rpc_context.rs
@@ -23,7 +23,6 @@ pub struct RpcContext {
 
     // services
     pub executor: Arc<Executor>,
-    #[allow(dead_code)] // HACK this was triggered in Rust 1.79
     pub miner: Arc<Miner>,
     pub storage: Arc<StratusStorage>,
     pub consensus: Arc<Consensus>,

--- a/src/eth/rpc/rpc_middleware.rs
+++ b/src/eth/rpc/rpc_middleware.rs
@@ -34,6 +34,7 @@ use crate::eth::rpc::RpcClientApp;
 use crate::event_with;
 use crate::ext::from_json_str;
 use crate::ext::to_json_value;
+#[cfg(feature = "metrics")]
 use crate::if_else;
 use crate::infra::metrics;
 use crate::infra::tracing::new_cid;
@@ -164,6 +165,8 @@ impl<'a> Future for RpcResponse<'a> {
             // trace response
             let response_success = response.is_success();
             let response_result: JsonValue = from_json_str(response.as_result());
+
+            #[cfg_attr(not(feature = "metrics"), allow(unused_variables))]
             let (level, error_code) = match response_result
                 .get("error")
                 .and_then(|v| v.get("code"))

--- a/src/eth/storage/rocks/rocks_state.rs
+++ b/src/eth/storage/rocks/rocks_state.rs
@@ -151,6 +151,7 @@ impl RocksStorageState {
     /// Get the filename of the database path.
     ///
     /// Should be checked on creation.
+    #[cfg(feature = "metrics")]
     fn db_path_filename(&self) -> &str {
         self.db.path().file_name().unwrap().to_str().unwrap()
     }


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Added conditional compilation for `metrics` feature in multiple files.
- Removed unnecessary `#[allow(dead_code)]` attribute in `rpc_context.rs`.
- Added conditional attribute to allow unused variables when `metrics` feature is not enabled in `rpc_middleware.rs`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>executor.rs</strong><dd><code>Add conditional compilation for metrics feature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/executor/executor.rs

- Added conditional compilation for `metrics` feature.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1593/files#diff-6b460d7dee8280c0287e8d9d9d59cf66a57ec9fed1bc003c6ede6fef60c7376b">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rpc_context.rs</strong><dd><code>Remove unnecessary allow(dead_code) attribute</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/rpc/rpc_context.rs

- Removed unnecessary `#[allow(dead_code)]` attribute.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1593/files#diff-a486ea1bd70eb81a959b89f514ed248a5c30fb4dabe7c08344b9bac246b6e92e">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rpc_middleware.rs</strong><dd><code>Add conditional compilation and attribute for metrics feature</code></dd></summary>
<hr>

src/eth/rpc/rpc_middleware.rs

<li>Added conditional compilation for <code>metrics</code> feature.<br> <li> Added conditional attribute to allow unused variables when <code>metrics</code> <br>feature is not enabled.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1593/files#diff-31b7182aec4416845e60ec9ec16720ae97d31260e1a9c50d601d542dee8776f5">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rocks_state.rs</strong><dd><code>Add conditional compilation for metrics feature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/rocks/rocks_state.rs

- Added conditional compilation for `metrics` feature.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1593/files#diff-f7b822022d2c4fd93ec507cd6b5302dcf1646acbf0ee0dd077a047272b686009">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

