### PR TITLE
enha: implement Consensus trait for Importer

### DIFF
--- a/src/eth/consensus/mod.rs
+++ b/src/eth/consensus/mod.rs
@@ -1,13 +1,56 @@
 pub mod raft;
 pub mod simple_consensus;
+use std::sync::Arc;
+
 use async_trait::async_trait;
 
 use crate::eth::primitives::Bytes;
 use crate::eth::primitives::Hash;
+use crate::infra::metrics;
+use crate::infra::BlockchainClient;
 
 #[async_trait]
 pub trait Consensus: Send + Sync {
-    async fn should_serve(&self) -> bool;
-    fn should_forward(&self) -> bool;
-    async fn forward(&self, transaction: Bytes) -> anyhow::Result<Hash>;
+    /// Whether this node should serve requests.
+    async fn should_serve(&self) -> bool {
+        let lag = match self.lag().await {
+            Ok(lag) => lag,
+            Err(err) => {
+                tracing::error!(?err, "failed to get the lag between this node and the leader");
+                return false;
+            }
+        };
+
+        let should_serve = lag <= 3;
+
+        if !should_serve {
+            tracing::info!(?lag, "validator and replica are too far appart");
+        }
+
+        return should_serve;
+    }
+
+    /// Forward a transaction
+    async fn forward(&self, transaction: Bytes) -> anyhow::Result<Hash> {
+        #[cfg(feature = "metrics")]
+        let start = metrics::now();
+
+        let blockchain_client = self.get_chain()?;
+
+        let result = blockchain_client.send_raw_transaction(transaction.into()).await?;
+
+        #[cfg(feature = "metrics")]
+        metrics::inc_consensus_forward(start.elapsed());
+
+        let tx_hash = result.tx_hash;
+        let validator_url = &blockchain_client.http_url;
+        tracing::info!(%tx_hash, ?validator_url, "forwarded eth_sendRawTransaction to leader");
+
+        Ok(result.tx_hash)
+    }
+
+    fn get_chain(&self) -> anyhow::Result<&Arc<BlockchainClient>>;
+
+    /// Get the lag between this node and the leader.
+    async fn lag(&self) -> anyhow::Result<u64>;
 }

--- a/src/eth/consensus/raft/mod.rs
+++ b/src/eth/consensus/raft/mod.rs
@@ -616,14 +616,19 @@ impl Consensus for Raft {
         self.should_serve().await
     }
 
-    fn should_forward(&self) -> bool {
-        self.should_forward()
-    }
-
     async fn forward(&self, transaction: Bytes) -> anyhow::Result<Hash> {
         let (tx_hash, url) = self.forward(transaction).await?;
         tracing::info!(%tx_hash, %url, "forwarded eth_sendRawTransaction to leader");
         Ok(tx_hash)
+    }
+
+    fn get_chain(&self) -> anyhow::Result<&Arc<BlockchainClient>> {
+        todo!();
+    }
+
+    /// Get the lag between this node and the leader.
+    async fn lag(&self) -> anyhow::Result<u64> {
+        todo!();
     }
 }
 

--- a/src/eth/consensus/simple_consensus/mod.rs
+++ b/src/eth/consensus/simple_consensus/mod.rs
@@ -1,15 +1,10 @@
 use std::sync::Arc;
 
-use anyhow::anyhow;
 use async_trait::async_trait;
 
 use super::Consensus;
-use crate::eth::primitives::Bytes;
-use crate::eth::primitives::Hash;
 use crate::eth::storage::StratusStorage;
-use crate::infra::metrics;
 use crate::infra::BlockchainClient;
