### PR TITLE
tweak: adjust misleading warning

### DIFF
--- a/src/bin/rpc_downloader.rs
+++ b/src/bin/rpc_downloader.rs
@@ -34,6 +34,10 @@ fn main() -> anyhow::Result<()> {
 async fn run(config: RpcDownloaderConfig) -> anyhow::Result<()> {
     let _timer = DropTimer::start("rpc-downloader");
 
+    if not(config.external_rpc.contains("app=") || config.external_rpc.contains("/app/")) {
+        tracing::warn!(url = config.external_rpc, "url isn't identified with '?app=NAME' query parameter");
+    }
+
     let rpc_storage = config.rpc_storage.init().await?;
     let chain = Arc::new(BlockchainClient::new_http(&config.external_rpc, config.external_rpc_timeout).await?);
 

--- a/src/eth/storage/postgres_external_rpc/postgres_external_rpc.rs
+++ b/src/eth/storage/postgres_external_rpc/postgres_external_rpc.rs
@@ -15,7 +15,6 @@ use crate::eth::primitives::ExternalReceipt;
 use crate::eth::primitives::Hash;
 use crate::eth::primitives::Wei;
 use crate::eth::storage::ExternalRpcStorage;
-use crate::ext::not;
 use crate::ext::to_json_value;
 use crate::ext::traced_sleep;
 use crate::ext::SleepReason;
@@ -38,10 +37,6 @@ impl PostgresExternalRpcStorage {
     /// Creates a new [`PostgresExternalRpcStorage`].
     pub async fn new(config: PostgresExternalRpcStorageConfig) -> anyhow::Result<Self> {
         tracing::info!(?config, "creating postgres external rpc storage");
-
-        if not(config.url.contains('?')) {
-            tracing::warn!(url = config.url, "url isn't identified with '?app=NAME' query parameter");
-        }
 
         let result = PgPoolOptions::new()
             .min_connections(config.connections)


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Improved URL validation for external RPC:
  - Added a check in `rpc_downloader.rs` to verify if the external RPC URL contains 'app=' or '/app/'
  - Implemented a warning log if the URL doesn't contain the expected identifier
- Removed redundant URL check from `postgres_external_rpc.rs`:
  - Deleted the previous warning log and associated import
- Enhanced code organization by moving the URL check to a more appropriate location


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rpc_downloader.rs</strong><dd><code>Add URL identifier check and warning</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/bin/rpc_downloader.rs

<li>Added a check for the presence of 'app=' or '/app/' in the external <br>RPC URL<br> <li> Implemented a warning log if the URL doesn't contain the expected <br>identifier<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1666/files#diff-34137b2d44a1c2a35b30a2515f309e99ecd04277d9b2d681ff55c5bbe30ac5c1">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>postgres_external_rpc.rs</strong><dd><code>Remove redundant URL check</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/postgres_external_rpc/postgres_external_rpc.rs

<li>Removed the URL check and warning from this file<br> <li> Deleted the import of the 'not' function<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1666/files#diff-faa79cbfb46cf46c342c70e132c2ab2e8b7011ec9e31eb9608f01a3f19f431db">+0/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

