### PR TITLE
fix(e2e): await evm mine

### DIFF
--- a/e2e/test/external/e2e-json-rpc.test.ts
+++ b/e2e/test/external/e2e-json-rpc.test.ts
@@ -304,7 +304,7 @@ describe("JSON-RPC", () => {
             it("Returns an expected result when sending calls", async () => {
                 // deploy
                 const contract = await deployTestContractBalances();
-                sendEvmMine();
+                await sendEvmMine();
                 contract.waitForDeployment();
 
                 {
@@ -312,7 +312,7 @@ describe("JSON-RPC", () => {
                     const data = contract.interface.encodeFunctionData("add", [ALICE.address, 5]);
                     const transaction = { to: contract.target, data: data };
                     await send("eth_call", [transaction, "latest"]);
-                    sendEvmMine();
+                    await sendEvmMine();
                 }
 
                 const data = contract.interface.encodeFunctionData("get", [ALICE.address]);
@@ -324,23 +324,20 @@ describe("JSON-RPC", () => {
                 expect(currentAliceBalance).eq(expectedAliceBalance);
             });
 
-            // FIXME: this test is intermitent
-            //        it sometimes receive undefined ad current balance,
-            //        because Stratus claims the contract.target address is not a contract
-            // it("Works when using the field 'input' instead of 'data'", async () => {
-            //     // deploy
-            //     const contract = await deployTestContractBalances();
-            //     sendEvmMine();
-            //     contract.waitForDeployment();
+            it("Works when using the field 'input' instead of 'data'", async () => {
+                // deploy
+                const contract = await deployTestContractBalances();
+                await sendEvmMine();
+                contract.waitForDeployment();
 
-            //     const data = contract.interface.encodeFunctionData("get", [ALICE.address]);
-            //     const transaction = { to: contract.target, input: data };
-            //     const currentAliceBalance = await send("eth_call", [transaction, "latest"]);
+                const data = contract.interface.encodeFunctionData("get", [ALICE.address]);
+                const transaction = { to: contract.target, input: data };
+                const currentAliceBalance = await send("eth_call", [transaction, "latest"]);
 
-            //     // validate
-            //     const expectedAliceBalance = toPaddedHex(0, 32);
-            //     expect(currentAliceBalance).eq(expectedAliceBalance);
-            // });
+                // validate
+                const expectedAliceBalance = toPaddedHex(0, 32);
+                expect(currentAliceBalance).eq(expectedAliceBalance);
+            });
         });
     });
 


### PR DESCRIPTION
### **PR Type**
Bug fix, Tests


___

### **Description**
- Fixed asynchronous behavior in JSON-RPC tests by adding `await` to `sendEvmMine()` calls
- Uncommented and fixed a previously intermittent test case that checks if eth_call works with 'input' field instead of 'data'
- Removed FIXME comment explaining the intermittent test issue, as it has been resolved
- Improved test reliability and coverage for JSON-RPC functionality


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>e2e-json-rpc.test.ts</strong><dd><code>Fix async behavior in JSON-RPC tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

e2e/test/external/e2e-json-rpc.test.ts

<li>Added <code>await</code> to <code>sendEvmMine()</code> calls to ensure proper synchronization<br> <li> Uncommented and fixed a previously intermittent test case<br> <li> Removed FIXME comment explaining the intermittent test issue<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1659/files#diff-f5d1f06c4777826f9cbdcb4372d15c42f354177c83df65f3324cfd607da16004">+16/-19</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

