### PR TITLE
doc: fix components.svg

### DIFF
--- a/static/diagrams/components.pik
+++ b/static/diagrams/components.pik
@@ -54,8 +54,8 @@ BlockchainClient   : box "BlockchainClient" big big mono width $bw1 height $bh1 
 
 // App
 arrow from RpcServer.e right to RpcSubs.w // to RpcSubs
-arrow from RpcServer.s down $p/2 then left $p2 then down $p * 1.5 // to Executor
-arrow from RpcServer.s down $p/2 then right $p2 then down $p * 1.5 // to Miner
+arrow from RpcServer.s down $p/2 then left $p2 then down $p * 2.5 // to Executor
+arrow from RpcServer.s down $p/2 then right $p2 then down $p * 2.5 // to Miner
 arrow from RpcServer.n up $p2 then right until even with AppLayer.e then right $p then down until even with Storage.c then to Storage.e // to Storage
 arrow from RpcServer.t up $p2 then left until even with Consensus.c then to Consensus.t // to Consensus
 

--- a/static/diagrams/components.svg
+++ b/static/diagrams/components.svg
@@ -31,10 +31,10 @@
 <text x="239.34" y="240.45" text-anchor="middle" font-family="monospace" fill="rgb(0,0,0)" font-size="156.25%" dominant-baseline="central">BlockchainClient</text>
 <polygon points="1086.84,75.45 1075.32,79.77 1075.32,71.13" style="fill:rgb(0,0,0)"/>
 <path d="M1064.34,75.45L1081.08,75.45"  style="fill:none;stroke-width:2.16;stroke:rgb(0,0,0);" />
-<polygon points="876.84,139.2 872.52,127.68 881.16,127.68" style="fill:rgb(0,0,0)"/>
-<path d="M921.84,94.2L921.84,105.45L876.84,105.45L876.84,133.44"  style="fill:none;stroke-width:2.16;stroke-linejoin:round;stroke:rgb(0,0,0);" />
-<polygon points="966.84,139.2 962.52,127.68 971.16,127.68" style="fill:rgb(0,0,0)"/>
-<path d="M921.84,94.2L921.84,105.45L966.84,105.45L966.84,133.44"  style="fill:none;stroke-width:2.16;stroke-linejoin:round;stroke:rgb(0,0,0);" />
+<polygon points="876.84,161.7 872.52,150.18 881.16,150.18" style="fill:rgb(0,0,0)"/>
+<path d="M921.84,94.2L921.84,105.45L876.84,105.45L876.84,155.94"  style="fill:none;stroke-width:2.16;stroke-linejoin:round;stroke:rgb(0,0,0);" />
+<polygon points="966.84,161.7 962.52,150.18 971.16,150.18" style="fill:rgb(0,0,0)"/>
+<path d="M921.84,94.2L921.84,105.45L966.84,105.45L966.84,155.94"  style="fill:none;stroke-width:2.16;stroke-linejoin:round;stroke:rgb(0,0,0);" />
 <polygon points="1371.84,345.45 1383.36,341.13 1383.36,349.77" style="fill:rgb(0,0,0)"/>
 <path d="M921.84,56.7L921.84,11.7L1394.34,11.7L1416.84,11.7L1416.84,345.45L1377.6,345.45"  style="fill:none;stroke-width:2.16;stroke-linejoin:round;stroke:rgb(0,0,0);" />
 <polygon points="239.34,161.7 235.02,150.18 243.66,150.18" style="fill:rgb(0,0,0)"/>


### PR DESCRIPTION
### **PR Type**
documentation


___

### **Description**
- Adjusted the vertical positioning of arrows in the `components.pik` diagram file to ensure correct alignment from `RpcServer` to `Executor` and `Miner`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>components.pik</strong><dd><code>Fix arrow positioning in components diagram</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

static/diagrams/components.pik

<li>Adjusted the vertical positioning of arrows from <code>RpcServer</code> to <code>Executor</code> <br>and <code>Miner</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1615/files#diff-466fade544de55e446f1f1c83c54559c340312718569ccbf5e08c7273d0e3b9f">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

