### PR TITLE
refactor: remove storage test methods

### DIFF
--- a/src/eth/primitives/log_filter.rs
+++ b/src/eth/primitives/log_filter.rs
@@ -96,6 +96,8 @@ mod tests {
     use crate::eth::primitives::Log;
     use crate::eth::primitives::LogFilterInputTopic;
     use crate::eth::primitives::LogTopic;
+    use crate::eth::storage::InMemoryPermanentStorage;
+    use crate::eth::storage::InMemoryTemporaryStorage;
     use crate::eth::storage::StratusStorage;
     use crate::utils::test_utils::fake_first;
     use crate::utils::test_utils::fake_list;
@@ -105,12 +107,14 @@ mod tests {
     fn build_filter(addresses: Vec<Address>, topics_nested: Vec<Vec<Option<LogTopic>>>) -> LogFilter {
         let topics_map = |topics: Vec<Option<LogTopic>>| LogFilterInputTopic(topics.into_iter().collect());
 
+        let storage = StratusStorage::new(Box::new(InMemoryTemporaryStorage::default()), Box::new(InMemoryPermanentStorage::default()));
+
         LogFilterInput {
             address: addresses,
             topics: topics_nested.into_iter().map(topics_map).collect(),
             ..LogFilterInput::default()
         }
-        .parse(&Arc::new(StratusStorage::mock_new()))
+        .parse(&Arc::new(storage))
         .unwrap()
     }
 

--- a/src/eth/storage/inmemory/inmemory_permanent.rs
+++ b/src/eth/storage/inmemory/inmemory_permanent.rs
@@ -45,12 +45,6 @@ pub struct InMemoryPermanentStorage {
 }
 
 impl InMemoryPermanentStorage {
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
-impl InMemoryPermanentStorage {
     // -------------------------------------------------------------------------
     // Lock methods
     // -------------------------------------------------------------------------

--- a/src/eth/storage/inmemory/inmemory_temporary.rs
+++ b/src/eth/storage/inmemory/inmemory_temporary.rs
@@ -33,10 +33,6 @@ pub struct InMemoryTemporaryStorage {
 }
 
 impl InMemoryTemporaryStorage {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
     /// Locks inner state for reading.
     pub fn lock_read(&self) -> RwLockReadGuard<'_, NonEmpty<InMemoryTemporaryStorageState>> {
         self.states.read().unwrap()

--- a/src/eth/storage/stratus_storage.rs
+++ b/src/eth/storage/stratus_storage.rs
@@ -29,14 +29,6 @@ use crate::infra::metrics;
 use crate::infra::metrics::timed;
 use crate::infra::tracing::SpanExt;
 
-cfg_if::cfg_if! {
-    if #[cfg(test)] {
-        use crate::eth::storage::InMemoryPermanentStorage;
-        use crate::eth::storage::InMemoryTemporaryStorage;
-        use crate::eth::storage::RocksPermanentStorage;
-    }
-}
-
 mod label {
     pub(super) const TEMP: &str = "temporary";
     pub(super) const PERM: &str = "permanent";
@@ -58,33 +50,6 @@ impl StratusStorage {
     /// Creates a new storage with the specified temporary and permanent implementations.
     pub fn new(temp: Box<dyn TemporaryStorage>, perm: Box<dyn PermanentStorage>) -> Self {
         Self { temp, perm }
-    }
-
-    /// Creates an inmemory stratus storage for testing.
-    #[cfg(test)]
-    pub fn mock_new() -> Self {
-        Self {
-            temp: Box::new(InMemoryTemporaryStorage::new()),
-            perm: Box::new(InMemoryPermanentStorage::new()),
-        }
-    }
-
-    /// Creates an inmemory stratus storage for testing.
-    #[cfg(test)]
-    pub fn mock_new_rocksdb() -> (Self, tempfile::TempDir) {
-        // Create a unique temporary directory within the ./data directory
-        let temp_dir = tempfile::TempDir::new().expect("Failed to create temp dir");
-        let temp_path = temp_dir.path().to_str().expect("Failed to get temp path").to_string();
-
-        let rocks_permanent_storage = RocksPermanentStorage::new(Some(temp_path.clone())).expect("Failed to create RocksPermanentStorage");
-
-        (
-            Self {
-                temp: Box::new(InMemoryTemporaryStorage::new()),
-                perm: Box::new(rocks_permanent_storage),
-            },
-            temp_dir,
-        )
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Refactored storage-related test methods and implementations:
  - Removed `mock_new` and `mock_new_rocksdb` methods from `StratusStorage`
  - Removed `new` methods from `InMemoryPermanentStorage` and `InMemoryTemporaryStorage`
- Updated `log_filter.rs` to use `StratusStorage::new` instead of `StratusStorage::mock_new`
- Removed conditional imports for test configuration in `stratus_storage.rs`
- Overall, this PR simplifies the storage implementations and removes test-specific methods, promoting better separation of concerns


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>log_filter.rs</strong><dd><code>Update log filter test setup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/log_filter.rs

<li>Added imports for <code>InMemoryPermanentStorage</code> and <br><code>InMemoryTemporaryStorage</code><br> <li> Modified <code>build_filter</code> function to use <code>StratusStorage::new</code> instead of <br><code>StratusStorage::mock_new</code><br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1646/files#diff-8a77d8af3c5d907f1763771a0823aa4cab0b90e55eb6b7b173943381b7388ff8">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>inmemory_permanent.rs</strong><dd><code>Simplify InMemoryPermanentStorage implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/inmemory/inmemory_permanent.rs

<li>Removed <code>new</code> method from <code>InMemoryPermanentStorage</code> implementation<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1646/files#diff-6cc83da72398cf1ba410cb7dd95e4e8f232f5db52c81bc92de5261dfe6d8e429">+0/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>inmemory_temporary.rs</strong><dd><code>Simplify InMemoryTemporaryStorage implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/inmemory/inmemory_temporary.rs

<li>Removed <code>new</code> method from <code>InMemoryTemporaryStorage</code> implementation<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1646/files#diff-6f4ee832c01927be4b428028743a37022368d351f09fd177f59e81a5a58dd661">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>stratus_storage.rs</strong><dd><code>Remove test-specific methods from StratusStorage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/stratus_storage.rs

<li>Removed conditional imports for test configuration<br> <li> Removed <code>mock_new</code> and <code>mock_new_rocksdb</code> methods from <code>StratusStorage</code> <br>implementation<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1646/files#diff-3b2e36e47959decdfe26b2c4fab90b41f9242bfdad29cc43b2377ee851f4f40a">+0/-35</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

