### PR TITLE
chore: fix typo

### DIFF
--- a/src/eth/consensus/mod.rs
+++ b/src/eth/consensus/mod.rs
@@ -24,7 +24,7 @@ pub trait Consensus: Send + Sync {
         let should_serve = lag <= 3;
 
         if !should_serve {
-            tracing::info!(?lag, "validator and replica are too far appart");
+            tracing::info!(?lag, "validator and replica are too far apart");
         }
 
         return should_serve;


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Corrected a typo in the log message within the `src/eth/consensus/mod.rs` file. The word "appart" was changed to "apart".


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Corrected typo in log message</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/consensus/mod.rs

- Fixed a typo in a log message.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1609/files#diff-f7df3d82112cd8c1758b7ccd906775c78e1cf8860f0d2ac7c0d6e5ad9ab92f80">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

