### PR TITLE
feat: new binary to revert RocksDB blocks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,6 +147,10 @@ path = "src/bin/rpc_downloader.rs"
 name = "importer-offline"
 path = "src/bin/importer_offline.rs"
 
+[[bin]]
+name = "rocks-revert-to-block"
+path = "src/bin/rocks_revert_to_block.rs"
+
 # ------------------------------------------------------------------------------
 # Features
 # ------------------------------------------------------------------------------

--- a/src/bin/rocks_revert_to_block.rs
+++ b/src/bin/rocks_revert_to_block.rs
@@ -1,0 +1,28 @@
+//! Revert block binary.
+//!
+//! Given a block number, it loads the Rocks database and tries to revert the state to that block.
+//!
+//! By reverting the state to a previous block, the final state must be the same as when that block
+//! was just processed, that is, before the next ones were processed.
+
+use stratus::config::RocksRevertToBlockConfig;
+use stratus::eth::storage::RocksPermanentStorage;
+use stratus::utils::DropTimer;
+use stratus::GlobalServices;
+
+fn main() -> anyhow::Result<()> {
+    let global_services = GlobalServices::<RocksRevertToBlockConfig>::init();
+    run(global_services.config)
+}
+
+fn run(config: RocksRevertToBlockConfig) -> anyhow::Result<()> {
+    let _timer = DropTimer::start("rocks-revert-to-block");
+
+    let rocks = RocksPermanentStorage::new(config.rocks_path_prefix)?;
+
+    if let Err(err) = rocks.revert_state_to_block(config.block_number.into()) {
+        tracing::error!(target_block = config.block_number, reason = ?err, "failed to revert block state to target block");
+    }
+
+    Ok(())
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -291,6 +291,29 @@ impl WithCommonConfig for ImporterOfflineConfig {
 }
 
 // -----------------------------------------------------------------------------
+// Config: RocksRevertToBlockConfig
+// -----------------------------------------------------------------------------
+
+#[derive(DebugAsJson, Clone, Parser, serde::Serialize)]
+pub struct RocksRevertToBlockConfig {
+    /// Block number to revert to.
+    #[arg(long = "block", env = "BLOCK")]
+    pub block_number: u64,
+
+    #[arg(long = "rocks-path-prefix", env = "ROCKS_PATH_PREFIX")]
+    pub rocks_path_prefix: Option<String>,
+
+    #[clap(flatten)]
+    pub common: CommonConfig,
+}
+
+impl WithCommonConfig for RocksRevertToBlockConfig {
+    fn common(&self) -> &CommonConfig {
+        &self.common
+    }
+}
+
+// -----------------------------------------------------------------------------
 // Config: Test
 // -----------------------------------------------------------------------------
 

--- a/src/eth/executor/executor.rs
+++ b/src/eth/executor/executor.rs
@@ -194,7 +194,7 @@ pub struct Executor {
     /// Executor inner locks.
     locks: ExecutorLocks,
 
-    // Executor configuration.
+    /// Executor configuration.
     config: ExecutorConfig,
 
     /// Channels to send transactions to background EVMs.

--- a/src/eth/storage/rocks/rocks_cf.rs
+++ b/src/eth/storage/rocks/rocks_cf.rs
@@ -154,6 +154,7 @@ where
             .with_context(|| format!("when trying to insert value in CF: '{}'", self.column_family))
     }
 
+    #[inline]
     fn insert_impl(&self, key: K, value: V) -> Result<()> {
         let cf = self.handle();
 
@@ -169,6 +170,7 @@ where
             .with_context(|| format!("when trying to delete value from CF: '{}'", self.column_family))
     }
 
+    #[inline]
     fn delete_impl(&self, key: &K) -> Result<()> {
         let serialized_key = self.serialize_key_with_context(key)?;
         let cf = self.handle();
@@ -184,6 +186,7 @@ where
             .with_context(|| format!("when trying to prepare batch insertion for CF: '{}'", self.column_family))
     }
 
+    #[inline]
     fn prepare_batch_insertion_impl<I>(&self, changes: I, batch: &mut WriteBatch) -> Result<()>
     where
         I: IntoIterator<Item = (K, V)>,

--- a/src/eth/storage/rocks/rocks_cf.rs
+++ b/src/eth/storage/rocks/rocks_cf.rs
@@ -178,6 +178,15 @@ where
         self.db.delete_cf(&cf, serialized_key).map_err(Into::into)
     }
 
