### PR TITLE
enha: add unknown_client_enabled config

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -110,6 +110,10 @@ pub struct CommonConfig {
     /// Prevents clap from breaking when passing `nocapture` options in tests.
     #[arg(long = "nocapture")]
     pub nocapture: bool,
+
+    /// Enables or disables unknown client interactions.
+    #[arg(long = "unknown-client-enabled", env = "UNKNOWN_CLIENT_ENABLED", default_value = "true")]
+    pub unknown_client_enabled: bool,
 }
 
 impl WithCommonConfig for CommonConfig {

--- a/src/globals.rs
+++ b/src/globals.rs
@@ -47,6 +47,9 @@ where
         let config = T::parse();
         let common = config.common();
 
+        // Set the unknown_client_enabled value
+        GlobalState::set_unknown_client_enabled(common.unknown_client_enabled);
+
         // init tokio
         let tokio = common.init_tokio_runtime().expect("failed to init tokio runtime");
 


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added a new configuration option `unknown_client_enabled` to `CommonConfig` in `src/config.rs`.
- This option can be set via an environment variable `UNKNOWN_CLIENT_ENABLED` with a default value of `true`.
- Updated `src/globals.rs` to set the `unknown_client_enabled` value in the global state.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.rs</strong><dd><code>Add `unknown_client_enabled` configuration option to `CommonConfig`</code></dd></summary>
<hr>

src/config.rs

<li>Added a new configuration option <code>unknown_client_enabled</code> to <br><code>CommonConfig</code>.<br> <li> This option can be set via an environment variable <br><code>UNKNOWN_CLIENT_ENABLED</code>.<br> <li> Default value for <code>unknown_client_enabled</code> is set to <code>true</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1661/files#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecd">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>globals.rs</strong><dd><code>Set `unknown_client_enabled` in global state</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/globals.rs

- Set the `unknown_client_enabled` value in the global state.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1661/files#diff-48d6fbc3a4ed67100952dcccfada858623c931e73d6de32984d4d1457e68d3a9">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

