### PR TITLE
feat: justfile follower commands and configs

### DIFF
--- a/config/stratus-follower.env.local
+++ b/config/stratus-follower.env.local
@@ -1,10 +1,12 @@
 RUST_LOG=info,stratus::eth::rpc::rpc_subscriptions::rx=off,stratus::eth::consensus::rx=off,stratus::eth::consensus=off,jsonrpsee-server=debug
 
+ADDRESS=0.0.0.0:3001
+
 CHAIN_ID=2008
 EVMS=1
 
 PERM_STORAGE=inmemory
 TEMP_STORAGE=inmemory
 
-EXTERNAL_RPC=http://spec.testnet.cloudwalk.network:9934/
-EXTERNAL_RPC_WS=ws://spec.testnet.cloudwalk.network:9946/
+EXTERNAL_RPC=http://localhost:3000/
+EXTERNAL_RPC_WS=ws://localhost:3000/

--- a/justfile
+++ b/justfile
@@ -32,6 +32,8 @@ setup:
 # ------------------------------------------------------------------------------
 
 alias run := stratus
+alias run-follower := stratus-follower
+alias run-importer := stratus-follower
 
 # Stratus: Compile with debug options
 build features="":


### PR DESCRIPTION
### **PR Type**
enhancement, configuration changes


___

### **Description**
- Updated the `stratus-follower.env.local` configuration file to include the `ADDRESS` setting and changed `EXTERNAL_RPC` and `EXTERNAL_RPC_WS` to use localhost.
- Added `run-follower` and `run-importer` aliases to the `justfile`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>stratus-follower.env.local</strong><dd><code>Update follower environment configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

config/stratus-follower.env.local

<li>Added <code>ADDRESS</code> configuration.<br> <li> Updated <code>EXTERNAL_RPC</code> and <code>EXTERNAL_RPC_WS</code> to use localhost.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1607/files#diff-48ee1351e3ea120c152ce7b7b909a170cd6f0e162aae86477bd71aab2e632ad6">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>justfile</strong><dd><code>Add follower and importer aliases to justfile</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

justfile

- Added `run-follower` and `run-importer` aliases.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1607/files#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

