### PR TITLE
enha: allow custom env when local

### DIFF
--- a/config/stratus-follower.env.local
+++ b/config/stratus-follower.env.local
@@ -1,0 +1,10 @@
+RUST_LOG=info,stratus::eth::rpc::rpc_subscriptions::rx=off,stratus::eth::consensus::rx=off,stratus::eth::consensus=off,jsonrpsee-server=debug
+
+CHAIN_ID=2008
+EVMS=1
+
+PERM_STORAGE=inmemory
+TEMP_STORAGE=inmemory
+
+EXTERNAL_RPC=http://spec.testnet.cloudwalk.network:9934/
+EXTERNAL_RPC_WS=ws://spec.testnet.cloudwalk.network:9946/

--- a/justfile
+++ b/justfile
@@ -8,8 +8,6 @@ export RUST_BACKTRACE := env("RUST_BACKTRACE", "0")
 nightly_flag := if env("NIGHTLY", "") =~ "(true|1)" { "+nightly" } else { "" }
 release_flag := if env("RELEASE", "") =~ "(true|1)" { "--release" } else { "" }
 database_url := env("DATABASE_URL", "postgres://postgres:123@0.0.0.0:5432/stratus")
-external_rpc := "http://spec.testnet.cloudwalk.network:9934/"
-external_rpc_ws := "ws://spec.testnet.cloudwalk.network:9946/"
 
 # Project: Show available tasks
 default:
@@ -92,8 +90,8 @@ stratus *args="":
     cargo {{nightly_flag}} run --bin stratus {{release_flag}} --features dev -- --leader {{args}}
 
 # Bin: Stratus main service as follower
-stratus-follower external_rpc=external_rpc external_rpc_ws=external_rpc_ws *args="":
-    cargo {{nightly_flag}} run --bin stratus {{release_flag}} --features dev -- --follower --external-rpc {{external_rpc}} --external-rpc-ws {{external_rpc_ws}} {{args}}
+stratus-follower *args="":
+    LOCAL_ENV_PATH=stratus-follower cargo {{nightly_flag}} run --bin stratus {{release_flag}} --features dev -- --follower {{args}}
 
 # Bin: Download external RPC blocks and receipts to temporary storage
 rpc-downloader *args="":

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,16 +35,23 @@ pub fn load_dotenv_file() {
         Ok(env) => Environment::from_str(env.as_str()),
         Err(_) => Ok(Environment::Local),
     };
-    let env = match env {
-        Ok(env) => env,
+
+    // determine the .env file to load
+    let env_filename = match env {
+        Ok(Environment::Local) => {
+            // local environment only
+            match std::env::var("LOCAL_ENV_PATH") {
+                Ok(local_path) => format!("config/{}.env.local", local_path),
+                Err(_) => format!("config/{}.env.local", build_info::binary_name()),
+            }
+        }
+        Ok(env) => format!("config/{}.env.{}", build_info::binary_name(), env),
         Err(e) => {
             println!("{e}");
             return;
         }
     };
 
-    // load .env file
-    let env_filename = format!("config/{}.env.{}", build_info::binary_name(), env);
     println!("reading env file | filename={}", env_filename);
 
     if let Err(e) = dotenvy::from_filename(env_filename) {


### PR DESCRIPTION
### **PR Type**
Enhancement, Configuration changes


___

### **Description**
- Added support for custom local environment paths in the dotenv loading process.
- Introduced a new environment configuration file for `stratus-follower`.
- Updated `justfile` to remove hardcoded external RPC URLs and use `LOCAL_ENV_PATH` for `stratus-follower`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.rs</strong><dd><code>Support custom local environment paths in dotenv loading</code>&nbsp; </dd></summary>
<hr>

src/config.rs

<li>Added support for custom local environment paths.<br> <li> Modified logic to determine the <code>.env</code> file to load based on the <br>environment.<br> <li> Introduced handling for <code>LOCAL_ENV_PATH</code> environment variable.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1602/files#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecd">+11/-4</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>stratus-follower.env.local</strong><dd><code>Add environment configuration for stratus-follower</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

config/stratus-follower.env.local

<li>Added new environment configuration file for <code>stratus-follower</code>.<br> <li> Included various environment variables like <code>RUST_LOG</code>, <code>CHAIN_ID</code>, and <br><code>EXTERNAL_RPC</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1602/files#diff-48ee1351e3ea120c152ce7b7b909a170cd6f0e162aae86477bd71aab2e632ad6">+10/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>justfile</strong><dd><code>Update justfile to use custom local environment paths</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

justfile

<li>Removed hardcoded external RPC URLs.<br> <li> Updated <code>stratus-follower</code> command to use <code>LOCAL_ENV_PATH</code> for environment <br>configuration.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1602/files#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1">+2/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