-use crate::log_and_err;
 
 pub struct SimpleConsensus {
     storage: Arc<StratusStorage>,
@@ -25,52 +20,21 @@ impl SimpleConsensus {
 
 #[async_trait]
 impl Consensus for SimpleConsensus {
-    fn should_forward(&self) -> bool {
-        self.blockchain_client.is_some()
+    async fn lag(&self) -> anyhow::Result<u64> {
+        let Some(blockchain_client) = &self.blockchain_client else {
+            return Err(anyhow::anyhow!("blockchain client not set"));
+        };
+
+        let validator_block_number = blockchain_client.fetch_block_number().await?;
+        let current_block_number = self.storage.read_mined_block_number()?;
+
+        Ok(validator_block_number.as_u64() - current_block_number.as_u64())
     }
 
-    async fn should_serve(&self) -> bool {
-        let Some(blockchain_client) = &self.blockchain_client else {
-            return true;
+    fn get_chain(&self) -> anyhow::Result<&Arc<BlockchainClient>> {
+        let Some(chain) = &self.blockchain_client else {
+            return Err(anyhow::anyhow!("blockchain client not set"));
         };
-
-        //gather the latest block number, check how far behind it is from current storage block
-        //if its greater than 3 blocks of distance, it should not be served
-        let Ok(validator_block_number) = blockchain_client.fetch_block_number().await else {
-            tracing::error!("unable to fetch latest block number");
-            return false;
-        };
-
-        let Ok(current_block_number) = self.storage.read_mined_block_number() else {
-            tracing::error!("unable to fetch current block number");
-            return false;
-        };
-        let should_serve = (validator_block_number.as_u64() - 3) <= current_block_number.as_u64();
-
-        if !should_serve {
-            tracing::info!(?validator_block_number, ?current_block_number, "validator and replica are too far appart");
-        }
-
-        return should_serve;
-    }
-
-    async fn forward(&self, transaction: Bytes) -> anyhow::Result<Hash> {
-        #[cfg(feature = "metrics")]
-        let start = metrics::now();
-
-        let Some(blockchain_client) = &self.blockchain_client else {
-            return log_and_err!("SimpleConsensus.forward was called but no blockchain client is set");
-        };
-
-        let result = blockchain_client.send_raw_transaction(transaction.into()).await?;
-
-        #[cfg(feature = "metrics")]
-        metrics::inc_consensus_forward(start.elapsed());
-
-        let tx_hash = result.tx_hash;
-        let validator_url = &blockchain_client.http_url;
-        tracing::info!(%tx_hash, ?validator_url, "forwarded eth_sendRawTransaction to leader");
-
-        Ok(result.tx_hash)
+        Ok(chain)
     }
 }

--- a/src/eth/rpc/rpc_context.rs
+++ b/src/eth/rpc/rpc_context.rs
@@ -25,7 +25,7 @@ pub struct RpcContext {
     pub executor: Arc<Executor>,
     pub miner: Arc<Miner>,
     pub storage: Arc<StratusStorage>,
-    pub consensus: Arc<dyn Consensus>,
+    pub consensus: Option<Arc<dyn Consensus>>,
     pub rpc_server: RpcServerConfig,
     pub subs: Arc<RpcSubscriptionsConnected>,
 }


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Enhanced the `Consensus` trait by adding default methods for `should_serve` and `forward`, along with new methods `get_chain` and `lag`.
- Implemented the `Consensus` trait for `Importer`, `Raft`, and `SimpleConsensus` structs.
- Modified the `RpcContext` and RPC server to handle an optional `consensus`.
- Updated the `run` function in `main.rs` to initialize `consensus` as an `Option`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Enhance `Consensus` trait with default methods and error handling</code></dd></summary>
<hr>

src/eth/consensus/mod.rs

<li>Implemented default methods for <code>should_serve</code> and <code>forward</code> in the <br><code>Consensus</code> trait.<br> <li> Added <code>get_chain</code> and <code>lag</code> methods to the <code>Consensus</code> trait.<br> <li> Introduced error handling and logging for lag computation and <br>transaction forwarding.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1608/files#diff-f7df3d82112cd8c1758b7ccd906775c78e1cf8860f0d2ac7c0d6e5ad9ab92f80">+46/-3</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Implement `get_chain` and `lag` for `Raft` struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/consensus/raft/mod.rs

<li>Implemented <code>get_chain</code> and <code>lag</code> methods for <code>Raft</code> struct.<br> <li> Removed redundant <code>should_forward</code> method.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1608/files#diff-a97f8ca0266dcc08d5d35b9a26ff6ed4779ffd9c1c28d15f5eaf5df0ea3f3b00">+9/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Implement `get_chain` and `lag` for `SimpleConsensus` struct</code></dd></summary>
<hr>

src/eth/consensus/simple_consensus/mod.rs

<li>Implemented <code>get_chain</code> and <code>lag</code> methods for <code>SimpleConsensus</code> struct.<br> <li> Removed redundant <code>should_forward</code> and <code>should_serve</code> methods.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1608/files#diff-1e90f65af299635f914fa491d43baf6489043999984255392d25e4a99018d8fa">+9/-45</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>importer.rs</strong><dd><code>Implement `Consensus` trait for `Importer` struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/importer/importer.rs

<li>Implemented <code>Consensus</code> trait for <code>Importer</code> struct.<br> <li> Added <code>lag</code> and <code>get_chain</code> methods to <code>Importer</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1608/files#diff-bd1e1daf064cf0b404fe9ec14ab3d823de599043ef25944fabe29a4e3ee3e3d6">+13/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rpc_context.rs</strong><dd><code>Make `consensus` field optional in `RpcContext`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/rpc/rpc_context.rs

- Changed `consensus` field in `RpcContext` to be an `Option`.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1608/files#diff-a486ea1bd70eb81a959b89f514ed248a5c30fb4dabe7c08344b9bac246b6e92e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rpc_server.rs</strong><dd><code>Handle optional `consensus` in RPC server</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/rpc/rpc_server.rs

<li>Updated RPC server to handle optional <code>consensus</code>.<br> <li> Added checks for <code>None</code> value in <code>consensus</code> before calling methods.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1608/files#diff-835ba255c9a5c1fe0e13285bc39e058e1c74422e5e03ebba483c9d8a15c45405">+9/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>main.rs</strong><dd><code>Update `run` function to handle optional `consensus`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main.rs

<li>Updated <code>run</code> function to initialize <code>consensus</code> as an <code>Option</code>.<br> <li> Removed initialization of <code>SimpleConsensus</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1608/files#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fc">+2/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