+    pub fn prepare_and_write_batch_with_context<I>(&self, changes: I) -> Result<()>
+    where
+        I: IntoIterator<Item = (K, V)>,
+    {
+        let mut batch = WriteBatch::default();
+        self.prepare_batch_insertion(changes, &mut batch)?;
+        self.write_batch_with_context(batch)
+    }
+
     pub fn prepare_batch_insertion<I>(&self, changes: I, batch: &mut WriteBatch) -> Result<()>
     where
         I: IntoIterator<Item = (K, V)>,

--- a/src/eth/storage/rocks/rocks_permanent.rs
+++ b/src/eth/storage/rocks/rocks_permanent.rs
@@ -60,6 +60,10 @@ impl RocksPermanentStorage {
         self.block_number.store(0, Ordering::SeqCst);
         Ok(())
     }
+
+    pub fn revert_state_to_block(&self, block_number: BlockNumber) -> anyhow::Result<()> {
+        self.state.revert_state_to_block(block_number.into())
+    }
 }
 
 impl PermanentStorage for RocksPermanentStorage {

--- a/src/eth/storage/rocks/rocks_state.rs
+++ b/src/eth/storage/rocks/rocks_state.rs
@@ -428,7 +428,7 @@ impl RocksStorageState {
 
         let mut batch = WriteBatch::default();
         self.accounts.prepare_batch_insertion(accounts, &mut batch)?;
-        self.accounts.write_batch_with_context(batch)
+        self.accounts.apply_batch_with_context(batch)
     }
 
     /// Writes slots to state (does not write to slot history)
@@ -440,7 +440,7 @@ impl RocksStorageState {
 
         let mut batch = WriteBatch::default();
         self.account_slots.prepare_batch_insertion(slots, &mut batch)?;
-        self.account_slots.write_batch_with_context(batch)
+        self.account_slots.apply_batch_with_context(batch)
     }
 
     /// Clears in-memory state.
@@ -480,7 +480,7 @@ impl RocksStorageState {
             }
         }
         let accounts_without_number = accounts.into_iter().map(|(address, (_, account))| (address, account));
-        self.accounts.prepare_and_write_batch_with_context(accounts_without_number)?;
+        self.accounts.prepare_and_apply_insertion_batch_with_context(accounts_without_number)?;
 
         // go through historical slots, clean all after target_number and reconstruct current slots state
         let mut account_slots = HashMap::<(AddressRocksdb, SlotIndexRocksdb), (BlockNumberRocksdb, SlotValueRocksdb)>::new();
@@ -499,7 +499,7 @@ impl RocksStorageState {
             }
         }
         let slots_without_number = account_slots.into_iter().map(|((address, idx), (_, value))| ((address, idx), value));
-        self.account_slots.prepare_and_write_batch_with_context(slots_without_number)?;
+        self.account_slots.prepare_and_apply_insertion_batch_with_context(slots_without_number)?;
 
         // truncate the rest of column families
         for next in self.transactions.iter_start() {

--- a/src/eth/storage/rocks/rocks_state.rs
+++ b/src/eth/storage/rocks/rocks_state.rs
@@ -480,9 +480,7 @@ impl RocksStorageState {
             }
         }
         let accounts_without_number = accounts.into_iter().map(|(address, (_, account))| (address, account));
