### PR TITLE
perf: avoid recomputing tx_hash when saving execution

### DIFF
--- a/src/eth/miner/miner.rs
+++ b/src/eth/miner/miner.rs
@@ -94,9 +94,11 @@ impl Miner {
 
     /// Persists a transaction execution.
     pub fn save_execution(&self, tx_execution: TransactionExecution, check_conflicts: bool) -> Result<(), StratusError> {
+        let tx_hash = tx_execution.hash();
+
         // track
         #[cfg(feature = "tracing")]
-        let _span = info_span!("miner::save_execution", tx_hash = %tx_execution.hash()).entered();
+        let _span = info_span!("miner::save_execution", %tx_hash).entered();
 
         // if automine is enabled, only one transaction can enter the block at time.
         let _save_execution_lock = if self.mode.is_automine() {
@@ -109,8 +111,10 @@ impl Miner {
         let tx_hash = tx_execution.hash();
         self.storage.save_execution(tx_execution, check_conflicts)?;
 
-        // if automine is enabled, automatically mines a block
+        // notify
         let _ = self.notifier_pending_txs.send(tx_hash);
+
+        // if automine is enabled, automatically mines a block
         if self.mode.is_automine() {
             self.mine_local_and_commit()?;
         }

--- a/src/eth/miner/miner.rs
+++ b/src/eth/miner/miner.rs
@@ -108,7 +108,6 @@ impl Miner {
         };
 
         // save execution to temporary storage
-        let tx_hash = tx_execution.hash();
         self.storage.save_execution(tx_execution, check_conflicts)?;
 
         // notify


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Optimize `save_execution` method by computing `tx_hash` once at the beginning
- Update tracing span to use pre-computed `tx_hash`, reducing redundant computations
- Reorder operations in `save_execution`:
  - Notify about pending transactions before mining in automine mode
  - Improve code readability and potentially slight performance gain
- These changes aim to enhance performance by avoiding unnecessary recomputation of `tx_hash`


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Performance optimization</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>miner.rs</strong><dd><code>Optimize transaction hash computation and execution flow</code>&nbsp; </dd></summary>
<hr>

src/eth/miner/miner.rs

<li>Compute <code>tx_hash</code> once at the beginning of <code>save_execution</code> method<br> <li> Update tracing span to use pre-computed <code>tx_hash</code><br> <li> Reorder operations: notify before mining in automine mode<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1634/files#diff-16f448afc7dae3e8e802f676a86dbd7051e19f6c17cbbeb53eb730d726372629">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

