### PR TITLE
fix: increase wait timeout to avoid errors on builds without cache

### DIFF
--- a/justfile_helpers
+++ b/justfile_helpers
@@ -12,8 +12,8 @@ _log message:
 # Wait for Stratus to start.
 _wait_for_stratus port="3000":
     #!/bin/bash
-    just _log "Waiting 60 seconds for Stratus on port {{port}} to start"
-    wait-service --tcp 0.0.0.0:{{port}} -t 60 -- echo
+    just _log "Waiting 120 seconds for Stratus on port {{port}} to start"
+    wait-service --tcp 0.0.0.0:{{port}} -t 120 -- echo
     if [ $? -eq 0 ]; then
         just _log "Stratus on port {{port}} started"
     else


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Increased the wait timeout for Stratus startup from 60 to 120 seconds to accommodate builds without cache
- Updated the log message to reflect the new timeout duration (120 seconds instead of 60)
- This change aims to prevent errors that occur when Stratus takes longer to start, especially in builds without cache


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>justfile_helpers</strong><dd><code>Extend Stratus startup wait timeout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

justfile_helpers

<li>Increased the wait timeout for Stratus startup from 60 to 120 seconds<br> <li> Updated the log message to reflect the new timeout duration<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1653/files#diff-ceafeefe0a05bcfb7f2605021b3a6023e055ac359102cb979fbb80fee7a2e2cd">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

