### PR TITLE
chore: simplify code

### DIFF
--- a/src/eth/rpc/rpc_parser.rs
+++ b/src/eth/rpc/rpc_parser.rs
@@ -58,6 +58,8 @@ where
 }
 
 /// Decode an RPC parameter encoded in RLP.
+///
+/// https://ethereum.org/en/developers/docs/data-structures-and-encoding/rlp
 pub fn parse_rpc_rlp<T: Decodable>(value: &[u8]) -> Result<T, StratusError> {
     match rlp::decode::<T>(value) {
         Ok(trx) => Ok(trx),


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Added a documentation link to the `parse_rpc_rlp` function in `rpc_parser.rs`.
- Simplified the `RocksStorageState` implementation by removing unnecessary clone operations and using `self` references directly.
- Updated iteration over transactions to use `iter().cloned()` instead of `clone()`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rpc_parser.rs</strong><dd><code>Add documentation link to `parse_rpc_rlp` function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/rpc/rpc_parser.rs

- Added a documentation link to the `parse_rpc_rlp` function.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1620/files#diff-2756485347ebcee6b3104300efc1ebc605d7ba6ede30878111e2a7d4dbe46b40">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rocks_state.rs</strong><dd><code>Simplify code by removing unnecessary clones and using `self`</code></dd></summary>
<hr>

src/eth/storage/rocks/rocks_state.rs

<li>Removed unnecessary clone operations.<br> <li> Simplified the iteration over transactions.<br> <li> Updated method calls to use <code>self</code> references directly.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1620/files#diff-f7b822022d2c4fd93ec507cd6b5302dcf1646acbf0ee0dd077a047272b686009">+6/-11</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

