### PR TITLE
regression test: don't save unchanged accounts to history 

### DIFF
--- a/src/eth/storage/rocks/rocks_state.rs
+++ b/src/eth/storage/rocks/rocks_state.rs
@@ -417,16 +417,6 @@ impl RocksStorageState {
         write_in_batch_for_multiple_cfs_impl(&self.db, batch)
     }
 
-    /// Writes accounts to state (does not write to account history)
-    #[allow(dead_code)]
-    fn write_accounts(&self, accounts: Vec<Account>) -> Result<()> {
-        let accounts = accounts.into_iter().map(Into::into);
-
-        let mut batch = WriteBatch::default();
-        self.accounts.prepare_batch_insertion(accounts, &mut batch)?;
-        self.accounts.apply_batch_with_context(batch)
-    }
-
     /// Writes slots to state (does not write to slot history)
     #[cfg_attr(not(test), allow(dead_code))]
     pub fn write_slots(&self, slots: Vec<(Address, Slot)>) -> Result<()> {

--- a/src/eth/storage/rocks/rocks_state.rs
+++ b/src/eth/storage/rocks/rocks_state.rs
@@ -175,12 +175,7 @@ impl RocksStorageState {
     }
 
     /// Updates the in-memory state with changes from transaction execution
-    fn prepare_batch_state_update_with_execution_changes(
-        &self,
-        changes: &[ExecutionAccountChanges],
-        block_number: BlockNumber,
-        batch: &mut WriteBatch,
-    ) -> Result<()> {
+    fn prepare_batch_with_execution_changes(&self, changes: &[ExecutionAccountChanges], block_number: BlockNumber, batch: &mut WriteBatch) -> Result<()> {
         let mut account_changes = Vec::new();
         let mut account_history_changes = Vec::new();
 
@@ -406,7 +401,7 @@ impl RocksStorageState {
         let block_by_hash = (block_hash.into(), number.into());
         self.blocks_by_hash.prepare_batch_insertion([block_by_hash], &mut batch)?;
 
-        self.prepare_batch_state_update_with_execution_changes(&account_changes, number, &mut batch)?;
+        self.prepare_batch_with_execution_changes(&account_changes, number, &mut batch)?;
 
         self.write_in_batch_for_multiple_cfs(batch)?;
         Ok(())
@@ -418,7 +413,7 @@ impl RocksStorageState {
     }
 
     /// Writes slots to state (does not write to slot history)
-    #[cfg_attr(not(test), allow(dead_code))]
+    #[cfg(test)]
     pub fn write_slots(&self, slots: Vec<(Address, Slot)>) -> Result<()> {
         let slots = slots
             .into_iter()
@@ -427,6 +422,16 @@ impl RocksStorageState {
         let mut batch = WriteBatch::default();
         self.account_slots.prepare_batch_insertion(slots, &mut batch)?;
         self.account_slots.apply_batch_with_context(batch)
+    }
+
+    #[cfg(test)]
+    pub fn read_all_accounts(&self) -> Result<Vec<AccountRocksdb>> {
+        self.accounts.iter_start().map(|result| Ok(result?.1)).collect()
+    }
+
+    #[cfg(test)]
+    pub fn read_all_historical_accounts(&self) -> Result<Vec<AccountRocksdb>> {
+        self.accounts_history.iter_start().map(|result| Ok(result?.1)).collect()
     }
 
     /// Clears in-memory state.
@@ -723,6 +728,7 @@ mod tests {
 
     use super::*;
     use crate::eth::primitives::BlockHeader;
+    use crate::eth::primitives::ExecutionValueChange;
     use crate::eth::primitives::SlotValue;
 
     #[test]
@@ -788,5 +794,52 @@ mod tests {
         };
 
         assert_eq!(state.read_logs(&filter).unwrap().len(), 200);
+    }
+
+    #[test]
+    fn regression_test_saving_account_changes_for_accounts_that_didnt_change() {
+        let test_dir = tempdir().unwrap();
+        let state = RocksStorageState::new(test_dir.path().display().to_string()).unwrap();
+
+        let change_base = ExecutionAccountChanges {
+            new_account: false,
+            address: Faker.fake(),
+            nonce: ExecutionValueChange::from_original(Faker.fake()),
+            balance: ExecutionValueChange::from_original(Faker.fake()),
+            bytecode: ExecutionValueChange::from_original(Faker.fake()),
+            code_hash: Faker.fake(),
+            slots: HashMap::new(),
+        };
+
+        // 4 changes for the same address, the first isn't modified, the other three are
+        let changes = [
+            ExecutionAccountChanges { ..change_base.clone() },
+            ExecutionAccountChanges {
+                nonce: ExecutionValueChange::from_modified(Faker.fake()),
+                ..change_base.clone()
+            },
+            ExecutionAccountChanges {
+                balance: ExecutionValueChange::from_modified(Faker.fake()),
+                ..change_base.clone()
+            },
+            ExecutionAccountChanges {
+                bytecode: ExecutionValueChange::from_modified(Faker.fake()),
+                ..change_base
+            },
+        ];
+
+        let mut batch = WriteBatch::default();
+        // add accounts in separate blocks so they show up in history
+        state.prepare_batch_with_execution_changes(&changes[0..=0], 1.into(), &mut batch).unwrap();
+        state.prepare_batch_with_execution_changes(&changes[1..=1], 2.into(), &mut batch).unwrap();
+        state.prepare_batch_with_execution_changes(&changes[2..=2], 3.into(), &mut batch).unwrap();
+        state.prepare_batch_with_execution_changes(&changes[3..=3], 4.into(), &mut batch).unwrap();
+        state.write_in_batch_for_multiple_cfs(batch).unwrap();
+
+        let accounts = state.read_all_accounts().unwrap();
+        assert_eq!(accounts.len(), 1);
+
+        let history = state.read_all_historical_accounts().unwrap();
+        assert_eq!(history.len(), 3);
     }
 }


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Refactored `RocksStorageState` implementation:
  - Simplified `prepare_batch_with_execution_changes` method
  - Removed unused `write_accounts` function
  - Made `write_slots` method test-only
- Added new test-only methods:
  - `read_all_accounts`: Reads all accounts from the database
  - `read_all_historical_accounts`: Reads all historical accounts from the database
- Implemented regression test to ensure unmodified accounts aren't saved in history
- Minor code cleanup and formatting improvements


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rocks_state.rs</strong><dd><code>Refactor RocksStorageState and add regression test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/rocks/rocks_state.rs

<li>Renamed and simplified <br><code>prepare_batch_state_update_with_execution_changes</code> to <br><code>prepare_batch_with_execution_changes</code><br> <li> Removed unused <code>write_accounts</code> function<br> <li> Added test-only methods <code>read_all_accounts</code> and <br><code>read_all_historical_accounts</code><br> <li> Implemented new regression test <br><code>regression_test_saving_account_changes_for_accounts_that_didnt_change</code><br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1677/files#diff-f7b822022d2c4fd93ec507cd6b5302dcf1646acbf0ee0dd077a047272b686009">+61/-18</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

