### PR TITLE
perf: do not depend on entire block

### DIFF
--- a/src/eth/executor/evm_input.rs
+++ b/src/eth/executor/evm_input.rs
@@ -6,7 +6,6 @@ use crate::eth::primitives::BlockNumber;
 use crate::eth::primitives::Bytes;
 use crate::eth::primitives::CallInput;
 use crate::eth::primitives::ChainId;
-use crate::eth::primitives::ExternalBlock;
 use crate::eth::primitives::ExternalReceipt;
 use crate::eth::primitives::ExternalTransaction;
 use crate::eth::primitives::Gas;
@@ -132,7 +131,7 @@ impl EvmInput {
     /// Creates a transaction that was executed in an external blockchain and imported to Stratus.
     ///
     /// Successful external transactions executes with max gas and zero gas price to ensure we will have the same execution result.
-    pub fn from_external(tx: &ExternalTransaction, receipt: &ExternalReceipt, block: &ExternalBlock) -> anyhow::Result<Self> {
+    pub fn from_external(tx: &ExternalTransaction, receipt: &ExternalReceipt, block_number: BlockNumber, block_timestamp: UnixTime) -> anyhow::Result<Self> {
         Ok(Self {
             from: tx.0.from.into(),
             to: tx.0.to.map_into(),
@@ -142,8 +141,8 @@ impl EvmInput {
             gas_limit: if_else!(receipt.is_success(), Gas::MAX, tx.0.gas.try_into()?),
             gas_price: if_else!(receipt.is_success(), Wei::ZERO, tx.0.gas_price.map_into().unwrap_or(Wei::ZERO)),
             point_in_time: StoragePointInTime::Pending,
-            block_number: block.number(),
-            block_timestamp: block.timestamp(),
+            block_number,
+            block_timestamp,
             chain_id: match tx.0.chain_id {
                 Some(chain_id) => Some(chain_id.try_into()?),
                 None => None,

--- a/src/eth/executor/executor.rs
+++ b/src/eth/executor/executor.rs
@@ -246,7 +246,7 @@ impl Executor {
                 tx,
                 receipt,
                 block_number,
-                block_timpestamp,
+                block_timestamp,
                 #[cfg(feature = "metrics")]
                 &mut block_metrics,
             )?;

--- a/src/eth/executor/executor.rs
+++ b/src/eth/executor/executor.rs
@@ -235,7 +235,7 @@ impl Executor {
 
         // track pending block
         let block_number = block.number();
-        let block_timpestamp = block.timestamp();
+        let block_timestamp = block.timestamp();
         self.storage.set_pending_external_block(block.clone())?;
         self.storage.set_pending_block_number(block_number)?;
 

--- a/src/eth/executor/executor.rs
+++ b/src/eth/executor/executor.rs
@@ -16,6 +16,7 @@ use crate::eth::executor::EvmInput;
 use crate::eth::executor::ExecutorConfig;
 use crate::eth::miner::Miner;
 use crate::eth::primitives::BlockFilter;
+use crate::eth::primitives::BlockNumber;
 use crate::eth::primitives::CallInput;
 use crate::eth::primitives::EvmExecution;
 use crate::eth::primitives::EvmExecutionMetrics;
@@ -27,6 +28,7 @@ use crate::eth::primitives::ExternalTransactionExecution;
 use crate::eth::primitives::StratusError;
 use crate::eth::primitives::TransactionExecution;
 use crate::eth::primitives::TransactionInput;
+use crate::eth::primitives::UnixTime;
 use crate::eth::storage::StoragePointInTime;
 use crate::eth::storage::StratusStorage;
 use crate::ext::spawn_thread;
@@ -231,10 +233,11 @@ impl Executor {
         let _span = info_span!("executor::external_block", block_number = %block.number()).entered();
         tracing::info!(block_number = %block.number(), "reexecuting external block");
 
-        // track pending block number
-        let storage = &self.storage;
-        storage.set_pending_external_block(block.clone())?;
-        storage.set_pending_block_number(block.number())?;
+        // track pending block
+        let block_number = block.number();
+        let block_timpestamp = block.timestamp();
+        self.storage.set_pending_external_block(block.clone())?;
+        self.storage.set_pending_block_number(block_number)?;
 
         // determine how to execute each transaction
         for tx in &block.transactions {
@@ -242,7 +245,8 @@ impl Executor {
             self.execute_external_transaction(
                 tx,
                 receipt,
-                block,
+                block_number,
+                block_timpestamp,
                 #[cfg(feature = "metrics")]
                 &mut block_metrics,
             )?;
@@ -267,7 +271,8 @@ impl Executor {
         &self,
         tx: &ExternalTransaction,
         receipt: &ExternalReceipt,
-        block: &ExternalBlock,
+        block_number: BlockNumber,
+        block_timestamp: UnixTime,
         #[cfg(feature = "metrics")] block_metrics: &mut EvmExecutionMetrics,
     ) -> anyhow::Result<()> {
         // track
@@ -275,7 +280,7 @@ impl Executor {
         let start = metrics::now();
         #[cfg(feature = "tracing")]
         let _span = info_span!("executor::external_transaction", tx_hash = %tx.hash).entered();
-        tracing::info!(block_number = %block.number(), tx_hash = %tx.hash(), "reexecuting external transaction");
+        tracing::info!(%block_number, tx_hash = %tx.hash(), "reexecuting external transaction");
 
         // when transaction externally failed, create fake transaction instead of reexecuting
         let tx_execution = match receipt.is_success() {
@@ -283,7 +288,7 @@ impl Executor {
             // successful external transaction, re-execute locally
             true => {
                 // re-execute transaction
-                let evm_input = EvmInput::from_external(tx, receipt, block)?;
+                let evm_input = EvmInput::from_external(tx, receipt, block_number, block_timestamp)?;
                 let evm_execution = self.evms.execute(evm_input.clone(), EvmRoute::External);
 
                 // handle re-execution result
@@ -292,7 +297,7 @@ impl Executor {
                     Err(e) => {
                         let json_tx = to_json_string(&tx);
                         let json_receipt = to_json_string(&receipt);
-                        tracing::error!(reason = ?e, block_number = %block.number(), tx_hash = %tx.hash(), %json_tx, %json_receipt, "failed to reexecute external transaction");
+                        tracing::error!(reason = ?e, %block_number, tx_hash = %tx.hash(), %json_tx, %json_receipt, "failed to reexecute external transaction");
                         return Err(e.into());
                     }
                 };
@@ -305,7 +310,7 @@ impl Executor {
                     let json_tx = to_json_string(&tx);
                     let json_receipt = to_json_string(&receipt);
                     let json_execution_logs = to_json_string(&evm_execution.execution.logs);
-                    tracing::error!(reason = %"mismatch reexecuting transaction", block_number = %block.number(), tx_hash = %tx.hash(), %json_tx, %json_receipt, %json_execution_logs, "failed to reexecute external transaction");
+                    tracing::error!(reason = %"mismatch reexecuting transaction", %block_number, tx_hash = %tx.hash(), %json_tx, %json_receipt, %json_execution_logs, "failed to reexecute external transaction");
                     return Err(e);
                 };
 
@@ -315,7 +320,7 @@ impl Executor {
             // failed external transaction, re-cretea from receipt without re-executing
             false => {
                 let sender = self.storage.read_account(&receipt.from.into(), &StoragePointInTime::Pending)?;
-                let execution = EvmExecution::from_failed_external_transaction(sender, receipt, block)?;
+                let execution = EvmExecution::from_failed_external_transaction(sender, receipt, block_timestamp)?;
                 let evm_result = EvmExecutionResult {
                     execution,
                     metrics: EvmExecutionMetrics::default(),

--- a/src/eth/primitives/execution.rs
+++ b/src/eth/primitives/execution.rs
@@ -10,7 +10,6 @@ use crate::eth::primitives::Address;
 use crate::eth::primitives::Bytes;
 use crate::eth::primitives::ExecutionAccountChanges;
 use crate::eth::primitives::ExecutionResult;
-use crate::eth::primitives::ExternalBlock;
 use crate::eth::primitives::ExternalReceipt;
 use crate::eth::primitives::Gas;
 use crate::eth::primitives::Log;
@@ -51,7 +50,7 @@ pub struct EvmExecution {
 
 impl EvmExecution {
     /// Creates an execution from an external transaction that failed.
-    pub fn from_failed_external_transaction(sender: Account, receipt: &ExternalReceipt, block: &ExternalBlock) -> anyhow::Result<Self> {
+    pub fn from_failed_external_transaction(sender: Account, receipt: &ExternalReceipt, block_timestamp: UnixTime) -> anyhow::Result<Self> {
         if receipt.is_success() {
             return log_and_err!("cannot create failed execution for successful transaction");
         }
@@ -66,7 +65,7 @@ impl EvmExecution {
 
         // crete execution and apply costs
         let mut execution = Self {
-            block_timestamp: block.timestamp(),
+            block_timestamp,
             receipt_applied: false,
             result: ExecutionResult::new_reverted(), // assume it reverted
             output: Bytes::default(),                // we cannot really know without performing an eth_call to the external system


### PR DESCRIPTION
### **User description**
Fist step to remove unnecessary `ExternalBlock` clones is receiving only the necessary external block fields, usually number and timestamp, in functions instead of a reference to the entire external block.


___

### **PR Type**
Enhancement, Performance


___

### **Description**
- Reduced dependency on `ExternalBlock` across multiple files, improving performance by avoiding unnecessary cloning.
- Refactored functions to accept specific block properties (number and timestamp) instead of the entire block object.
- Updated `EvmInput`, `Executor`, and `EvmExecution` to work with individual block properties.
- Optimized error logging and execution tracking to use specific block information.
- Removed unused imports related to `ExternalBlock`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>evm_input.rs</strong><dd><code>Refactor EvmInput to reduce ExternalBlock dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/executor/evm_input.rs

<li>Removed dependency on <code>ExternalBlock</code><br> <li> Modified <code>from_external</code> function to accept <code>block_number</code> and <br><code>block_timestamp</code> instead of <code>block</code><br> <li> Updated function parameters and usage accordingly<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1628/files#diff-9dbdf7472d01464e439067cbd23dfe3648c7fb38a307bee0cf8642ad16a1a252">+3/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>execution.rs</strong><dd><code>Refactor EvmExecution to use specific block timestamp</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/execution.rs

<li>Modified <code>from_failed_external_transaction</code> to accept <code>block_timestamp</code> <br>instead of <code>block</code><br> <li> Removed dependency on <code>ExternalBlock</code><br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1628/files#diff-cd13932ed3cbc97c18547275105d872a204eda4ad4bf0c2811b18553b48e9038">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Performance</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>executor.rs</strong><dd><code>Optimize Executor to use specific block properties</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/executor/executor.rs

<li>Modified <code>execute_external_transaction</code> to accept <code>block_number</code> and <br><code>block_timestamp</code> instead of <code>block</code><br> <li> Updated function calls and error logging to use individual block <br>properties<br> <li> Removed unnecessary cloning of <code>ExternalBlock</code><br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1628/files#diff-6b460d7dee8280c0287e8d9d9d59cf66a57ec9fed1bc003c6ede6fef60c7376b">+16/-11</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

