### PR TITLE
enha: expose leader/follower branching on health and send_raw_transaction endpoints

### DIFF
--- a/e2e/cloudwalk-contracts/integration/test/leader-follower.test.ts
+++ b/e2e/cloudwalk-contracts/integration/test/leader-follower.test.ts
@@ -19,10 +19,18 @@ describe("Leader & Follower integration test", function () {
         const leaderMode = await sendWithRetry("stratus_state", []);
         expect(leaderMode.is_leader).to.equal(true);
 
+        // Check Stratus Leader health
+        const leaderHealth = await sendWithRetry("stratus_health", []);
+        expect(leaderHealth).to.equal(true);
+
         // Check Stratus Follower node mode
         updateProviderUrl("stratus-follower");
         const followerMode = await sendWithRetry("stratus_state", []);
         expect(followerMode.is_leader).to.equal(false);
+
+        // Check Stratus Follower health
+        const followerHealth = await sendWithRetry("stratus_health", []);
+        expect(followerHealth).to.equal(true);
 
         updateProviderUrl("stratus");
     });

--- a/e2e/cloudwalk-contracts/integration/test/leader-follower.test.ts
+++ b/e2e/cloudwalk-contracts/integration/test/leader-follower.test.ts
@@ -31,8 +31,6 @@ describe("Leader & Follower integration test", function () {
         // Check Stratus Follower health
         const followerHealth = await sendWithRetry("stratus_health", []);
         expect(followerHealth).to.equal(true);
-
-        updateProviderUrl("stratus");
     });
 
     before(async function () {
@@ -46,6 +44,8 @@ describe("Leader & Follower integration test", function () {
 
             expect(deployer.address).to.equal(await brlcToken.mainMinter());
             expect(await brlcToken.isMinter(deployer.address)).to.be.true;
+
+            updateProviderUrl("stratus");
         });
     });
 

--- a/e2e/cloudwalk-contracts/integration/test/leader-follower.test.ts
+++ b/e2e/cloudwalk-contracts/integration/test/leader-follower.test.ts
@@ -39,7 +39,7 @@ describe("Leader & Follower integration test", function () {
         await setDeployer();
     });
 
-    describe("Deploy and configure BRLC contract via Transaction Forward to Leader node", function () {
+    describe("Deploy and configure BRLC contract using transaction forwarding from follower to leader", function () {
         it("Validate deployer is main minter", async function () {
             updateProviderUrl("stratus-follower");
 

--- a/e2e/cloudwalk-contracts/integration/test/leader-follower.test.ts
+++ b/e2e/cloudwalk-contracts/integration/test/leader-follower.test.ts
@@ -31,14 +31,18 @@ describe("Leader & Follower integration test", function () {
         // Check Stratus Follower health
         const followerHealth = await sendWithRetry("stratus_health", []);
         expect(followerHealth).to.equal(true);
+
+        updateProviderUrl("stratus");
     });
 
     before(async function () {
         await setDeployer();
     });
 
-    describe("Deploy and configure BRLC contract", function () {
+    describe("Deploy and configure BRLC contract via Transaction Forward to Leader node", function () {
         it("Validate deployer is main minter", async function () {
+            updateProviderUrl("stratus-follower");
+
             await deployBRLC();
             await configureBRLC();
 

--- a/src/eth/primitives/stratus_error.rs
+++ b/src/eth/primitives/stratus_error.rs
@@ -34,6 +34,10 @@ pub enum StratusError {
     #[strum(props(kind = "client_request"))]
     RpcBlockRangeInvalid { actual: u64, max: u64 },
 
+    #[error("Consensus is temporarily unavailable for follower node.")]
+    #[strum(props(kind = "server_state"))]
+    RpcConsensusUnavailable,
+
     #[error("Denied because client did not identify itself.")]
     #[strum(props(kind = "client_request"))]
     RpcClientMissing,

--- a/src/eth/rpc/rpc_server.rs
+++ b/src/eth/rpc/rpc_server.rs
@@ -649,7 +649,7 @@ fn eth_send_raw_transaction(params: Params<'_>, ctx: Arc<RpcContext>, ext: Exten
                 Err(e) => Err(e),
             },
             None => {
-                tracing::error!("consensus is None for follower node");
+                tracing::error!("unable to forward transaction because consensus is unavailable for follower node");
                 Err(StratusError::RpcConsensusUnavailable)
             }
         },

--- a/src/eth/rpc/rpc_server.rs
+++ b/src/eth/rpc/rpc_server.rs
@@ -250,12 +250,10 @@ async fn stratus_health(_params: Params<'_>, context: Arc<RpcContext>, _extensio
 
     let should_serve = match GlobalState::get_node_mode() {
         NodeMode::Leader => true,
-        NodeMode::Follower =>
-            if let Some(consensus) = &context.consensus {
-                consensus.should_serve().await
-            } else {
-                false
-            },
+        NodeMode::Follower => match &context.consensus {
+            Some(consensus) => consensus.should_serve().await,
+            None => false,
+        },
     };
 
     if not(should_serve) {


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Improved handling of leader and follower node behavior in RPC functions:
  - Modified `stratus_health` to check consensus readiness for follower nodes only.
  - Updated `eth_send_raw_transaction` to use `NodeMode` for determining leader/follower status.
- Added new error `RpcConsensusUnavailable` for cases when consensus is unavailable for follower nodes.
- Enhanced integration tests:
  - Added health checks for both leader and follower nodes.
  - Modified BRLC contract deployment test to demonstrate transaction forwarding via follower node.
- Improved error handling and logging for consensus-related issues.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>stratus_error.rs</strong><dd><code>Add new error for unavailable consensus</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/stratus_error.rs

<li>Added a new error variant <code>RpcConsensusUnavailable</code> to handle cases when <br>consensus is temporarily unavailable for follower nodes.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1664/files#diff-301cded01d772388e3e5c08ede093b91c3e4478c08e11a48f70e3d44351385fb">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rpc_server.rs</strong><dd><code>Improve leader/follower handling in RPC functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/rpc/rpc_server.rs

<li>Modified <code>stratus_health</code> function to handle health checks differently <br>for leader and follower nodes.<br> <li> Updated <code>eth_send_raw_transaction</code> function to use <code>NodeMode</code> for <br>determining leader/follower status and handle consensus unavailability <br>for follower nodes.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1664/files#diff-835ba255c9a5c1fe0e13285bc39e058e1c74422e5e03ebba483c9d8a15c45405">+18/-11</a>&nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>leader-follower.test.ts</strong><dd><code>Enhance leader-follower integration tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

e2e/cloudwalk-contracts/integration/test/leader-follower.test.ts

<li>Added health checks for both leader and follower nodes in the <br>integration test.<br> <li> Modified the BRLC contract deployment test to use the follower node, <br>demonstrating transaction forwarding.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1664/files#diff-c558dd9393a1b9fbba4a68444666278a6549d291684c43101985ab4223c25457">+13/-1</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

