### PR TITLE
perf: remove more unnecessary cloning and pass receipts by mutable reference

### DIFF
--- a/src/eth/executor/executor.rs
+++ b/src/eth/executor/executor.rs
@@ -228,7 +228,7 @@ impl Executor {
     /// Reexecutes an external block locally and imports it to the temporary storage.
     ///
     /// Returns the remaining receipts that were not consumed by the execution.
-    pub fn execute_external_block(&self, mut block: ExternalBlock, mut receipts: ExternalReceipts) -> anyhow::Result<ExternalReceipts> {
+    pub fn execute_external_block(&self, mut block: ExternalBlock, receipts: &mut ExternalReceipts) -> anyhow::Result<()> {
         // track
         #[cfg(feature = "metrics")]
         let (start, mut block_metrics) = (metrics::now(), EvmExecutionMetrics::default());
@@ -246,7 +246,7 @@ impl Executor {
 
         // determine how to execute each transaction
         for tx in block_transactions {
-            let receipt = receipts.try_take(&tx.hash())?;
+            let receipt = receipts.try_remove(&tx.hash())?;
             self.execute_external_transaction(
                 tx,
                 receipt,
@@ -265,7 +265,7 @@ impl Executor {
             metrics::inc_executor_external_block_slot_reads(block_metrics.slot_reads);
         }
 
-        Ok(receipts)
+        Ok(())
     }
 
     /// Reexecutes an external transaction locally ensuring it produces the same output.

--- a/src/eth/follower/importer/importer.rs
+++ b/src/eth/follower/importer/importer.rs
@@ -167,9 +167,9 @@ impl Importer {
             let (start, block_number, block_tx_len) = (metrics::now(), block.number(), block.transactions.len());
 
             // execute and mine
-            let receipts = ExternalReceipts::from(receipts);
+            let mut receipts = ExternalReceipts::from(receipts);
             let receipts_len = receipts.len();
-            if let Err(e) = executor.execute_external_block(block, receipts) {
+            if let Err(e) = executor.execute_external_block(block, &mut receipts) {
                 let message = GlobalState::shutdown_from(TASK_NAME, "failed to reexecute external block");
                 return log_and_err!(reason = e, message);
             };

--- a/src/eth/primitives/external_receipts.rs
+++ b/src/eth/primitives/external_receipts.rs
@@ -1,9 +1,7 @@
 use std::collections::HashMap;
 
 use anyhow::anyhow;
-use itertools::Itertools;
 
-use crate::eth::primitives::BlockNumber;
 use crate::eth::primitives::ExternalReceipt;
 use crate::eth::primitives::Hash;
 
@@ -12,26 +10,15 @@ use crate::eth::primitives::Hash;
 pub struct ExternalReceipts(HashMap<Hash, ExternalReceipt>);
 
 impl ExternalReceipts {
-    /// Generates a new collection of receipts only with receipts of the specified block number.
-    pub fn filter_block(&self, number: BlockNumber) -> ExternalReceipts {
-        let receipts = self.0.values().filter(|receipt| receipt.block_number() == number).cloned().collect_vec();
-        ExternalReceipts::from(receipts)
-    }
-
-    /// Tries to take a receipt by its hash.
-    pub fn try_take(&mut self, tx_hash: &Hash) -> anyhow::Result<ExternalReceipt> {
-        match self.take(tx_hash) {
+    /// Tries to remove a receipt by its hash.
+    pub fn try_remove(&mut self, tx_hash: &Hash) -> anyhow::Result<ExternalReceipt> {
+        match self.0.remove(tx_hash) {
             Some(receipt) => Ok(receipt),
             None => {
                 tracing::error!(%tx_hash, "receipt is missing for hash");
                 Err(anyhow!("receipt missing for hash {}", tx_hash))
             }
         }
-    }
-
-    /// Takes a receipt by its hash.
-    pub fn take(&mut self, hash: &Hash) -> Option<ExternalReceipt> {
-        self.0.remove(hash)
     }
 
     /// Returns the number of receipts.


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Optimized block execution by passing receipts as mutable reference instead of cloning
- Simplified and renamed methods in `ExternalReceipts` struct for better clarity and efficiency
- Improved variable naming throughout the codebase for better readability
- Removed unnecessary cloning and unused methods to enhance performance
- Updated function signatures and calls to reflect the new optimized approach
- Simplified block mining process in the importer
- Adjusted logging and metrics to provide more accurate information


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>importer_offline.rs</strong><dd><code>Optimize block execution and improve variable naming</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/bin/importer_offline.rs

<li>Renamed variables for clarity (e.g., <code>blocks_len</code> to <code>batch_blocks_len</code>)<br> <li> Optimized block execution by passing receipts as mutable reference<br> <li> Simplified block mining process<br> <li> Updated logging and metrics<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1638/files#diff-9fef7d584818c3db119ea1cd0952a57a953751f85f93ca813af861c4c737c53a">+10/-11</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>executor.rs</strong><dd><code>Refactor external block execution for efficiency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/executor/executor.rs

<li>Modified <code>execute_external_block</code> to take receipts as mutable reference<br> <li> Changed return type to <code>()</code> instead of <code>ExternalReceipts</code><br> <li> Updated <code>try_take</code> to <code>try_remove</code> for consistency<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1638/files#diff-6b460d7dee8280c0287e8d9d9d59cf66a57ec9fed1bc003c6ede6fef60c7376b">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>importer.rs</strong><dd><code>Adjust importer to use updated executor interface</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/follower/importer/importer.rs

<li>Updated <code>execute_external_block</code> call to pass receipts as mutable <br>reference<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1638/files#diff-bd50f502f039aff8f75753bc780d281ae7d7936fadc9d53482084c647aec94ca">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>external_receipts.rs</strong><dd><code>Simplify ExternalReceipts struct and its methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/external_receipts.rs

<li>Removed <code>filter_block</code> and <code>take</code> methods<br> <li> Renamed <code>try_take</code> to <code>try_remove</code> and simplified its implementation<br> <li> Removed unused imports<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1638/files#diff-c485a8d59ab59b4a46365a97e16383a9e39a985dc9e5cd297992b94fcb382bce">+3/-16</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

