### PR TITLE
perf: skip conflict checks for external transactions

### DIFF
--- a/src/eth/executor/executor.rs
+++ b/src/eth/executor/executor.rs
@@ -334,7 +334,7 @@ impl Executor {
 
         // persist state
         let tx_execution = TransactionExecution::External(tx_execution);
-        self.miner.save_execution(tx_execution)?;
+        self.miner.save_execution(tx_execution, false)?;
 
         // track metrics
         #[cfg(feature = "metrics")]
@@ -497,7 +497,7 @@ impl Executor {
             // save execution to temporary storage
             // in case of failure, retry if conflict or abandon if unexpected error
             let tx_execution = TransactionExecution::new_local(tx_input.clone(), evm_result.clone());
-            match self.miner.save_execution(tx_execution.clone()) {
+            match self.miner.save_execution(tx_execution.clone(), true) {
                 Ok(_) => {
                     return Ok(tx_execution);
                 }

--- a/src/eth/miner/miner.rs
+++ b/src/eth/miner/miner.rs
@@ -92,7 +92,7 @@ impl Miner {
     }
 
     /// Persists a transaction execution.
-    pub fn save_execution(&self, tx_execution: TransactionExecution) -> Result<(), StratusError> {
+    pub fn save_execution(&self, tx_execution: TransactionExecution, check_conflicts: bool) -> Result<(), StratusError> {
         // track
         #[cfg(feature = "tracing")]
         let _span = info_span!("miner::save_execution", tx_hash = %tx_execution.hash()).entered();
@@ -106,7 +106,7 @@ impl Miner {
 
         // save execution to temporary storage
         let tx_hash = tx_execution.hash();
-        self.storage.save_execution(tx_execution)?;
+        self.storage.save_execution(tx_execution, check_conflicts)?;
 
         // if automine is enabled, automatically mines a block
         let _ = self.notifier_pending_txs.send(tx_hash);

--- a/src/eth/storage/stratus_storage.rs
+++ b/src/eth/storage/stratus_storage.rs
@@ -324,12 +324,12 @@ impl StratusStorage {
     // Blocks
     // -------------------------------------------------------------------------
 
-    pub fn save_execution(&self, tx: TransactionExecution) -> Result<(), StratusError> {
+    pub fn save_execution(&self, tx: TransactionExecution, check_conflicts: bool) -> Result<(), StratusError> {
         #[cfg(feature = "tracing")]
         let _span = tracing::info_span!("storage::save_execution", tx_hash = %tx.hash()).entered();
         tracing::debug!(storage = %label::TEMP, tx_hash = %tx.hash(), "saving execution");
 
-        timed(|| self.temp.save_execution(tx))
+        timed(|| self.temp.save_execution(tx, check_conflicts))
             .with(|m| {
                 metrics::inc_storage_save_execution(m.elapsed, label::TEMP, m.result.is_ok());
                 if let Err(ref e) = m.result {

--- a/src/eth/storage/temporary_storage.rs
+++ b/src/eth/storage/temporary_storage.rs
@@ -36,7 +36,7 @@ pub trait TemporaryStorage: Send + Sync + 'static {
     fn set_pending_external_block(&self, block: ExternalBlock) -> anyhow::Result<()>;
 
     /// Saves a re-executed transaction to the pending mined block.
-    fn save_execution(&self, tx: TransactionExecution) -> Result<(), StratusError>;
+    fn save_execution(&self, tx: TransactionExecution, check_conflicts: bool) -> Result<(), StratusError>;
 
     /// Retrieves the pending transactions of the pending block.
     fn pending_transactions(&self) -> anyhow::Result<Vec<TransactionExecution>>;


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Introduced a new `check_conflicts` boolean parameter in the `save_execution` method across multiple components (executor, miner, storage).
- Implemented conditional conflict checking for transaction executions, allowing skipping of conflict checks for external transactions.
- Updated the `TemporaryStorage` trait to include the new `check_conflicts` parameter.
- Renamed internal functions in the inmemory storage implementation for better clarity (e.g., `read_account` to `do_read_account`).
- Modified the executor to pass `false` for external transactions and `true` for local transactions when calling `save_execution`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>executor.rs</strong><dd><code>Update save_execution calls with conflict check flag</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/executor/executor.rs

<li>Modified <code>save_execution</code> calls to include a new boolean parameter <code>false</code> <br>for external transactions and <code>true</code> for local transactions.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1627/files#diff-6b460d7dee8280c0287e8d9d9d59cf66a57ec9fed1bc003c6ede6fef60c7376b">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>miner.rs</strong><dd><code>Add conflict check flag to miner's save_execution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/miner/miner.rs

<li>Added a new <code>check_conflicts</code> parameter to the <code>save_execution</code> method.<br> <li> Updated the <code>save_execution</code> call to the storage to include the <br><code>check_conflicts</code> parameter.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1627/files#diff-16f448afc7dae3e8e802f676a86dbd7051e19f6c17cbbeb53eb730d726372629">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>inmemory_temporary.rs</strong><dd><code>Implement conditional conflict checking in inmemory storage</code></dd></summary>
<hr>

src/eth/storage/inmemory/inmemory_temporary.rs

<li>Added <code>check_conflicts</code> parameter to <code>save_execution</code> method.<br> <li> Introduced conditional conflict checking based on the new parameter.<br> <li> Renamed internal functions with 'do_' prefix for clarity.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1627/files#diff-6f4ee832c01927be4b428028743a37022368d351f09fd177f59e81a5a58dd661">+12/-10</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>stratus_storage.rs</strong><dd><code>Update stratus storage to support conditional conflict checks</code></dd></summary>
<hr>

src/eth/storage/stratus_storage.rs

<li>Updated <code>save_execution</code> method to include the <code>check_conflicts</code> <br>parameter.<br> <li> Modified the call to <code>self.temp.save_execution</code> to pass the new <br>parameter.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1627/files#diff-3b2e36e47959decdfe26b2c4fab90b41f9242bfdad29cc43b2377ee851f4f40a">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>temporary_storage.rs</strong><dd><code>Add conflict check parameter to TemporaryStorage trait</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/temporary_storage.rs

<li>Modified the <code>save_execution</code> trait method to include the <br><code>check_conflicts</code> parameter.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1627/files#diff-58337f46f036f808e0166f195e0ed5dfbfdc092fc1665c3424f01d799a5195de">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

