### PR TITLE
perf: improve InMemoryPermanentStorage#save_block

### DIFF
--- a/src/eth/primitives/block.rs
+++ b/src/eth/primitives/block.rs
@@ -125,27 +125,27 @@ impl Block {
     pub fn compact_account_changes(&self) -> Vec<ExecutionAccountChanges> {
         let mut block_compacted_changes: HashMap<Address, ExecutionAccountChanges> = HashMap::new();
         for transaction in &self.transactions {
-            for transaction_changes in transaction.execution.changes.values().cloned() {
+            for transaction_changes in transaction.execution.changes.values() {
                 let account_compacted_changes = block_compacted_changes
                     .entry(transaction_changes.address)
                     .or_insert(transaction_changes.clone());
 
-                if let Some(nonce) = transaction_changes.nonce.take_modified() {
-                    account_compacted_changes.nonce.set_modified(nonce);
+                if let Some(nonce) = transaction_changes.nonce.take_modified_ref() {
+                    account_compacted_changes.nonce.set_modified(*nonce);
                 }
 
-                if let Some(balance) = transaction_changes.balance.take_modified() {
-                    account_compacted_changes.balance.set_modified(balance);
+                if let Some(balance) = transaction_changes.balance.take_modified_ref() {
+                    account_compacted_changes.balance.set_modified(*balance);
                 }
 
-                if let Some(bytecode) = transaction_changes.bytecode.take_modified() {
-                    account_compacted_changes.bytecode.set_modified(bytecode);
+                if let Some(bytecode) = transaction_changes.bytecode.take_modified_ref() {
+                    account_compacted_changes.bytecode.set_modified(bytecode.clone());
                 }
 
-                for (slot_index, slot) in transaction_changes.slots {
-                    let slot_compacted_changes = account_compacted_changes.slots.entry(slot_index).or_insert(slot.clone());
-                    if let Some(slot_value) = slot.take_modified() {
-                        slot_compacted_changes.set_modified(slot_value);
+                for (slot_index, slot) in &transaction_changes.slots {
+                    let slot_compacted_changes = account_compacted_changes.slots.entry(*slot_index).or_insert(slot.clone());
+                    if let Some(slot_value) = slot.take_modified_ref() {
+                        slot_compacted_changes.set_modified(*slot_value);
                     }
                 }
             }

--- a/src/eth/storage/inmemory/inmemory_permanent.rs
+++ b/src/eth/storage/inmemory/inmemory_permanent.rs
@@ -173,7 +173,7 @@ impl PermanentStorage for InMemoryPermanentStorage {
                 continue;
             };
 
-            let tx_logs = block.transactions.iter().flat_map(|tx| &tx.logs).take_while(|log| filter.matches(log));
+            let tx_logs = block.transactions.iter().flat_map(|tx| &tx.logs).filter(|log| filter.matches(log));
             filtered_logs.extend(tx_logs);
         }
 

--- a/src/eth/storage/inmemory/inmemory_permanent.rs
+++ b/src/eth/storage/inmemory/inmemory_permanent.rs
@@ -29,7 +29,6 @@ use crate::eth::primitives::Wei;
 use crate::eth::storage::inmemory::InMemoryHistory;
 use crate::eth::storage::PermanentStorage;
 use crate::eth::storage::StoragePointInTime;
-use crate::ext::not;
 
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 pub struct InMemoryPermanentStorageState {
@@ -174,16 +173,8 @@ impl PermanentStorage for InMemoryPermanentStorage {
                 continue;
             };
 
-            let tx_logs = block
-                .transactions
-                .iter()
-                .flat_map(|tx| &tx.logs)
-                .take_while(|log| filter.matches(log))
-                .collect_vec();
-
-            if not(tx_logs.is_empty()) {
-                filtered_logs.extend(tx_logs);
-            }
+            let tx_logs = block.transactions.iter().flat_map(|tx| &tx.logs).take_while(|log| filter.matches(log));
+            filtered_logs.extend(tx_logs);
         }
 
         Ok(filtered_logs.into_iter().cloned().collect_vec())

--- a/src/eth/storage/inmemory/inmemory_permanent.rs
+++ b/src/eth/storage/inmemory/inmemory_permanent.rs
@@ -190,8 +190,8 @@ impl PermanentStorage for InMemoryPermanentStorage {
         state.blocks_by_hash.insert(block.hash(), Arc::clone(&block));
 
         // save transactions
-        for transaction in block.transactions.clone() {
-            state.transactions.insert(transaction.input.hash, Arc::clone(&block));
+        for tx in &block.transactions {
+            state.transactions.insert(tx.input.hash, Arc::clone(&block));
         }
 
         // save block account changes


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Optimized `InMemoryPermanentStorage` to reduce memory usage and improve performance:
  - Removed separate storage of logs, now retrieving them from blocks
  - Changed transaction storage to keep entire blocks, reducing duplication
  - Improved `read_logs` method to filter logs more efficiently
- Enhanced `Block::compact_account_changes` method to minimize cloning:
  - Updated to use references instead of cloning data
  - Changed method calls to use `take_modified_ref` for better performance
- Added `itertools` crate dependency for improved iteration methods
- Removed unnecessary cloning operations throughout the codebase


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Performance optimization</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>block.rs</strong><dd><code>Optimize Block Account Changes Compaction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/block.rs

<li>Modified <code>compact_account_changes</code> method to reduce cloning<br> <li> Changed method calls from <code>take_modified</code> to <code>take_modified_ref</code><br> <li> Updated loop to use references instead of cloning<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1643/files#diff-1713a99b45fd64ac0570786603a3a17edc97657646bd333e5e214e4a531def10">+11/-11</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>inmemory_permanent.rs</strong><dd><code>Refactor InMemoryPermanentStorage for Improved Performance</code></dd></summary>
<hr>

src/eth/storage/inmemory/inmemory_permanent.rs

<li>Removed <code>logs</code> field from <code>InMemoryPermanentStorageState</code><br> <li> Changed <code>transactions</code> field to store <code>Arc<Block></code> instead of <code>TransactionMined</code><br> <li> Optimized <code>read_transaction</code> and <code>read_logs</code> methods<br> <li> Updated <code>save_block</code> method to store entire blocks for transactions<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1643/files#diff-6cc83da72398cf1ba410cb7dd95e4e8f232f5db52c81bc92de5261dfe6d8e429">+27/-25</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

