### PR TITLE
tests: add tests for more primitive types

### DIFF
--- a/src/eth/executor/evm_result.rs
+++ b/src/eth/executor/evm_result.rs
@@ -5,6 +5,7 @@ use crate::eth::primitives::EvmExecutionMetrics;
 
 /// Evm execution result.
 #[derive(DebugAsJson, Clone, serde::Serialize)]
+#[cfg_attr(test, derive(serde::Deserialize, fake::Dummy, PartialEq))]
 pub struct EvmExecutionResult {
     pub execution: EvmExecution,
     pub metrics: EvmExecutionMetrics,

--- a/src/eth/primitives/address.rs
+++ b/src/eth/primitives/address.rs
@@ -22,6 +22,7 @@ use crate::gen_newtype_from;
 
 /// Address of an Ethereum account (wallet or contract).
 #[derive(DebugAsJson, Clone, Copy, Default, Eq, PartialEq, Hash, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(test, derive(PartialOrd, Ord))]
 pub struct Address(pub H160);
 
 impl Address {

--- a/src/eth/primitives/block_filter.rs
+++ b/src/eth/primitives/block_filter.rs
@@ -100,10 +100,7 @@ impl<'de> serde::Deserialize<'de> for BlockFilter {
             }
 
             // unhandled type
-            a => {
-                println!("{:?}", a);
-                Err(serde::de::Error::custom("block filter must be a string or integer"))
-            }
+            _ => Err(serde::de::Error::custom("block filter must be a string or integer")),
         }
     }
 }

--- a/src/eth/primitives/block_filter.rs
+++ b/src/eth/primitives/block_filter.rs
@@ -98,7 +98,9 @@ impl<'de> serde::Deserialize<'de> for BlockFilter {
                         let number: BlockNumber = value_str.parse().map_err(serde::de::Error::custom)?;
                         Ok(Self::Number(number))
                     }
-                    _ => Err(serde::de::Error::custom("value was an object but its field was neither \"Hash\" nor \"Number\"")),
+                    _ => Err(serde::de::Error::custom(
+                        "value was an object but its field was neither \"Hash\" nor \"Number\"",
+                    )),
                 }
             }
 

--- a/src/eth/primitives/block_filter.rs
+++ b/src/eth/primitives/block_filter.rs
@@ -80,6 +80,9 @@ impl<'de> serde::Deserialize<'de> for BlockFilter {
             }
 
             serde_json::Value::Object(map) => {
+                if map.len() != 1 {
+                    return Err(serde::de::Error::custom("value was an object with an unexpected number of fields"));
+                }
                 let Some((key, value)) = map.iter().next() else {
                     return Err(serde::de::Error::custom("value was an object with no fields"));
                 };
@@ -95,7 +98,7 @@ impl<'de> serde::Deserialize<'de> for BlockFilter {
                         let number: BlockNumber = value_str.parse().map_err(serde::de::Error::custom)?;
                         Ok(Self::Number(number))
                     }
-                    _ => Err(serde::de::Error::custom("block filter must be a string or integer")),
+                    _ => Err(serde::de::Error::custom("value was an object but its field was neither \"Hash\" nor \"Number\"")),
                 }
             }
 

--- a/src/eth/primitives/block_filter.rs
+++ b/src/eth/primitives/block_filter.rs
@@ -79,25 +79,25 @@ impl<'de> serde::Deserialize<'de> for BlockFilter {
                 }
             }
 
