### PR TITLE
fix: slot counters in rocks revert_to_block

### DIFF
--- a/src/eth/storage/rocks/rocks_state.rs
+++ b/src/eth/storage/rocks/rocks_state.rs
@@ -469,8 +469,8 @@ impl RocksStorageState {
             account: AccountRocksdb,
         }
 
-        let mut history_accounts_count = 0;
-        let mut accounts_count = 0;
+        let mut history_accounts_count = 0_u64;
+        let mut accounts_count = 0_u64;
         let mut last_account: Option<LastHistoricalAccount> = None;
 
         tracing::info!("starting iteration through historical accounts to clean values after target_block and reconstruct current accounts state");
@@ -510,8 +510,8 @@ impl RocksStorageState {
             value: SlotValueRocksdb,
         }
 
-        let mut history_slots_count = 0;
-        let mut slots_count = 0;
+        let mut history_slots_count = 0_u64;
+        let mut slots_count = 0_u64;
         let mut last_slot: Option<LastHistoricalSlot> = None;
 
         tracing::info!("starting iteration through historical slots to clean values after target_block and reconstruct current slots state");


### PR DESCRIPTION
### **User description**
for the logging, they did overflow previously


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed potential integer overflow issues in the `RocksStorageState` implementation
- Changed the type of counter variables from implicit integer to explicit `u64`:
  - `history_accounts_count`
  - `accounts_count`
  - `history_slots_count`
  - `slots_count`
- This change ensures that these counters can handle large numbers without overflowing
- Improves code clarity and prevents potential bugs related to integer size assumptions


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rocks_state.rs</strong><dd><code>Explicit type declaration for counter variables</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/rocks/rocks_state.rs

<li>Changed the type of <code>history_accounts_count</code> and <code>accounts_count</code> from <br>implicit integer to explicit <code>u64</code><br> <li> Changed the type of <code>history_slots_count</code> and <code>slots_count</code> from implicit <br>integer to explicit <code>u64</code><br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1665/files#diff-f7b822022d2c4fd93ec507cd6b5302dcf1646acbf0ee0dd077a047272b686009">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

