### PR TITLE
fix: set tracing events parents to None on long lived subscription tasks

### DIFF
--- a/src/eth/rpc/rpc_subscriptions.rs
+++ b/src/eth/rpc/rpc_subscriptions.rs
@@ -235,7 +235,7 @@ impl RpcSubscriptions {
         let msg = match msg.try_into() {
             Ok(msg) => msg,
             Err(e) => {
-                tracing::error!(reason = ?e, "failed to convert message into subscription message");
+                tracing::error!(parent: None, reason = ?e, "failed to convert message into subscription message");
                 return;
             }
         };

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -208,6 +208,8 @@ pub fn spawn_named<T>(name: &str, task: impl std::future::Future<Output = T> + S
 where
     T: Send + 'static,
 {
+    info_task_spawn(name);
+
     tokio::task::Builder::new()
         .name(name)
         .spawn(task)

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -208,8 +208,6 @@ pub fn spawn_named<T>(name: &str, task: impl std::future::Future<Output = T> + S
 where
     T: Send + 'static,
 {
-    info_task_spawn(name);
-
     tokio::task::Builder::new()
         .name(name)
         .spawn(task)

--- a/src/infra/tracing/tracing_services.rs
+++ b/src/infra/tracing/tracing_services.rs
@@ -358,7 +358,7 @@ pub fn new_cid() -> String {
 /// Emits an info message that a task was spawned to backgroud.
 #[track_caller]
 pub fn info_task_spawn(name: &str) {
-    tracing::info!(%name, "spawning task");
+    tracing::info!(parent: None, %name, "spawning task");
 }
 
 /// Emits an warning that a task is exiting because it received a cancenllation signal.


### PR DESCRIPTION
### **User description**
This was causing a leak because of an unbounded Vec in https://github.com/tokio-rs/tracing-opentelemetry/blob/v0.1.x/src/layer.rs#L978 .


___

### **PR Type**
Bug fix


___

### **Description**
- Set tracing events parents to None for long-lived subscription tasks to prevent memory leaks
- Updated error logging in RPC subscriptions to use `parent: None`
- Modified task spawn logging to use `parent: None`
- Addresses a potential memory leak caused by an unbounded Vec in tracing-opentelemetry


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rpc_subscriptions.rs</strong><dd><code>Update error logging in RPC subscriptions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/rpc/rpc_subscriptions.rs

- Modified error logging to set the parent trace to None



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1657/files#diff-a07ba1157cec6586a0520b8dfb11e9d073359af24471ac286ff5eaa2669d355c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>tracing_services.rs</strong><dd><code>Update task spawn logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/infra/tracing/tracing_services.rs

<li>Modified info logging for task spawning to set the parent trace to <br>None<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1657/files#diff-21c16d06019b3283856236ea996d455c4170d7bc0dcd40cfcc498842adde69c4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