-            serde_json::Value::Object(map) =>
-                if let Some((key, value)) = map.iter().next() {
-                    let Some(value_str) = value.as_str() else {
-                        return Err(serde::de::Error::custom("block filter must be a string or integer"));
-                    };
-                    match key.as_str() {
-                        "Hash" => {
-                            let hash: Hash = value_str.parse().map_err(serde::de::Error::custom)?;
-                            Ok(Self::Hash(hash))
-                        }
-                        "Number" => {
-                            let number: BlockNumber = value_str.parse().map_err(serde::de::Error::custom)?;
-                            Ok(Self::Number(number))
-                        }
-                        _ => Err(serde::de::Error::custom("block filter must be a string or integer")),
+            serde_json::Value::Object(map) => {
+                let Some((key, value)) = map.iter().next() else {
+                    return Err(serde::de::Error::custom("value was an object with no fields"));
+                };
+                let Some(value_str) = value.as_str() else {
+                    return Err(serde::de::Error::custom("value was an object with non-str fields"));
+                };
+                match key.as_str() {
+                    "Hash" => {
+                        let hash: Hash = value_str.parse().map_err(serde::de::Error::custom)?;
+                        Ok(Self::Hash(hash))
                     }
-                } else {
-                    Err(serde::de::Error::custom("block filter must be a string or integer"))
-                },
+                    "Number" => {
+                        let number: BlockNumber = value_str.parse().map_err(serde::de::Error::custom)?;
+                        Ok(Self::Number(number))
+                    }
+                    _ => Err(serde::de::Error::custom("block filter must be a string or integer")),
+                }
+            }
 
             // unhandled type
             a => {

--- a/src/eth/primitives/execution.rs
+++ b/src/eth/primitives/execution.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
-use std::fmt::Debug;
 
 use anyhow::anyhow;
 use anyhow::Ok;
+use display_json::DebugAsJson;
 use hex_literal::hex;
 
 use crate::eth::primitives::Account;
@@ -16,12 +16,14 @@ use crate::eth::primitives::Log;
 use crate::eth::primitives::UnixTime;
 use crate::eth::primitives::Wei;
 use crate::ext::not;
+#[cfg(test)]
+use crate::ext::ordered_map;
 use crate::log_and_err;
 
 pub type ExecutionChanges = HashMap<Address, ExecutionAccountChanges>;
 
 /// Output of a transaction executed in the EVM.
-#[derive(Debug, Clone, PartialEq, Eq, fake::Dummy, serde::Serialize, serde::Deserialize)]
+#[derive(DebugAsJson, Clone, PartialEq, Eq, fake::Dummy, serde::Serialize, serde::Deserialize)]
 pub struct EvmExecution {
     /// Assumed block timestamp during the execution.
     pub block_timestamp: UnixTime,
@@ -42,7 +44,8 @@ pub struct EvmExecution {
     pub gas: Gas,
 
     /// Storage changes that happened during the transaction execution.
-    pub changes: HashMap<Address, ExecutionAccountChanges>,
+    #[cfg_attr(test, serde(serialize_with = "ordered_map"))]
+    pub changes: ExecutionChanges,
 
     /// The contract address if the executed transaction deploys a contract.
     pub deployed_contract_address: Option<Address>,

--- a/src/eth/primitives/execution_account_changes.rs
+++ b/src/eth/primitives/execution_account_changes.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
 
+use display_json::DebugAsJson;
+
 use super::CodeHash;
 use crate::eth::primitives::Account;
 use crate::eth::primitives::Address;
@@ -9,9 +11,11 @@ use crate::eth::primitives::Nonce;
 use crate::eth::primitives::Slot;
 use crate::eth::primitives::SlotIndex;
 use crate::eth::primitives::Wei;
+#[cfg(test)]
+use crate::ext::ordered_map;
 
 /// Changes that happened to an account during a transaction.
-#[derive(Debug, Clone, PartialEq, Eq, fake::Dummy, serde::Serialize, serde::Deserialize)]
+#[derive(DebugAsJson, Clone, PartialEq, Eq, fake::Dummy, serde::Serialize, serde::Deserialize)]
 pub struct ExecutionAccountChanges {
     pub new_account: bool,
     pub address: Address,
@@ -21,6 +25,7 @@ pub struct ExecutionAccountChanges {
     // TODO: bytecode related information should be grouped in a Bytecode struct
     pub bytecode: ExecutionValueChange<Option<Bytes>>,
     pub code_hash: CodeHash, // TODO: should be wrapped in a ExecutionValueChange
+    #[cfg_attr(test, serde(serialize_with = "ordered_map"))]
     pub slots: HashMap<SlotIndex, ExecutionValueChange<Slot>>,
 }
 

--- a/src/eth/primitives/execution_conflict.rs
+++ b/src/eth/primitives/execution_conflict.rs
@@ -41,6 +41,7 @@ impl ExecutionConflictsBuilder {
 }
 
 #[derive(DebugAsJson, serde::Serialize)]
+#[cfg_attr(test, derive(serde::Deserialize, fake::Dummy, PartialEq))]
 pub enum ExecutionConflict {
     /// Account nonce mismatch.
     Nonce { address: Address, expected: Nonce, actual: Nonce },

--- a/src/eth/primitives/log_filter.rs
+++ b/src/eth/primitives/log_filter.rs
@@ -7,6 +7,7 @@ use crate::eth::primitives::LogMined;
 use crate::ext::not;
 
 #[derive(Clone, DebugAsJson, serde::Serialize, Eq, Hash, PartialEq)]
+#[cfg_attr(test, derive(serde::Deserialize, fake::Dummy))]
 #[cfg_attr(test, derive(Default))]
 pub struct LogFilter {
     pub from_block: BlockNumber,
@@ -14,7 +15,7 @@ pub struct LogFilter {
     pub addresses: Vec<Address>,
 
     /// Original payload received via RPC.
-    #[serde(skip)]
+    #[cfg_attr(not(test), serde(skip))]
     pub original_input: LogFilterInput,
 }
 

--- a/src/eth/primitives/log_filter_input.rs
+++ b/src/eth/primitives/log_filter_input.rs
@@ -1,6 +1,7 @@
 use std::ops::Deref;
 use std::sync::Arc;
 
+use display_json::DebugAsJson;
 use serde_with::formats::PreferMany;
 use serde_with::serde_as;
 use serde_with::DefaultOnNull;
@@ -17,7 +18,8 @@ use crate::eth::storage::StratusStorage;
 
 /// JSON-RPC input used in methods like `eth_getLogs` and `eth_subscribe`.
 #[serde_as]
-#[derive(Debug, Clone, Default, serde::Deserialize, serde::Serialize, PartialEq, Eq, Hash)]
+#[derive(DebugAsJson, Clone, Default, serde::Deserialize, serde::Serialize, PartialEq, Eq, Hash)]
+#[cfg_attr(test, derive(fake::Dummy))]
 pub struct LogFilterInput {
     #[serde(rename = "fromBlock", default)]
     pub from_block: Option<BlockFilter>,
@@ -78,7 +80,8 @@ impl LogFilterInput {
 }
 
 #[serde_as]
-#[derive(Debug, Clone, Default, serde::Deserialize, serde::Serialize, PartialEq, Eq, Hash)]
+#[derive(DebugAsJson, Clone, Default, serde::Deserialize, serde::Serialize, PartialEq, Eq, Hash)]
+#[cfg_attr(test, derive(fake::Dummy))]
 // This nested type is necessary to fine-tune how we want serde to deserialize the topics field
 pub struct LogFilterInputTopic(#[serde_as(deserialize_as = "OneOrMany<_, PreferMany>")] pub Vec<Option<LogTopic>>);
 

--- a/src/eth/primitives/mod.rs
+++ b/src/eth/primitives/mod.rs
@@ -114,30 +114,22 @@ mod tests {
     type TransactionExecutionValueChangeSlot = ExecutionValueChange<Slot>;
     type TransactionExecutionValueChangeWei = ExecutionValueChange<Wei>;
 
-    // FIX: gen_test_serde!(Block);
-    // FIX: gen_test_serde!(EvmExecution);
-    // FIX: gen_test_serde!(ExecutionAccountChanges);
-    // FIX: gen_test_serde!(ExecutionChanges);
-    // FIX: gen_test_serde!(TransactionMined);
-    // TODO: gen_test_serde!(BlockFilter);
-    // TODO: gen_test_serde!(ExecutionConflict);
-    // TODO: gen_test_serde!(ExecutionConflicts);
-    // TODO: gen_test_serde!(ExecutionConflictsBuilder);
-    // TODO: gen_test_serde!(ExternalBlock);
-    // TODO: gen_test_serde!(ExternalReceipt);
-    // TODO: gen_test_serde!(ExternalReceipts);
-    // TODO: gen_test_serde!(ExternalTransaction);
-    // TODO: gen_test_serde!(ExternalTransactionExecution);
-    // TODO: gen_test_serde!(LocalTransactionExecution);
-    // TODO: gen_test_serde!(LogFilter);
-    // TODO: gen_test_serde!(LogFilterInput);
-    // TODO: gen_test_serde!(LogFilterInputTopic);
-    // TODO: gen_test_serde!(PendingBlock);
-    // TODO: gen_test_serde!(StratusError);
-    // TODO: gen_test_serde!(TransactionExecution);
-    // TODO: gen_test_serde!(TransactionStage);
+    // TODO: Test external structs and internal structs that contain external strtucts that do no implement faker::Dummy
+    // gen_test_serde!(ExecutionConflicts);
+    // gen_test_serde!(ExecutionConflictsBuilder);
+    // gen_test_serde!(ExternalBlock);
+    // gen_test_serde!(ExternalReceipt);
+    // gen_test_serde!(ExternalReceipts);
+    // gen_test_serde!(ExternalTransaction);
+    // gen_test_serde!(ExternalTransactionExecution);
+    // gen_test_serde!(PendingBlock);
+    // gen_test_serde!(TransactionExecution);
+    // gen_test_serde!(TransactionStage);
+
     gen_test_serde!(Account);
     gen_test_serde!(Address);
+    gen_test_serde!(Block);
+    gen_test_serde!(BlockFilter);
     gen_test_serde!(BlockHeader);
     gen_test_serde!(BlockNumber);
     gen_test_serde!(Bytes);
@@ -148,12 +140,19 @@ mod tests {
     gen_test_serde!(Difficulty);
     gen_test_serde!(EcdsaRs);
     gen_test_serde!(EcdsaV);
+    gen_test_serde!(EvmExecution);
     gen_test_serde!(EvmExecutionMetrics);
+    gen_test_serde!(ExecutionAccountChanges);
+    gen_test_serde!(ExecutionConflict);
     gen_test_serde!(ExecutionResult);
     gen_test_serde!(Gas);
     gen_test_serde!(Hash);
     gen_test_serde!(Index);
+    gen_test_serde!(LocalTransactionExecution);
     gen_test_serde!(Log);
+    gen_test_serde!(LogFilter);
+    gen_test_serde!(LogFilterInput);
+    gen_test_serde!(LogFilterInputTopic);
     gen_test_serde!(LogMined);
     gen_test_serde!(LogTopic);
     gen_test_serde!(MinerNonce);
@@ -168,6 +167,7 @@ mod tests {
     gen_test_serde!(TransactionExecutionValueChangeSlot);
     gen_test_serde!(TransactionExecutionValueChangeWei);
     gen_test_serde!(TransactionInput);
+    gen_test_serde!(TransactionMined);
     gen_test_serde!(UnixTime);
     gen_test_serde!(Wei);
 }

--- a/src/eth/primitives/transaction_execution.rs
+++ b/src/eth/primitives/transaction_execution.rs
@@ -82,6 +82,7 @@ impl TransactionExecution {
 }
 
 #[derive(DebugAsJson, Clone, derive_new::new, serde::Serialize)]
+#[cfg_attr(test, derive(serde::Deserialize, fake::Dummy, PartialEq))]
 pub struct LocalTransactionExecution {
     pub input: TransactionInput,
     pub result: EvmExecutionResult,

--- a/src/eth/primitives/transaction_mined.rs
+++ b/src/eth/primitives/transaction_mined.rs
@@ -1,5 +1,6 @@
 use std::hash::Hash as HashTrait;
 
+use display_json::DebugAsJson;
 use itertools::Itertools;
 
 use crate::alias::EthersReceipt;
@@ -17,7 +18,7 @@ use crate::ext::OptionExt;
 use crate::if_else;
 
 /// Transaction that was executed by the EVM and added to a block.
-#[derive(Debug, Clone, PartialEq, Eq, fake::Dummy, serde::Serialize, serde::Deserialize)]
+#[derive(DebugAsJson, Clone, PartialEq, Eq, fake::Dummy, serde::Serialize, serde::Deserialize)]
 pub struct TransactionMined {
     /// Transaction input received through RPC.
     pub input: TransactionInput,


### PR DESCRIPTION
### **PR Type**
Tests, Enhancement


___

### **Description**
- Enhanced serialization and deserialization for multiple types, including `BlockFilter`, `EvmExecution`, and `ExecutionAccountChanges`.
- Added test-specific attributes to various structs and enums to improve testability.
- Implemented `DebugAsJson` for several types to improve debug output.
- Removed bincode-specific serde tests and focused on JSON serialization.
- Added support for ordered map serialization in test environments.
- Updated and expanded serde tests for primitive types in the `mod.rs` file.
- Improved case-insensitive deserialization for `BlockFilter`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>evm_result.rs</strong><dd><code>Add test attributes to EvmExecutionResult</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/executor/evm_result.rs

<li>Added <code>#[cfg_attr(test, derive(serde::Deserialize, fake::Dummy, </code><br><code>PartialEq))]</code> to <code>EvmExecutionResult</code> struct<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1640/files#diff-1e609c49515d2d7c46a9b850c0cf64a35dc37cf1a73b3939a9749ec843d5ddaf">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>address.rs</strong><dd><code>Add test attributes to Address struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/address.rs

<li>Added <code>#[cfg_attr(test, derive(PartialOrd, Ord))]</code> to <code>Address</code> struct<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1640/files#diff-43c180e22a2858040d18def981f15acd2fbe7f76fe1b59b76121e9aceeead96d">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>execution_conflict.rs</strong><dd><code>Add test attributes to ExecutionConflict</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/execution_conflict.rs

<li>Added <code>#[cfg_attr(test, derive(serde::Deserialize, fake::Dummy, </code><br><code>PartialEq))]</code> to <code>ExecutionConflict</code> enum<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1640/files#diff-989664061f5331343a7fe685e7bbc19f01044105c3e966afd41233c163671df1">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>log_filter.rs</strong><dd><code>Enhance LogFilter for testing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/log_filter.rs

<li>Added <code>#[cfg_attr(test, derive(serde::Deserialize, fake::Dummy))]</code> to <br><code>LogFilter</code> struct<br> <li> Modified <code>original_input</code> field serialization for tests<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1640/files#diff-8a77d8af3c5d907f1763771a0823aa4cab0b90e55eb6b7b173943381b7388ff8">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>log_filter_input.rs</strong><dd><code>Improve LogFilterInput and LogFilterInputTopic for testing</code></dd></summary>
<hr>

src/eth/primitives/log_filter_input.rs

<li>Added <code>DebugAsJson</code> and <code>#[cfg_attr(test, derive(fake::Dummy))]</code> to <br><code>LogFilterInput</code> and <code>LogFilterInputTopic</code> structs<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1640/files#diff-1fc314c5ef2bb71e10a986847e852f50d787c67b002131aa6f4afae62ebd4555">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Update and expand serde tests for primitive types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/mod.rs

<li>Removed commented-out test generation macros<br> <li> Added new test generation macros for various types<br> <li> Reorganized and expanded the list of types for serde testing<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1640/files#diff-0519ffc32191c9229d8b7672cd29638b49891c486a10d62379772dce98f1947c">+22/-22</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>transaction_execution.rs</strong><dd><code>Add test attributes to LocalTransactionExecution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/transaction_execution.rs

<li>Added <code>#[cfg_attr(test, derive(serde::Deserialize, fake::Dummy, </code><br><code>PartialEq))]</code> to <code>LocalTransactionExecution</code> struct<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1640/files#diff-363d860c6f773a2fea3a060866e15cdfa2fbe9e355b16a7567d9b2ed465fc987">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>block_filter.rs</strong><dd><code>Enhance BlockFilter serialization and deserialization</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/block_filter.rs

<li>Added <code>DebugAsJson</code> and <code>#[cfg_attr(test, derive(fake::Dummy))]</code> to <br><code>BlockFilter</code> enum<br> <li> Modified <code>serde::Deserialize</code> implementation to handle more cases and be <br>case-insensitive<br> <li> Added support for deserialization from JSON objects<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1640/files#diff-71bbb262ed6bad37e90e0427c9aeadd4a20c7857f403488d91f8aa82d85d7ea0">+31/-5</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>execution.rs</strong><dd><code>Improve EvmExecution serialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/execution.rs

<li>Replaced <code>Debug</code> with <code>DebugAsJson</code> for <code>EvmExecution</code> struct<br> <li> Added <code>#[cfg_attr(test, serde(serialize_with = "ordered_map"))]</code> to <br><code>changes</code> field<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1640/files#diff-cd13932ed3cbc97c18547275105d872a204eda4ad4bf0c2811b18553b48e9038">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>execution_account_changes.rs</strong><dd><code>Enhance ExecutionAccountChanges serialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/execution_account_changes.rs

<li>Replaced <code>Debug</code> with <code>DebugAsJson</code> for <code>ExecutionAccountChanges</code> struct<br> <li> Added <code>#[cfg_attr(test, serde(serialize_with = "ordered_map"))]</code> to <br><code>slots</code> field<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1640/files#diff-2f8319711f3b8bc5b706dcbb93ad7aeb7fc461b3416f6e5adcd715852a88c619">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>transaction_mined.rs</strong><dd><code>Use DebugAsJson for TransactionMined</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/transaction_mined.rs

- Replaced `Debug` with `DebugAsJson` for `TransactionMined` struct



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1640/files#diff-79809f5ea2cc1e67126d745072125f6992cb5857ac9abf5c0d21b1f67879359b">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ext.rs</strong><dd><code>Add ordered map serialization and update serde tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/ext.rs

<li>Added <code>ordered_map</code> function for serializing HashMaps as ordered BTrees<br> <li> Removed bincode-specific serde tests from <code>gen_test_serde!</code> macro<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1640/files#diff-4ff673578dd06edb71da19750f05cb48bbbd3c78ded3dbeda59409354c35cef6">+12/-19</a>&nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

