### PR TITLE
chore: remove unused leftover consensus code

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,6 @@
 //! Application configuration.
 
 use std::env;
-use std::net::SocketAddr;
 use std::str::FromStr;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
@@ -107,14 +106,6 @@ pub struct CommonConfig {
 
     #[clap(flatten)]
     pub metrics: MetricsConfig,
-
-    /// Direct access to peers via IP address, why will be included on data propagation and leader election.
-    #[arg(long = "candidate-peers", env = "CANDIDATE_PEERS", value_delimiter = ',')]
-    pub candidate_peers: Vec<String>,
-
-    // Address for the GRPC Server
-    #[arg(long = "grpc-server-address", env = "GRPC_SERVER_ADDRESS", default_value = "0.0.0.0:3777")]
-    pub grpc_server_address: SocketAddr,
 
     /// Prevents clap from breaking when passing `nocapture` options in tests.
     #[arg(long = "nocapture")]

--- a/src/eth/follower/consensus.rs
+++ b/src/eth/follower/consensus.rs
@@ -36,7 +36,7 @@ pub trait Consensus: Send + Sync {
         #[cfg(feature = "metrics")]
         let start = metrics::now();
 
-        tracing::info!(%tx_hash, %rpc_client, "forwaring transaction to leader");
+        tracing::info!(%tx_hash, %rpc_client, "forwarding transaction to leader");
 
         let hash = self.get_chain()?.send_raw_transaction_to_leader(tx_data.into(), rpc_client).await?;
 

--- a/src/infra/metrics/metrics_definitions.rs
+++ b/src/infra/metrics/metrics_definitions.rs
@@ -207,29 +207,8 @@ metrics! {
 metrics! {
     group: consensus,
 
-    "Time to run Consensus::append_block_to_peer."
-    histogram_duration consensus_append_block_to_peer{},
-
-    "Time to run Consensus::start_election."
-    histogram_duration consensus_start_election{},
-
     "Time to run Consensus::forward."
     histogram_duration consensus_forward{},
-
-    "The diff between what is on the follower database and what it received from Append Entries."
-    gauge append_entries_block_number_diff{},
-
-    "If the node is the leader or not."
-    gauge consensus_is_leader{},
-
-    "Counter of leadership changes."
-    counter consensus_leadership_change{},
-
-    "Time to run gRPC requests that finished."
-    histogram_duration consensus_grpc_requests_finished{method},
-
-    "The amount of available peers."
-    gauge consensus_available_peers{},
 
     "The readiness of Stratus."
     gauge consensus_is_ready{}


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Removed unused consensus-related configuration from `CommonConfig` struct in `src/config.rs`
- Cleaned up unused consensus metrics in `src/infra/metrics/metrics_definitions.rs`
- Fixed a typo in a log message in the consensus module
- Overall, this PR removes leftover unused code related to consensus, improving code cleanliness and maintainability


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.rs</strong><dd><code>Remove unused consensus-related configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/config.rs

<li>Removed unused import of <code>SocketAddr</code><br> <li> Removed <code>candidate_peers</code> and <code>grpc_server_address</code> fields from <br><code>CommonConfig</code> struct<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1636/files#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecd">+0/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>consensus.rs</strong><dd><code>Fix typo in consensus log message</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/follower/consensus.rs

- Fixed a typo in a log message: "forwaring" to "forwarding"



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1636/files#diff-d16e08176a325dc1f8ffd7aa8d0bc88f4741e605d930e60ad2b6358e097e2fec">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>metrics_definitions.rs</strong><dd><code>Remove unused consensus metrics</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/infra/metrics/metrics_definitions.rs

<li>Removed several consensus-related metrics definitions<br> <li> Kept only <code>consensus_forward</code> and <code>consensus_is_ready</code> metrics<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1636/files#diff-2ca1adc579301e6de5f9e1d69eb1ed2f70aeee0f3b54fe113346040b4eab652b">+0/-21</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

