### PR TITLE
tweak: importer-offline decrease backlog size

### DIFF
--- a/src/bin/importer_offline.rs
+++ b/src/bin/importer_offline.rs
@@ -39,7 +39,7 @@ use tokio::time::Instant;
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
 /// Number of tasks in the backlog. Each task contains `--blocks-by-fetch` blocks and all receipts for them.
-const BACKLOG_SIZE: usize = 50;
+const BACKLOG_SIZE: usize = 10;
 
 type BacklogTask = (Vec<ExternalBlock>, Vec<ExternalReceipt>);
 


### PR DESCRIPTION
### **User description**
there is currently no benefit in having a larger backlog size, and we've been experiencing OOM problems, so this PR reduces it


___

### **PR Type**
Enhancement


___

### **Description**
- Reduced the `BACKLOG_SIZE` constant in the importer_offline module from 50 to 10
- This change aims to address Out of Memory (OOM) issues experienced with the larger backlog size
- The smaller backlog size is expected to improve memory usage without significant performance impact


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>importer_offline.rs</strong><dd><code>Decrease importer offline backlog size</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/bin/importer_offline.rs

- Reduced the `BACKLOG_SIZE` constant from 50 to 10



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1663/files#diff-9fef7d584818c3db119ea1cd0952a57a953751f85f93ca813af861c4c737c53a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

