### PR TITLE
perf: use VecDeque instead of NonEmpty because it is faster

### DIFF
--- a/src/eth/storage/inmemory/inmemory_temporary.rs
+++ b/src/eth/storage/inmemory/inmemory_temporary.rs
@@ -178,7 +178,7 @@ impl TemporaryStorage for InMemoryTemporaryStorage {
         }
 
         // save execution
-        head_mut(&mut states).require_pending_block_mut()?.push_transaction(tx);
+        head.require_pending_block_mut()?.push_transaction(tx);
 
         Ok(())
     }

--- a/src/eth/storage/inmemory/inmemory_temporary.rs
+++ b/src/eth/storage/inmemory/inmemory_temporary.rs
@@ -148,9 +148,9 @@ impl TemporaryStorage for InMemoryTemporaryStorage {
         }
 
         // save account changes
+        let head = head_mut(&mut states);
         let changes = tx.execution().changes.values();
         for change in changes {
-            let head = head_mut(&mut states);
             let account = head
                 .accounts
                 .entry(change.address)

--- a/src/eth/storage/inmemory/inmemory_temporary.rs
+++ b/src/eth/storage/inmemory/inmemory_temporary.rs
@@ -111,11 +111,11 @@ impl TemporaryStorage for InMemoryTemporaryStorage {
 
     fn set_pending_block_number(&self, number: BlockNumber) -> anyhow::Result<()> {
         let mut states = self.lock_write();
-        match head_mut(&mut states).block.as_mut() {
+        let head = head_mut(&mut states);
+
+        match head.block.as_mut() {
             Some(block) => block.number = number,
-            None => {
-                head_mut(&mut states).block = Some(PendingBlock::new(number));
-            }
+            None => head.block = Some(PendingBlock::new(number)),
         }
         Ok(())
     }


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Replaced `NonEmpty` with `VecDeque` in `InMemoryTemporaryStorage` for improved performance
- Updated all methods to work with `VecDeque`, maintaining the same functionality
- Added helper functions `head` and `head_mut` to safely access the first element of `VecDeque`
- Modified `reset` method to properly clear and reinitialize the `VecDeque`
- Removed unnecessary `reset` method from `InMemoryTemporaryStorageState`
- Updated `finish_pending_block` to use `push_front` and `pop_back` for managing block history
- Adjusted imports and removed unused `nonempty` crate dependency


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>inmemory_temporary.rs</strong><dd><code>Optimize InMemoryTemporaryStorage with VecDeque</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/inmemory/inmemory_temporary.rs

<li>Replaced <code>NonEmpty</code> with <code>VecDeque</code> for <code>states</code> in <code>InMemoryTemporaryStorage</code><br> <li> Updated methods to work with <code>VecDeque</code> instead of <code>NonEmpty</code><br> <li> Added helper functions <code>head</code> and <code>head_mut</code> for accessing the first <br>element<br> <li> Modified <code>reset</code> method to clear and reinitialize the <code>VecDeque</code><br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1631/files#diff-6f4ee832c01927be4b428028743a37022368d351f09fd177f59e81a5a58dd661">+41/-34</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

