### PR TITLE
test: migrate automine to external (part 2) 

### DIFF
--- a/e2e/test/external/e2e-json-rpc.test.ts
+++ b/e2e/test/external/e2e-json-rpc.test.ts
@@ -307,7 +307,8 @@ describe("JSON-RPC", () => {
                 sendEvmMine();
                 contract.waitForDeployment();
 
-                { // eth_call should not really change the state
+                {
+                    // eth_call should not really change the state
                     const data = contract.interface.encodeFunctionData("add", [ALICE.address, 5]);
                     const transaction = { to: contract.target, data: data };
                     await send("eth_call", [transaction, "latest"]);
@@ -324,7 +325,7 @@ describe("JSON-RPC", () => {
             });
 
             // FIXME: this test is intermitent
-            //        it sometimes receive undefined ad current balance, 
+            //        it sometimes receive undefined ad current balance,
             //        because Stratus claims the contract.target address is not a contract
             // it("Works when using the field 'input' instead of 'data'", async () => {
             //     // deploy
@@ -474,7 +475,12 @@ describe("JSON-RPC", () => {
                 await sendReset();
                 const waitTimeInMilliseconds = 40;
                 const automaticallySendEVMMines = true;
-                const response = await subscribeAndGetEventWithContract("logs", waitTimeInMilliseconds, 2, automaticallySendEVMMines);
+                const response = await subscribeAndGetEventWithContract(
+                    "logs",
+                    waitTimeInMilliseconds,
+                    2,
+                    automaticallySendEVMMines,
+                );
                 expect(response).to.not.be.undefined;
 
                 const params = response.params;

--- a/e2e/test/helpers/rpc.ts
+++ b/e2e/test/helpers/rpc.ts
@@ -344,8 +344,6 @@ export async function subscribeAndGetEventWithContract(
     return event;
 }
 
-
-
 // Prepares a signed transaction to interact with a contract
 export async function prepareSignedTx(props: {
     contract: BaseContract;
@@ -355,7 +353,7 @@ export async function prepareSignedTx(props: {
     custom_nonce?: number;
 }): Promise<string> {
     const { contract, account, methodName, methodParameters, custom_nonce } = props;
-    const nonce = custom_nonce || await sendGetNonce(account);
+    const nonce = custom_nonce || (await sendGetNonce(account));
     const tx = await (contract.connect(account.signer()) as Contract)[methodName].populateTransaction(
         ...methodParameters,
         {


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Added comprehensive test cases for JSON-RPC functionalities:
  - New tests for "Call" (eth_call), "Evm" (evm_mine, evm_setNextBlockTimestamp), and "Subscription" (eth_subscribe)
  - Implemented validation for various event types: newHeads, logs, and newPendingTransactions
  - Added error handling tests for unsupported subscriptions
- Enhanced RPC helper functions:
  - Modified asyncContractOperation and subscribeAndGetEventWithContract to support optional mining
  - Updated prepareSignedTx to allow custom nonce
- Improved test coverage and flexibility for different scenarios in JSON-RPC interactions


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>e2e-json-rpc.test.ts</strong><dd><code>Expand JSON-RPC tests with new functionalities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

e2e/test/external/e2e-json-rpc.test.ts

<li>Added new test cases for "Call", "Evm", and "Subscription" <br>functionalities<br> <li> Implemented tests for eth_call, evm_mine, evm_setNextBlockTimestamp<br> <li> Added tests for eth_subscribe with various event types (newHeads, <br>logs, newPendingTransactions)<br> <li> Included validation for event structures and error handling<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1648/files#diff-f5d1f06c4777826f9cbdcb4372d15c42f354177c83df65f3324cfd607da16004">+223/-0</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rpc.ts</strong><dd><code>Enhance RPC helper functions with mining options</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

e2e/test/helpers/rpc.ts

<li>Modified asyncContractOperation to support optional mining<br> <li> Updated subscribeAndGetEventWithContract to include optional mining<br> <li> Added custom_nonce option to prepareSignedTx function<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1648/files#diff-de92f3345fb0b828a3a1af4938646038808ddee426127f029255c9c10bdaa1bb">+19/-5</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

