### PR TITLE
chore: remove outdated todo at permanent_storage

### DIFF
--- a/src/eth/storage/permanent_storage.rs
+++ b/src/eth/storage/permanent_storage.rs
@@ -47,8 +47,6 @@ pub trait PermanentStorage: Send + Sync + 'static {
     fn read_transaction(&self, hash: &Hash) -> anyhow::Result<Option<TransactionMined>>;
 
     /// Retrieves logs from the storage.
-    ///
-    /// TODO: `filter.to_block` is always populated, need to change the type to reflect that.
     fn read_logs(&self, filter: &LogFilter) -> anyhow::Result<Vec<LogMined>>;
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Removed an outdated TODO comment in the `read_logs` method of the `PermanentStorage` trait.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>permanent_storage.rs</strong><dd><code>Remove outdated TODO comment in `PermanentStorage` trait</code>&nbsp; </dd></summary>
<hr>

src/eth/storage/permanent_storage.rs

- Removed an outdated TODO comment.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1601/files#diff-7b27a17201e5a4916214bb7bebbeaba2874cce309edd6f628018abe45f88a1c5">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

