### PR TITLE
chore: review error handling and remove unwraps 

### DIFF
--- a/src/bin/rpc_downloader.rs
+++ b/src/bin/rpc_downloader.rs
@@ -110,7 +110,7 @@ async fn download(
 ) -> anyhow::Result<()> {
     // calculate current block
     let mut current = match rpc_storage.read_max_block_number_in_range(start, end_inclusive).await? {
-        Some(number) => number.next(),
+        Some(number) => number.next_block_number(),
         None => start,
     };
     tracing::info!(%start, current = %current, end = %end_inclusive, "starting download task (might skip)");
@@ -170,7 +170,7 @@ async fn download(
                 continue;
             }
 
-            current = current.next();
+            current = current.next_block_number();
             break;
         }
     }

--- a/src/eth/follower/importer/importer.rs
+++ b/src/eth/follower/importer/importer.rs
@@ -347,7 +347,7 @@ impl Importer {
             while blocks_to_fetch > 0 {
                 blocks_to_fetch -= 1;
                 tasks.push(fetch_block_and_receipts(Arc::clone(&chain), importer_block_number));
-                importer_block_number = importer_block_number.next();
+                importer_block_number = importer_block_number.next_block_number();
             }
 
             // keep fetching in order

--- a/src/eth/miner/miner.rs
+++ b/src/eth/miner/miner.rs
@@ -427,8 +427,12 @@ mod interval_miner_ticker {
         const TASK_NAME: &str = "interval-miner-ticker";
 
         // sync to next second
-        let next_second = (Utc::now() + Duration::from_secs(1)).with_nanosecond(0).unwrap();
-        thread::sleep((next_second - Utc::now()).to_std().unwrap());
+        let next_second = (Utc::now() + Duration::from_secs(1))
+            .with_nanosecond(0)
+            .expect("nanosecond above is set to `0`, which is always less than 2 billion");
+
+        let time_to_sleep = (next_second - Utc::now()).to_std().unwrap_or_default();
+        thread::sleep(time_to_sleep);
 
         // prepare ticker
         let mut ticker = tokio::time::interval(block_time);

--- a/src/eth/miner/miner.rs
+++ b/src/eth/miner/miner.rs
@@ -440,7 +440,6 @@ mod interval_miner_ticker {
             ticker.tick().await;
             loop {
                 if GlobalState::is_shutdown_warn(TASK_NAME) {
-                    println!("e");
                     return;
                 }
 

--- a/src/eth/miner/miner.rs
+++ b/src/eth/miner/miner.rs
@@ -252,7 +252,7 @@ impl Miner {
 fn mine_external_transactions(block_number: BlockNumber, txs: Vec<ExternalTransactionExecution>) -> anyhow::Result<Vec<TransactionMined>> {
     let mut mined_txs = Vec::with_capacity(txs.len());
     for tx in txs {
-        if tx.tx.block_number() != block_number {
+        if tx.tx.block_number()? != block_number {
             return log_and_err!("failed to mine external block because one of the transactions does not belong to the external block");
         }
         mined_txs.push(TransactionMined::from_external(tx.tx, tx.receipt, tx.evm_execution.execution)?);

--- a/src/eth/primitives/block_number.rs
+++ b/src/eth/primitives/block_number.rs
@@ -59,7 +59,7 @@ impl BlockNumber {
     }
 
     /// Returns the next block number.
-    pub fn next(&self) -> Self {
+    pub fn next_block_number(&self) -> Self {
         Self(self.0 + 1)
     }
 

--- a/src/eth/primitives/code_hash.rs
+++ b/src/eth/primitives/code_hash.rs
@@ -59,10 +59,3 @@ impl From<FixedBytes<32>> for CodeHash {
         CodeHash::new(value.0.into())
     }
 }
-
-impl From<Vec<u8>> for CodeHash {
-    fn from(value: Vec<u8>) -> Self {
-        let value: &[u8; 32] = value.as_slice().try_into().unwrap();
-        CodeHash::new(value.into())
-    }
-}

--- a/src/eth/primitives/execution.rs
+++ b/src/eth/primitives/execution.rs
@@ -59,8 +59,12 @@ impl EvmExecution {
         }
 
         // generate sender changes incrementing the nonce
-        let mut sender_changes = ExecutionAccountChanges::from_original_values(sender);
-        let sender_next_nonce = sender_changes.nonce.take_original_ref().unwrap().next();
+        let mut sender_changes = ExecutionAccountChanges::from_original_values(sender); // NOTE: don't change from_original_values without updating .expect() below
+        let sender_next_nonce = sender_changes
+            .nonce
+            .take_original_ref()
+            .expect("from_original_values populates original values, so taking original ref here will succeed")
+            .next();
         sender_changes.nonce.set_modified(sender_next_nonce);
 
         // crete execution and apply costs

--- a/src/eth/primitives/execution.rs
+++ b/src/eth/primitives/execution.rs
@@ -64,7 +64,7 @@ impl EvmExecution {
             .nonce
             .take_original_ref()
             .expect("from_original_values populates original values, so taking original ref here will succeed")
-            .next();
+            .next_nonce();
         sender_changes.nonce.set_modified(sender_next_nonce);
 
         // crete execution and apply costs

--- a/src/eth/primitives/execution_conflict.rs
+++ b/src/eth/primitives/execution_conflict.rs
@@ -36,11 +36,7 @@ impl ExecutionConflictsBuilder {
 
     /// Builds the list of tracked conflicts into a non-empty list of conflicts.
     pub fn build(self) -> Option<ExecutionConflicts> {
-        if self.0.is_empty() {
-            None
-        } else {
-            Some(ExecutionConflicts(NonEmpty::from_vec(self.0).unwrap()))
-        }
+        NonEmpty::from_vec(self.0).map(ExecutionConflicts)
     }
 }
 

--- a/src/eth/primitives/external_transaction.rs
+++ b/src/eth/primitives/external_transaction.rs
@@ -2,14 +2,17 @@ use crate::alias::EthersTransaction;
 use crate::eth::primitives::BlockNumber;
 use crate::eth::primitives::Hash;
 
-#[derive(Debug, Clone, Default, derive_more:: Deref, serde::Deserialize, serde::Serialize)]
+use anyhow::Context;
+use anyhow::Result;
+
+#[derive(Debug, Clone, Default, derive_more::Deref, serde::Deserialize, serde::Serialize)]
 #[serde(transparent)]
 pub struct ExternalTransaction(#[deref] pub EthersTransaction);
 
 impl ExternalTransaction {
     /// Returns the block number where the transaction was mined.
-    pub fn block_number(&self) -> BlockNumber {
-        self.0.block_number.unwrap().into()
+    pub fn block_number(&self) -> Result<BlockNumber> {
+        Ok(self.0.block_number.context("ExternalTransaction has no block_number")?.into())
     }
 
     /// Returns the transaction hash.

--- a/src/eth/primitives/external_transaction.rs
+++ b/src/eth/primitives/external_transaction.rs
@@ -1,9 +1,9 @@
+use anyhow::Context;
+use anyhow::Result;
+
 use crate::alias::EthersTransaction;
 use crate::eth::primitives::BlockNumber;
 use crate::eth::primitives::Hash;
-
-use anyhow::Context;
-use anyhow::Result;
 
 #[derive(Debug, Clone, Default, derive_more::Deref, serde::Deserialize, serde::Serialize)]
 #[serde(transparent)]

--- a/src/eth/primitives/log_mined.rs
+++ b/src/eth/primitives/log_mined.rs
@@ -93,9 +93,11 @@ impl From<LogMined> for EthersLog {
     }
 }
 
-impl From<LogMined> for SubscriptionMessage {
-    fn from(value: LogMined) -> Self {
+impl TryFrom<LogMined> for SubscriptionMessage {
+    type Error = serde_json::Error;
+
+    fn try_from(value: LogMined) -> Result<Self, Self::Error> {
         let ethers_log = Into::<EthersLog>::into(value);
-        Self::from_json(&ethers_log).unwrap()
+        Self::from_json(&ethers_log)
     }
 }

--- a/src/eth/primitives/nonce.rs
+++ b/src/eth/primitives/nonce.rs
@@ -22,7 +22,7 @@ impl Nonce {
     }
 
     /// Returns the next nonce.
-    pub fn next(&self) -> Self {
+    pub fn next_nonce(&self) -> Self {
         Self(self.0 + 1)
     }
 

--- a/src/eth/rpc/rpc_middleware.rs
+++ b/src/eth/rpc/rpc_middleware.rs
@@ -33,7 +33,7 @@ use crate::eth::rpc::rpc_parser::RpcExtensionsExt;
 use crate::eth::rpc::RpcClientApp;
 use crate::event_with;
 use crate::ext::from_json_str;
-use crate::ext::to_json_value;
+use crate::ext::to_json_string;
 #[cfg(feature = "metrics")]
 use crate::if_else;
 use crate::infra::metrics;
@@ -103,7 +103,7 @@ impl<'a> RpcServiceT<'a> for RpcMiddleware {
             rpc_client = %client,
             rpc_id = %request.id,
             rpc_method = %method,
-            rpc_params = %to_json_value(&request.params),
+            rpc_params = %to_json_string(&request.params),
             rpc_tx_hash = %tx.as_ref().and_then(|tx|tx.hash).or_empty(),
             rpc_tx_contract = %tx.as_ref().map(|tx|tx.contract).or_empty(),
             rpc_tx_function = %tx.as_ref().map(|tx|tx.function).or_empty(),

--- a/src/eth/storage/inmemory/inmemory_history.rs
+++ b/src/eth/storage/inmemory/inmemory_history.rs
@@ -39,13 +39,9 @@ where
     }
 
     /// Resets changes to the specified block number.
-    pub fn reset_at(&self, block_number: BlockNumber) -> Option<InMemoryHistory<T>> {
+    pub fn reset_at(&self, block_number: BlockNumber) -> Option<Self> {
         let history = self.0.iter().filter(|x| x.block_number <= block_number).cloned().collect_vec();
-        if history.is_empty() {
-            None
-        } else {
-            Some(Self(NonEmpty::from_vec(history).unwrap()))
-        }
+        NonEmpty::from_vec(history).map(Self)
     }
 
     /// Returns the value at the given point in time.

--- a/src/eth/storage/inmemory/inmemory_temporary.rs
+++ b/src/eth/storage/inmemory/inmemory_temporary.rs
@@ -208,7 +208,7 @@ impl TemporaryStorage for InMemoryTemporaryStorage {
 
         // create new state
         states.insert(0, InMemoryTemporaryStorageState::default());
-        states.head.block = Some(PendingBlock::new(finished_block.number.next()));
+        states.head.block = Some(PendingBlock::new(finished_block.number.next_block_number()));
 
         Ok(finished_block)
     }

--- a/src/eth/storage/redis/redis_permanent.rs
+++ b/src/eth/storage/redis/redis_permanent.rs
@@ -18,6 +18,7 @@ use crate::eth::primitives::TransactionMined;
 use crate::eth::storage::PermanentStorage;
 use crate::eth::storage::StoragePointInTime;
 use crate::ext::from_json_str;
+use crate::ext::to_json_object;
 use crate::ext::to_json_string;
 use crate::ext::to_json_value;
 use crate::log_and_err;
@@ -117,8 +118,8 @@ impl PermanentStorage for RedisPermanentStorage {
                 }
 
                 // add block number to force slot modification
-                let mut account_value = to_json_value(&account);
-                account_value.as_object_mut().unwrap().insert("block".to_owned(), to_json_value(block.number()));
+                let mut account_value = to_json_object(&account);
+                account_value.insert("block".to_owned(), to_json_value(block.number()));
                 let account_value = to_json_string(&account_value);
 
                 mset_values.push((key_account(&account.address), account_value.clone()));

--- a/src/eth/storage/rocks/rocks_state.rs
+++ b/src/eth/storage/rocks/rocks_state.rs
@@ -148,11 +148,9 @@ impl RocksStorageState {
     }
 
     /// Get the filename of the database path.
-    ///
-    /// Should be checked on creation.
     #[cfg(feature = "metrics")]
     fn db_path_filename(&self) -> &str {
-        self.db.path().file_name().unwrap().to_str().unwrap()
+        self.db_path.rsplit('/').next().unwrap_or(&self.db_path)
     }
 
     pub fn preload_block_number(&self) -> Result<AtomicU64> {

--- a/src/eth/storage/rocks/rocks_state.rs
+++ b/src/eth/storage/rocks/rocks_state.rs
@@ -586,17 +586,19 @@ impl fmt::Debug for RocksStorageState {
 #[cfg(test)]
 mod tests {
     use std::collections::HashSet;
-    use std::fs;
 
     use fake::Fake;
     use fake::Faker;
+    use tempfile::tempdir;
 
     use super::*;
     use crate::eth::primitives::SlotValue;
 
     #[test]
     fn test_rocks_multi_get() {
-        let (db, _db_options) = create_or_open_db("./data/slots_test.rocksdb", &CF_OPTIONS_MAP).unwrap();
+        let test_dir = tempdir().unwrap();
+
+        let (db, _db_options) = create_or_open_db(test_dir.path(), &CF_OPTIONS_MAP).unwrap();
         let account_slots: RocksCfRef<SlotIndex, SlotValue> = new_cf_ref(&db, "account_slots").unwrap();
 
         let slots: HashMap<SlotIndex, SlotValue> = (0..1000).map(|_| (Faker.fake(), Faker.fake())).collect();
@@ -622,7 +624,5 @@ mod tests {
         for (idx, value) in result {
             assert_eq!(value, *slots.get(&idx).expect("should not be None"));
         }
-
-        fs::remove_dir_all("./data/slots_test.rocksdb").unwrap();
     }
 }

--- a/src/eth/storage/stratus_storage.rs
+++ b/src/eth/storage/stratus_storage.rs
@@ -115,7 +115,7 @@ impl StratusStorage {
         match mined_block {
             Some(_) => {
                 tracing::info!(block_number = %mined_number, reason = %"set in storage and block exist", "resume from MINED + 1");
-                Ok(mined_number.next())
+                Ok(mined_number.next_block_number())
             }
             None => {
                 tracing::info!(block_number = %mined_number, reason = %"set in storage but block does not exist", "resume from MINED");
@@ -174,7 +174,7 @@ impl StratusStorage {
         let _span = tracing::info_span!("storage::set_pending_block_number_as_next").entered();
 
         let last_mined_block = self.read_mined_block_number()?;
-        self.set_pending_block_number(last_mined_block.next())?;
+        self.set_pending_block_number(last_mined_block.next_block_number())?;
         Ok(())
     }
 
@@ -374,7 +374,7 @@ impl StratusStorage {
 
         // check mined number
         let mined_number = self.read_mined_block_number()?;
-        if not(block_number.is_zero()) && block_number != mined_number.next() {
+        if not(block_number.is_zero()) && block_number != mined_number.next_block_number() {
             tracing::error!(%block_number, %mined_number, "failed to save block because mismatch with mined block number");
             return Err(StratusError::StorageMinedNumberConflict {
                 new: block_number,

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -37,7 +37,7 @@ pub fn not(value: bool) -> bool {
 /// Extracts only the basename of a Rust type instead of the full qualification.
 pub fn type_basename<T>() -> &'static str {
     let name: &'static str = std::any::type_name::<T>();
-    name.split("::").last().unwrap()
+    name.rsplit("::").next().unwrap_or(name)
 }
 
 // -----------------------------------------------------------------------------

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -290,6 +290,17 @@ pub fn to_json_value<V: serde::Serialize>(value: V) -> serde_json::Value {
     serde_json::to_value(value).expect_infallible()
 }
 
+/// Serializes any serializable value to [`serde_json::Map`] without having to check for errors.
+pub fn to_json_object<V: serde::Serialize>(value: V) -> serde_json::Map<String, serde_json::Value> {
+    match serde_json::to_value(value).expect_infallible() {
+        serde_json::Value::Object(map) => map,
+        _ => unreachable!(
+            "to_json_object called with type {} which didn't serialize to a JSON object",
+            type_basename::<V>(),
+        ),
+    }
+}
+
 /// Deserializes any deserializable value from [`&str`] without having to check for errors.
 pub fn from_json_str<T: serde::de::DeserializeOwned>(s: &str) -> T {
     serde_json::from_str::<T>(s).expect_infallible()


### PR DESCRIPTION
### **User description**
In this PR I try removing unwraps, or, when not possible, replacing them by expect with a message of why that isn't going to fail.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Improved error handling across multiple modules by replacing `unwrap()` calls with proper error handling mechanisms.
- Enhanced the `ExternalTransaction` struct to return `Result<BlockNumber>` instead of unwrapping.
- Implemented `TryFrom` trait for `SubscriptionMessage` conversion to handle potential serialization errors.
- Simplified and optimized various utility functions and methods, including JSON handling and type manipulations.
- Improved RPC logging by using pretty-printed JSON strings.
- Enhanced test suite by using temporary directories and removing unnecessary file system operations.
- Refactored JSON object manipulations in Redis storage for better efficiency.
- Simplified `InMemoryHistory` and `ExecutionConflictsBuilder` implementations.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>miner.rs</strong><dd><code>Enhance error handling in miner module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/miner/miner.rs

<li>Replaced unwraps with error handling in <code>block_number()</code> call<br> <li> Improved error handling in time-related operations<br> <li> Removed unnecessary print statement<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1624/files#diff-16f448afc7dae3e8e802f676a86dbd7051e19f6c17cbbeb53eb730d726372629">+7/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>execution.rs</strong><dd><code>Enhance error handling in EvmExecution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/execution.rs

<li>Improved error handling in <code>EvmExecution</code> implementation<br> <li> Added explanatory comments for error handling<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1624/files#diff-cd13932ed3cbc97c18547275105d872a204eda4ad4bf0c2811b18553b48e9038">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>external_transaction.rs</strong><dd><code>Improve error handling in ExternalTransaction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/external_transaction.rs

<li>Changed <code>block_number()</code> method to return <code>Result<BlockNumber></code><br> <li> Added context to error handling<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1624/files#diff-a5bcf577600cee6a4844b4015797a92684df8ec490f06f66b4a556881a66032d">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>log_mined.rs</strong><dd><code>Implement TryFrom for SubscriptionMessage conversion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/log_mined.rs

<li>Changed <code>From</code> implementation to <code>TryFrom</code> for <code>SubscriptionMessage</code><br> <li> Added error handling for JSON serialization<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1624/files#diff-0ce210a69394a14d9a6424cf5ddf8b84c10a535b9ecae1dd34c0dbcff4beaf07">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rpc_subscriptions.rs</strong><dd><code>Improve error handling in RPC subscriptions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/rpc/rpc_subscriptions.rs

<li>Enhanced <code>notify</code> function to handle conversion errors<br> <li> Implemented generic error handling for message conversion<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1624/files#diff-a07ba1157cec6586a0520b8dfb11e9d073359af24471ac286ff5eaa2669d355c">+14/-2</a>&nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>code_hash.rs</strong><dd><code>Remove unused CodeHash conversion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/code_hash.rs

- Removed unnecessary `From<Vec<u8>>` implementation for `CodeHash`



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1624/files#diff-588f5e271548cdb222c974e0c5b540e707b96f69ce5f3d7bd36b9e0572f692d8">+0/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>execution_conflict.rs</strong><dd><code>Simplify ExecutionConflictsBuilder</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/execution_conflict.rs

- Simplified `build()` method in `ExecutionConflictsBuilder`



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1624/files#diff-989664061f5331343a7fe685e7bbc19f01044105c3e966afd41233c163671df1">+1/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rpc_middleware.rs</strong><dd><code>Improve RPC logging format</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/rpc/rpc_middleware.rs

- Changed `to_json_value` to `to_json_string_pretty` for logging



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1624/files#diff-31b7182aec4416845e60ec9ec16720ae97d31260e1a9c50d601d542dee8776f5">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>inmemory_history.rs</strong><dd><code>Simplify InMemoryHistory reset logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/inmemory/inmemory_history.rs

- Simplified `reset_at` method using `NonEmpty::from_vec`



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1624/files#diff-322061156099977548ec07fa5d628c583d880f23259fdb3a53fd4e2ad9a21789">+2/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>redis_permanent.rs</strong><dd><code>Refactor JSON handling in Redis storage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/redis/redis_permanent.rs

<li>Replaced <code>to_json_value</code> with <code>to_json_object</code> for account modification<br> <li> Simplified JSON object manipulation<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1624/files#diff-068ece78c4a374a891db1f4759a7a035df7aa981bf04c3bffecfd44e94f5841b">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rocks_state.rs</strong><dd><code>Improve RocksDB state handling and testing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/rocks/rocks_state.rs

<li>Simplified <code>db_path_filename</code> method<br> <li> Updated test to use temporary directory<br> <li> Removed unnecessary file system cleanup<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1624/files#diff-f7b822022d2c4fd93ec507cd6b5302dcf1646acbf0ee0dd077a047272b686009">+5/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ext.rs</strong><dd><code>Enhance JSON handling and type utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/ext.rs

<li>Enhanced <code>type_basename</code> function to handle edge cases<br> <li> Added <code>to_json_object</code> function for JSON object serialization<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1624/files#diff-4ff673578dd06edb71da19750f05cb48bbbd3c78ded3dbeda59409354c35cef6">+12/-1</a>&nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