-        let mut batch = WriteBatch::default();
-        self.accounts.prepare_batch_insertion(accounts_without_number, &mut batch)?;
-        self.accounts.write_batch_with_context(batch)?;
+        self.accounts.prepare_and_write_batch_with_context(accounts_without_number)?;
 
         // go through historical slots, clean all after target_number and reconstruct current slots state
         let mut account_slots = HashMap::<(AddressRocksdb, SlotIndexRocksdb), (BlockNumberRocksdb, SlotValueRocksdb)>::new();
@@ -501,9 +499,7 @@ impl RocksStorageState {
             }
         }
         let slots_without_number = account_slots.into_iter().map(|((address, idx), (_, value))| ((address, idx), value));
-        let mut batch = WriteBatch::default();
-        self.account_slots.prepare_batch_insertion(slots_without_number, &mut batch)?;
-        self.account_slots.write_batch_with_context(batch)?;
+        self.account_slots.prepare_and_write_batch_with_context(slots_without_number)?;
 
         // truncate the rest of column families
         for next in self.transactions.iter_start() {


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Implemented a new binary `rocks_revert_to_block.rs` to revert RocksDB state to a specified block number
- Added `RocksRevertToBlockConfig` for configuration of the new binary
- Enhanced `RocksStorageState` with `revert_state_to_block` method to handle state reversion logic
- Added `delete`, `iter_start`, and `iter_end` methods to improve RocksDB column family operations
- Implemented `revert_state_to_block` in `RocksPermanentStorage` to expose the functionality
- Updated Cargo.toml to include the new binary
- Minor documentation and code refactoring improvements


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rocks_revert_to_block.rs</strong><dd><code>New binary for reverting RocksDB blocks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/bin/rocks_revert_to_block.rs

<li>Added a new binary file for reverting RocksDB blocks<br> <li> Implements functionality to revert the state to a specified block <br>number<br> <li> Uses <code>RocksPermanentStorage</code> and <code>RocksRevertToBlockConfig</code><br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1635/files#diff-9edb1344ae783fdd07dc1896fcccc9374d542df7f2bafaebd5f3b5866887f89b">+28/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rocks_cf.rs</strong><dd><code>Enhanced RocksDB column family operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/rocks/rocks_cf.rs

<li>Added <code>delete</code> and <code>delete_impl</code> methods for deleting entries<br> <li> Implemented <code>iter_start</code> and <code>iter_end</code> methods for iteration<br> <li> Minor code refactoring<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1635/files#diff-0eaed53baca4bd2355e2a54a150b305569904a45c93547da288208c6373d1df2">+28/-1</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rocks_permanent.rs</strong><dd><code>Added state reversion to RocksPermanentStorage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/rocks/rocks_permanent.rs

- Added `revert_state_to_block` method to `RocksPermanentStorage`



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1635/files#diff-c129c50a85915e0c5154c4e048a4577bd45ce6ae9ec98e95acbcad09ff79b3c6">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rocks_state.rs</strong><dd><code>Implemented state reversion in RocksStorageState</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/rocks/rocks_state.rs

<li>Implemented <code>revert_state_to_block</code> method in <code>RocksStorageState</code><br> <li> Added logic to revert accounts, slots, transactions, logs, and blocks<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1635/files#diff-f7b822022d2c4fd93ec507cd6b5302dcf1646acbf0ee0dd077a047272b686009">+84/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.rs</strong><dd><code>Configuration for RocksDB block reversion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/config.rs

<li>Added <code>RocksRevertToBlockConfig</code> struct for the new binary<br> <li> Implemented <code>WithCommonConfig</code> trait for <code>RocksRevertToBlockConfig</code><br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1635/files#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecd">+23/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Added new binary to Cargo.toml</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Cargo.toml

- Added new binary entry for `rocks-revert-to-block`



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1635/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>executor.rs</strong><dd><code>Minor comment update in Executor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/executor/executor.rs

- Minor comment update for `config` field in `Executor` struct



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1635/files#diff-6b460d7dee8280c0287e8d9d9d59cf66a57ec9fed1bc003c6ede6fef60c7376b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

