### PR TITLE
perf: remove unnecessary block, transcation and receipt clones

### DIFF
--- a/src/eth/primitives/external_block.rs
+++ b/src/eth/primitives/external_block.rs
@@ -12,7 +12,7 @@ use crate::eth::primitives::Hash;
 use crate::eth::primitives::UnixTime;
 use crate::log_and_err;
 
-#[derive(Debug, Clone, derive_more:: Deref, serde::Deserialize, serde::Serialize)]
+#[derive(Debug, Clone, derive_more:: Deref, derive_more::DerefMut, serde::Deserialize, serde::Serialize)]
 #[serde(transparent)]
 pub struct ExternalBlock(#[deref] pub EthersBlockExternalTransaction);
 

--- a/src/eth/primitives/external_receipts.rs
+++ b/src/eth/primitives/external_receipts.rs
@@ -19,8 +19,8 @@ impl ExternalReceipts {
     }
 
     /// Tries to take a receipt by its hash.
-    pub fn try_get(&self, tx_hash: &Hash) -> anyhow::Result<&ExternalReceipt> {
-        match self.get(tx_hash) {
+    pub fn try_take(&mut self, tx_hash: &Hash) -> anyhow::Result<ExternalReceipt> {
+        match self.take(tx_hash) {
             Some(receipt) => Ok(receipt),
             None => {
                 tracing::error!(%tx_hash, "receipt is missing for hash");
@@ -30,8 +30,8 @@ impl ExternalReceipts {
     }
 
     /// Takes a receipt by its hash.
-    pub fn get(&self, hash: &Hash) -> Option<&ExternalReceipt> {
-        self.0.get(hash)
+    pub fn take(&mut self, hash: &Hash) -> Option<ExternalReceipt> {
+        self.0.remove(hash)
     }
 
     /// Returns the number of receipts.


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Optimized block and transaction execution by removing unnecessary cloning and improving memory usage
- Refactored `execute_external_block` and related functions to take ownership of data instead of borrowing
- Updated `ExternalReceipts` to consume receipts when accessed, reducing redundant data storage
- Improved logging and metrics collection throughout the execution process
- Added mutable dereferencing for `ExternalBlock` struct
- Minor code cleanup and variable naming improvements


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>importer_offline.rs</strong><dd><code>Optimize offline importer block execution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/bin/importer_offline.rs

<li>Optimized block execution by removing unnecessary cloning<br> <li> Improved variable naming and logging<br> <li> Refactored to use mutable <code>receipts</code> and return them from <br><code>execute_external_block</code><br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1630/files#diff-9fef7d584818c3db119ea1cd0952a57a953751f85f93ca813af861c4c737c53a">+10/-9</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>executor.rs</strong><dd><code>Refactor executor for improved performance</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/executor/executor.rs

<li>Modified <code>execute_external_block</code> to take ownership of block and <br>receipts<br> <li> Optimized memory usage by using <code>mem::take</code> for block transactions<br> <li> Updated <code>execute_external_transaction</code> to take ownership of tx and <br>receipt<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1630/files#diff-6b460d7dee8280c0287e8d9d9d59cf66a57ec9fed1bc003c6ede6fef60c7376b">+26/-21</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>importer.rs</strong><dd><code>Update importer to align with executor changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/follower/importer/importer.rs

<li>Updated to pass ownership of block and receipts to <br><code>execute_external_block</code><br> <li> Improved logging and metrics collection<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1630/files#diff-bd50f502f039aff8f75753bc780d281ae7d7936fadc9d53482084c647aec94ca">+8/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>external_block.rs</strong><dd><code>Add mutable dereferencing for ExternalBlock</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/external_block.rs

- Added `DerefMut` derive for `ExternalBlock` struct



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1630/files#diff-a9f4dfb1768eeb5161bd375436af42b8fbb82726916dd9c4cc1e7a08edd54388">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>external_receipts.rs</strong><dd><code>Modify ExternalReceipts to consume receipts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/external_receipts.rs

<li>Changed <code>try_get</code> to <code>try_take</code>, now consuming the receipt<br> <li> Updated <code>get</code> to <code>take</code>, now removing the receipt from the collection<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1630/files#diff-c485a8d59ab59b4a46365a97e16383a9e39a985dc9e5cd297992b94fcb382bce">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

