### PR TITLE
enha: improve rocks revert to block

### DIFF
--- a/src/eth/storage/inmemory/inmemory_permanent.rs
+++ b/src/eth/storage/inmemory/inmemory_permanent.rs
@@ -99,7 +99,7 @@ impl PermanentStorage for InMemoryPermanentStorage {
 
     // -------------------------------------------------------------------------
     // State operations
-    // ------------------------------------------------------------------------
+    // -------------------------------------------------------------------------
 
     fn read_account(&self, address: &Address, point_in_time: &StoragePointInTime) -> anyhow::Result<Option<Account>> {
         let state = self.lock_read();

--- a/src/eth/storage/rocks/mod.rs
+++ b/src/eth/storage/rocks/mod.rs
@@ -1,3 +1,5 @@
+/// Batch writer with capacity for flushing temporarily.
+mod rocks_batch_writer;
 /// Data manipulation for column families.
 mod rocks_cf;
 /// Settings and tweaks for the database and column families.

--- a/src/eth/storage/rocks/rocks_batch_writer.rs
+++ b/src/eth/storage/rocks/rocks_batch_writer.rs
@@ -1,0 +1,82 @@
+use std::fmt::Debug;
+use std::mem;
+
+use anyhow::Context;
+use rocksdb::WriteBatch;
+use rocksdb::DB;
+use serde::Deserialize;
+use serde::Serialize;
+
+use super::rocks_cf::RocksCfRef;
+
+pub fn write_in_batch_for_multiple_cfs_impl(db: &DB, batch: WriteBatch) -> anyhow::Result<()> {
+    let batch_len = batch.len();
+    db.write(batch)
+        .context("failed to write in batch to (possibly) multiple column families")
+        .inspect_err(|e| {
+            tracing::error!(reason = ?e, batch_len, "failed to write batch to DB");
+        })
+}
+
+/// A writer that automatically flushes the batch when it exhausts capacity, supports multiple CFs.
+///
+/// Similar to `io::BufWriter`.
+pub struct BufferedBatchWriter {
+    len: usize,
+    capacity: usize,
+    batch: WriteBatch,
+}
+
+impl BufferedBatchWriter {
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            len: 0,
+            capacity,
+            batch: WriteBatch::default(),
+        }
+    }
+
+    pub fn insert<K, V>(&mut self, cf_ref: &RocksCfRef<K, V>, key: K, value: V) -> anyhow::Result<()>
+    where
+        K: Serialize + for<'de> Deserialize<'de> + Debug + std::hash::Hash + Eq,
+        V: Serialize + for<'de> Deserialize<'de> + Debug + Clone,
+    {
+        self.len += 1;
+        cf_ref.prepare_batch_insertion([(key, value)], &mut self.batch)?;
+        if self.len >= self.capacity {
+            self.flush(cf_ref.db())?;
+        }
+        Ok(())
+    }
+
+    pub fn delete<K, V>(&mut self, cf_ref: &RocksCfRef<K, V>, key: K) -> anyhow::Result<()>
+    where
+        K: Serialize + for<'de> Deserialize<'de> + Debug + std::hash::Hash + Eq,
+        V: Serialize + for<'de> Deserialize<'de> + Debug + Clone,
+    {
+        self.len += 1;
+        cf_ref.prepare_batch_deletion([key], &mut self.batch)?;
+        if self.len >= self.capacity {
+            self.flush(cf_ref.db())?;
+        }
+        Ok(())
+    }
+
+    pub fn flush(&mut self, db: &DB) -> anyhow::Result<()> {
+        if self.len == 0 {
+            return Ok(());
+        }
+        let batch = mem::take(&mut self.batch);
+        write_in_batch_for_multiple_cfs_impl(db, batch)?;
+        self.len = 0;
+        Ok(())
+    }
+}
+
+impl Drop for BufferedBatchWriter {
+    fn drop(&mut self) {
+        if self.len > 0 {
+            tracing::error!(elements_remaining = %self.len, "BufferedBatchWriter dropped with elements not flushed");
+        }
+    }
+}

