### PR TITLE
fix: clear poison from wrong Mutex

### DIFF
--- a/src/eth/executor/executor.rs
+++ b/src/eth/executor/executor.rs
@@ -402,7 +402,7 @@ impl Executor {
                 let _miner_lock = if self.miner.mode.is_interval() {
                     let miner_lock = Some(self.miner.locks.mine_and_commit.lock().unwrap_or_else(|poison| {
                         tracing::warn!("miner mine_and_commit lock was poisoned");
-                        self.locks.serial.clear_poison();
+                        self.miner.locks.mine_and_commit.clear_poison();
                         poison.into_inner()
                     }));
                     miner_lock

--- a/src/eth/miner/miner.rs
+++ b/src/eth/miner/miner.rs
@@ -107,7 +107,7 @@ impl Miner {
 
         // if automine is enabled, only one transaction can enter the block at time.
         let _save_execution_lock = if self.mode.is_automine() {
-            Some(self.locks.save_execution.lock().unwrap())
+            Some(self.locks.save_execution.lock().expect("fatal, save_execution lock poisoned"))
         } else {
             None
         };


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed a critical bug in the `Executor` implementation where the wrong mutex was being cleared of poison. The correct mutex (`self.miner.locks.mine_and_commit`) is now being cleared instead of `self.locks.serial`.
- Improved error handling in the `Miner` implementation for the `save_execution` lock. Now using `expect()` with a descriptive error message instead of `unwrap()`.
- These changes enhance the robustness and maintainability of the codebase, particularly in concurrent execution scenarios.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>executor.rs</strong><dd><code>Fix mutex poison clearing in Executor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/executor/executor.rs

<li>Fixed a bug in the <code>Executor</code> implementation where the wrong mutex was <br>being cleared of poison.<br> <li> Changed <code>self.locks.serial.clear_poison()</code> to <br><code>self.miner.locks.mine_and_commit.clear_poison()</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1678/files#diff-6b460d7dee8280c0287e8d9d9d59cf66a57ec9fed1bc003c6ede6fef60c7376b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>miner.rs</strong><dd><code>Improve error handling in Miner lock</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/miner/miner.rs

<li>Updated error handling in the <code>Miner</code> implementation for the <br><code>save_execution</code> lock.<br> <li> Changed from using <code>unwrap()</code> to <code>expect()</code> with a more descriptive error <br>message.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1678/files#diff-16f448afc7dae3e8e802f676a86dbd7051e19f6c17cbbeb53eb730d726372629">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

