### PR TITLE
fix: reintroduce #908

### DIFF
--- a/src/eth/storage/rocks/rocks_state.rs
+++ b/src/eth/storage/rocks/rocks_state.rs
@@ -191,21 +191,23 @@ impl RocksStorageState {
         let mut account_history_changes = Vec::new();
 
         for change in changes {
-            let address: AddressRocksdb = change.address.into();
-            let mut account_info_entry = accounts.get_or_insert_with(address, AccountRocksdb::default)?;
+            if change.is_account_modified() {
+                let address: AddressRocksdb = change.address.into();
+                let mut account_info_entry = accounts.get_or_insert_with(address, AccountRocksdb::default)?;
 
-            if let Some(nonce) = change.nonce.clone().take_modified() {
-                account_info_entry.nonce = nonce.into();
-            }
-            if let Some(balance) = change.balance.clone().take_modified() {
-                account_info_entry.balance = balance.into();
-            }
-            if let Some(bytecode) = change.bytecode.clone().take_modified() {
-                account_info_entry.bytecode = bytecode.map_into();
-            }
+                if let Some(nonce) = change.nonce.clone().take_modified() {
+                    account_info_entry.nonce = nonce.into();
+                }
+                if let Some(balance) = change.balance.clone().take_modified() {
+                    account_info_entry.balance = balance.into();
+                }
+                if let Some(bytecode) = change.bytecode.clone().take_modified() {
+                    account_info_entry.bytecode = bytecode.map_into();
+                }
 
-            account_changes.push((address, account_info_entry.clone()));
-            account_history_changes.push(((address, block_number.into()), account_info_entry));
+                account_changes.push((address, account_info_entry.clone()));
+                account_history_changes.push(((address, block_number.into()), account_info_entry));
+            }
         }
 
         accounts.prepare_batch_insertion(account_changes, batch)?;


### PR DESCRIPTION
### **User description**
this contribution was mistakenly removed by #871


___

### **PR Type**
Bug fix


___

### **Description**
- Reintroduced account change checks that were mistakenly removed in a previous commit.
- Added a conditional check to ensure account modifications are only processed when changes occur.
- Updated logic to push account changes and history changes only when modifications are detected.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rocks_state.rs</strong><dd><code>Reintroduce and conditionally check account changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/rocks/rocks_state.rs

<li>Reintroduced account change checks that were mistakenly removed.<br> <li> Wrapped account modifications in a conditional check.<br> <li> Ensured account changes are only pushed when modifications occur.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1617/files#diff-f7b822022d2c4fd93ec507cd6b5302dcf1646acbf0ee0dd077a047272b686009">+15/-13</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