--- a/src/eth/storage/rocks/rocks_permanent.rs
+++ b/src/eth/storage/rocks/rocks_permanent.rs
@@ -82,7 +82,7 @@ impl PermanentStorage for RocksPermanentStorage {
 
     // -------------------------------------------------------------------------
     // State operations
-    // ------------------------------------------------------------------------
+    // -------------------------------------------------------------------------
 
     fn read_account(&self, address: &Address, point_in_time: &StoragePointInTime) -> anyhow::Result<Option<Account>> {
         self.state.read_account(address, point_in_time)

--- a/src/eth/storage/rocks/rocks_state.rs
+++ b/src/eth/storage/rocks/rocks_state.rs
@@ -18,6 +18,8 @@ use serde::Deserialize;
 use serde::Serialize;
 use sugars::hmap;
 
+use super::rocks_batch_writer::write_in_batch_for_multiple_cfs_impl;
+use super::rocks_batch_writer::BufferedBatchWriter;
 use super::rocks_cf::RocksCfRef;
 use super::rocks_config::CacheSetting;
 use super::rocks_config::DbConfig;
@@ -43,7 +45,6 @@ use crate::eth::storage::rocks::types::IndexRocksdb;
 use crate::eth::storage::rocks::types::SlotIndexRocksdb;
 use crate::eth::storage::rocks::types::SlotValueRocksdb;
 use crate::eth::storage::StoragePointInTime;
-use crate::ext::not;
 use crate::ext::OptionExt;
 use crate::log_and_err;
 use crate::utils::GIGABYTE;
@@ -413,12 +414,7 @@ impl RocksStorageState {
 
     /// Write to DB in a batch
     pub fn write_in_batch_for_multiple_cfs(&self, batch: WriteBatch) -> Result<()> {
-        let batch_len = batch.len();
-        let result = self.db.write(batch).context("failed to write in batch to multiple column families");
-
-        result.inspect_err(|e| {
-            tracing::error!(reason = ?e, batch_len, "failed to write batch to DB");
-        })
+        write_in_batch_for_multiple_cfs_impl(&self.db, batch)
     }
 
     /// Writes accounts to state (does not write to account history)
@@ -456,93 +452,131 @@ impl RocksStorageState {
         Ok(())
     }
 
-    pub fn revert_state_to_block(&self, target_number: BlockNumberRocksdb) -> Result<()> {
-        // clear current state, it will be reconstructed
-        tracing::info!("clearing current account state");
+    /// Revert state to target block, removing all effect from blocks after it.
+    pub fn revert_state_to_block(&self, target_block: BlockNumberRocksdb) -> Result<()> {
+        tracing::info!("clearing current account state (it will be reconstructed)");
         self.accounts.clear()?;
-        tracing::info!("clearing current slots state");
+        tracing::info!("clearing current slots state (it will be reconstructed)");
         self.account_slots.clear()?;
 
-        // whether or not a block should be kept
-        let should_keep_block = |block_number| block_number <= target_number;
+        // all data from blocks after `target_block` should be deleted
+        let should_delete_block = |block_number| block_number > target_block;
+
+        let mut bufwriter = BufferedBatchWriter::new(1024 * 2);
+
+        struct LastHistoricalAccount {
+            address: AddressRocksdb,
+            account: AccountRocksdb,
+        }
+
+        let mut history_accounts_count = 0;
+        let mut accounts_count = 0;
+        let mut last_account: Option<LastHistoricalAccount> = None;
 
         tracing::info!("starting iteration through historical accounts to clean values after target_block and reconstruct current accounts state");
-        let mut accounts = HashMap::<AddressRocksdb, (BlockNumberRocksdb, AccountRocksdb)>::new();
-        let mut history_accounts_count = 0;
         for next in self.accounts_history.iter_start() {
-            history_accounts_count += 1;
             let ((address, account_block_number), account) = next?;
 
-            if not(should_keep_block(account_block_number)) {
-                self.accounts_history.delete(&(address, account_block_number))?;
-            } else if accounts
-                .get(&address)
-                .map(|(previous_number, _)| previous_number < &account_block_number)
-                .unwrap_or(true)
-            {
-                accounts.insert(address, (account_block_number, account));
+            if should_delete_block(account_block_number) {
+                bufwriter.delete(&self.accounts_history, (address, account_block_number))?;
             }
-        }
-        tracing::info!(%history_accounts_count, "iterated through all historical accounts");
 
-        let accounts_len = accounts.len();
-        let accounts_without_number = accounts.into_iter().map(|(address, (_, account))| (address, account));
-        tracing::info!(%accounts_len, "saving reprocessed accounts");
-        self.accounts.prepare_and_apply_insertion_batch_with_context(accounts_without_number)?;
+            if let Some(last) = last_account {
+                let is_different_account = last.address != address;
+                // if reached a new account, insert the previous as it is the most up-to-date for that address,
+                // considering that it's ordered by block number too
+                if is_different_account {
+                    bufwriter.insert(&self.accounts, last.address, last.account)?;
+                    accounts_count += 1;
+                }
+            }
+
+            last_account = Some(LastHistoricalAccount { address, account });
+            history_accounts_count += 1;
+        }
+
+        // always insert last seen account
+        if let Some(last) = last_account {
+            bufwriter.insert(&self.accounts, last.address, last.account)?;
+            accounts_count += 1;
+        }
+
+        bufwriter.flush(&self.db)?;
+        tracing::info!(%history_accounts_count, %accounts_count, "finished historical accounts iteration");
+
+        struct LastHistoricalSlot {
+            address: AddressRocksdb,
+            index: SlotIndexRocksdb,
+            value: SlotValueRocksdb,
+        }
+
+        let mut history_slots_count = 0;
+        let mut slots_count = 0;
+        let mut last_slot: Option<LastHistoricalSlot> = None;
 
         tracing::info!("starting iteration through historical slots to clean values after target_block and reconstruct current slots state");
-        let mut slots = HashMap::<(AddressRocksdb, SlotIndexRocksdb), (BlockNumberRocksdb, SlotValueRocksdb)>::new();
-        let mut history_slots_count = 0;
         for next in self.account_slots_history.iter_start() {
-            history_slots_count += 1;
-            let ((address, index, slot_block_number), slot_value) = next?;
-            let key = (address, index);
+            let ((address, index, slot_block_number), value) = next?;
 
-            if not(should_keep_block(slot_block_number)) {
-                self.account_slots_history.delete(&(address, index, slot_block_number))?;
-            } else if slots.get(&key).map(|(previous_number, _)| previous_number < &slot_block_number).unwrap_or(true) {
-                slots.insert(key, (slot_block_number, slot_value));
+            if should_delete_block(slot_block_number) {
+                bufwriter.delete(&self.account_slots_history, (address, index, slot_block_number))?;
             }
+
+            if let Some(last) = last_slot {
+                let is_different_slot = last.address != address || last.index != index;
+                // if reached a new slot, insert the previous as it is the most up-to-date for that account
+                // and index, considering that it's ordered by block number too
+                if is_different_slot {
+                    bufwriter.insert(&self.account_slots, (last.address, last.index), last.value)?;
+                    slots_count += 1;
+                }
+            }
+
+            last_slot = Some(LastHistoricalSlot { address, index, value });
+            history_slots_count += 1;
         }
-        tracing::info!(%history_slots_count, "iterated through all historical slots");
 
-        let slots_len = slots.len();
-        let slots_without_number = slots.into_iter().map(|((address, idx), (_, value))| ((address, idx), value));
+        // always insert last seen slot
+        if let Some(last) = last_slot {
+            bufwriter.insert(&self.account_slots, (last.address, last.index), last.value)?;
+            slots_count += 1;
+        }
 
-        tracing::info!(%slots_len, "saving reprocessed slots");
-        self.account_slots.prepare_and_apply_insertion_batch_with_context(slots_without_number)?;
+        bufwriter.flush(&self.db)?;
+        tracing::info!(%history_slots_count, %slots_count, "finished historical slots iteration");
 
-        // truncate the rest of column families
-        tracing::info!("cleaning values in transactions CF");
+        tracing::info!("cleaning values in transactions column family");
         for next in self.transactions.iter_start() {
             let (hash, block) = next?;
-            if not(should_keep_block(block)) {
-                self.transactions.delete(&hash)?;
+            if should_delete_block(block) {
+                bufwriter.delete(&self.transactions, hash)?;
             }
         }
-        tracing::info!("cleaning values in logs CF");
+        bufwriter.flush(&self.db)?;
+
+        tracing::info!("cleaning values in logs column family");
         for next in self.logs.iter_start() {
             let (key, block) = next?;
-            if block > target_number {
-                self.logs.delete(&key)?;
+            if block > target_block {
+                bufwriter.delete(&self.logs, key)?;
             }
         }
-        tracing::info!("cleaning values in blocks_by_hash CF");
+        bufwriter.flush(&self.db)?;
+
+        tracing::info!("cleaning values in blocks_by_hash column family");
         for next in self.blocks_by_hash.iter_start() {
             let (hash, block) = next?;
-            if not(should_keep_block(block)) {
-                self.blocks_by_hash.delete(&hash)?;
+            if should_delete_block(block) {
+                bufwriter.delete(&self.blocks_by_hash, hash)?;
             }
         }
-        tracing::info!("cleaning values in blocks_by_number CF");
-        for next in self.blocks_by_number.iter_end() {
-            let (block, _) = next?;
-            if not(should_keep_block(block)) {
-                self.blocks_by_number.delete(&block)?;
-            } else {
-                break; // blocks are ordered by key, so we can stop early here
-            }
+        bufwriter.flush(&self.db)?;
+
+        tracing::info!("cleaning values in blocks_by_number column family");
+        for block in self.blocks_by_number.iter_from(target_block + 1, Direction::Forward)?.keys() {
+            bufwriter.delete(&self.blocks_by_number, block?)?;
         }
+        bufwriter.flush(&self.db)?;
 
         Ok(())
     }

--- a/src/eth/storage/rocks/types/block_number.rs
+++ b/src/eth/storage/rocks/types/block_number.rs
@@ -1,4 +1,5 @@
 use std::fmt::Debug;
+use std::ops::Add;
 
 use ethereum_types::U64;
 
@@ -30,5 +31,13 @@ impl From<BlockNumberRocksdb> for BlockNumber {
 impl From<BlockNumberRocksdb> for u64 {
     fn from(value: BlockNumberRocksdb) -> Self {
         value.0.as_u64()
+    }
+}
+
+impl Add<u64> for BlockNumberRocksdb {
+    type Output = Self;
+
+    fn add(self, other: u64) -> Self {
+        BlockNumberRocksdb(self.0 + other)
     }
 }

--- a/src/eth/storage/rocks/types/slot.rs
+++ b/src/eth/storage/rocks/types/slot.rs
@@ -6,7 +6,7 @@ use crate::eth::primitives::SlotIndex;
 use crate::eth::primitives::SlotValue;
 use crate::gen_newtype_from;
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct SlotValueRocksdb(U256);
 
 impl SlotValueRocksdb {


### PR DESCRIPTION
### **User description**
it's now constant in memory complexity and writes everything in batches
to reduce overhead

previously, this binary was O(Slots) in memory and was crashed by OS's
OOM when running with our production database due to the amount
of slots

now, it shouldn't crash


___

### **PR Type**
Enhancement


___

### **Description**
- Implemented `BufferedBatchWriter` and `CfBufferedBatchWriter` for efficient batch operations in RocksDB
- Refactored and optimized `revert_state_to_block` method to use `BufferedBatchWriter`, improving memory usage and performance
- Enhanced `RocksCfRef` with new methods and improved iterators
- Added `Add` trait implementation for `BlockNumberRocksdb` and `Copy` trait for `SlotValueRocksdb`
- Minor formatting improvements in some files


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>inmemory_permanent.rs</strong><dd><code>Minor formatting in inmemory_permanent.rs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/inmemory/inmemory_permanent.rs

- Minor formatting change: replaced dashes with hyphens in a comment



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1662/files#diff-6cc83da72398cf1ba410cb7dd95e4e8f232f5db52c81bc92de5261dfe6d8e429">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rocks_permanent.rs</strong><dd><code>Minor formatting in rocks_permanent.rs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/rocks/rocks_permanent.rs

- Minor formatting change: replaced dashes with hyphens in a comment



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1662/files#diff-c129c50a85915e0c5154c4e048a4577bd45ce6ae9ec98e95acbcad09ff79b3c6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Add rocks_batch_writer module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/rocks/mod.rs

- Added a new module `rocks_batch_writer`



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1662/files#diff-38613469ff37344dd2d68aa4da8280b321c01993e312518834dbf4834f9422bc">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rocks_batch_writer.rs</strong><dd><code>Implement batch writers for RocksDB</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/rocks/rocks_batch_writer.rs

<li>Implemented new <code>BufferedBatchWriter</code> and <code>CfBufferedBatchWriter</code> structs<br> <li> Added functions for batch writing and flushing<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1662/files#diff-d9ef8ac39be277b072f06ff5a4399800ecc9b3082883b20ec0a0993f8fee1cfb">+151/-0</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rocks_cf.rs</strong><dd><code>Enhance RocksCF functionality and iterators</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/rocks/rocks_cf.rs

<li>Added <code>db()</code> method to <code>RocksCfRef</code><br> <li> Implemented <code>prepare_batch_deletion</code> method<br> <li> Renamed <code>RocksCfIterator</code> to <code>RocksCfIter</code> and added <code>RocksCfKeysIter</code><br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1662/files#diff-0eaed53baca4bd2355e2a54a150b305569904a45c93547da288208c6373d1df2">+83/-30</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rocks_state.rs</strong><dd><code>Optimize revert_state_to_block using BufferedBatchWriter</code>&nbsp; </dd></summary>
<hr>

src/eth/storage/rocks/rocks_state.rs

<li>Refactored <code>revert_state_to_block</code> method to use <code>BufferedBatchWriter</code><br> <li> Optimized memory usage and improved performance<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1662/files#diff-f7b822022d2c4fd93ec507cd6b5302dcf1646acbf0ee0dd077a047272b686009">+95/-61</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>block_number.rs</strong><dd><code>Add addition operation for BlockNumberRocksdb</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/rocks/types/block_number.rs

- Implemented `Add` trait for `BlockNumberRocksdb`



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1662/files#diff-512e4dee45efa0fbed2256d295710f3c1239264453abd114abccea21488bef61">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>slot.rs</strong><dd><code>Add Copy trait to SlotValueRocksdb</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/rocks/types/slot.rs

- Added `Copy` trait to `SlotValueRocksdb` struct



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1662/files#diff-09cc32bbf181bb4f4d19c90c8f15fbabcb8e7ea86de2a60b2f14e41a111e2a27">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

