### PR TITLE
refactor: remove unused mine_external_mixed from miner

### DIFF
--- a/src/eth/follower/importer/importer.rs
+++ b/src/eth/follower/importer/importer.rs
@@ -189,7 +189,7 @@ impl Importer {
                 );
             }
 
-            if let Err(e) = miner.mine_external_mixed_and_commit() {
+            if let Err(e) = miner.mine_external_and_commit() {
                 let message = GlobalState::shutdown_from(TASK_NAME, "failed to mine external block");
                 return log_and_err!(reason = e, message);
             };


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Removed unused `mine_external_mixed()` and `mine_external_mixed_and_commit()` methods from the `Miner` struct
- Updated the importer to use `mine_external_and_commit()` instead of `mine_external_mixed_and_commit()`
- Simplified the miner implementation by removing logic for mining external mixed blocks
- This change reduces code complexity and removes unused functionality


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>importer.rs</strong><dd><code>Update miner method call in importer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/follower/importer/importer.rs

<li>Changed <code>mine_external_mixed_and_commit()</code> to <code>mine_external_and_commit()</code><br> <br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1633/files#diff-bd50f502f039aff8f75753bc780d281ae7d7936fadc9d53482084c647aec94ca">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>miner.rs</strong><dd><code>Remove unused external mixed mining methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/miner/miner.rs

<li>Removed <code>mine_external_mixed_and_commit()</code> method<br> <li> Removed <code>mine_external_mixed()</code> method<br> <li> Removed logic for mining external mixed blocks<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1633/files#diff-16f448afc7dae3e8e802f676a86dbd7051e19f6c17cbbeb53eb730d726372629">+0/-44</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

