### PR TITLE
enha: simplify code in execution changes batching

### DIFF
--- a/src/eth/storage/rocks/rocks_state.rs
+++ b/src/eth/storage/rocks/rocks_state.rs
@@ -175,35 +175,40 @@ impl RocksStorageState {
     }
 
     /// Updates the in-memory state with changes from transaction execution
-    fn prepare_batch_with_execution_changes(&self, changes: &[ExecutionAccountChanges], block_number: BlockNumber, batch: &mut WriteBatch) -> Result<()> {
+    fn prepare_batch_with_execution_changes<C>(&self, changes: C, block_number: BlockNumber, batch: &mut WriteBatch) -> Result<()>
+    where
+        C: IntoIterator<Item = ExecutionAccountChanges>,
+    {
         for change in changes {
+            let block_number = block_number.into();
+            let address: AddressRocksdb = change.address.into();
+
             if change.is_account_modified() {
-                let address: AddressRocksdb = change.address.into();
                 let mut account_info_entry = self.accounts.get_or_insert_with(address, AccountRocksdb::default)?;
 
-                if let Some(nonce) = change.nonce.clone().take_modified() {
+                if let Some(nonce) = change.nonce.take_modified() {
                     account_info_entry.nonce = nonce.into();
                 }
-                if let Some(balance) = change.balance.clone().take_modified() {
+                if let Some(balance) = change.balance.take_modified() {
                     account_info_entry.balance = balance.into();
                 }
-                if let Some(bytecode) = change.bytecode.clone().take_modified() {
+                if let Some(bytecode) = change.bytecode.take_modified() {
                     account_info_entry.bytecode = bytecode.map_into();
                 }
 
                 self.accounts.prepare_batch_insertion([(address, account_info_entry.clone())], batch)?;
                 self.accounts_history
-                    .prepare_batch_insertion([((address, block_number.into()), account_info_entry)], batch)?;
+                    .prepare_batch_insertion([((address, block_number), account_info_entry)], batch)?;
             }
 
             for (slot_index, slot_change) in &change.slots {
                 if let Some(slot) = slot_change.take_modified_ref() {
-                    let address: AddressRocksdb = change.address.into();
-                    let slot_index = *slot_index;
-                    self.account_slots
-                        .prepare_batch_insertion([((address, slot_index.into()), slot.value.into())], batch)?;
+                    let slot_index = (*slot_index).into();
+                    let slot_value = slot.value.into();
+
+                    self.account_slots.prepare_batch_insertion([((address, slot_index), slot_value)], batch)?;
                     self.account_slots_history
-                        .prepare_batch_insertion([((address, slot_index.into(), block_number.into()), slot.value.into())], batch)?;
+                        .prepare_batch_insertion([((address, slot_index, block_number), slot_value)], batch)?;
                 }
             }
         }
@@ -391,7 +396,7 @@ impl RocksStorageState {
         let block_by_hash = (block_hash.into(), number.into());
         self.blocks_by_hash.prepare_batch_insertion([block_by_hash], &mut batch)?;
 
-        self.prepare_batch_with_execution_changes(&account_changes, number, &mut batch)?;
+        self.prepare_batch_with_execution_changes(account_changes, number, &mut batch)?;
 
         self.write_in_batch_for_multiple_cfs(batch)?;
         Ok(())
@@ -820,10 +825,10 @@ mod tests {
 
         let mut batch = WriteBatch::default();
         // add accounts in separate blocks so they show up in history
-        state.prepare_batch_with_execution_changes(&changes[0..=0], 1.into(), &mut batch).unwrap();
-        state.prepare_batch_with_execution_changes(&changes[1..=1], 2.into(), &mut batch).unwrap();
-        state.prepare_batch_with_execution_changes(&changes[2..=2], 3.into(), &mut batch).unwrap();
-        state.prepare_batch_with_execution_changes(&changes[3..=3], 4.into(), &mut batch).unwrap();
+        state.prepare_batch_with_execution_changes([changes[0].clone()], 1.into(), &mut batch).unwrap();
+        state.prepare_batch_with_execution_changes([changes[1].clone()], 2.into(), &mut batch).unwrap();
+        state.prepare_batch_with_execution_changes([changes[2].clone()], 3.into(), &mut batch).unwrap();
+        state.prepare_batch_with_execution_changes([changes[3].clone()], 4.into(), &mut batch).unwrap();
         state.write_in_batch_for_multiple_cfs(batch).unwrap();
 
         let accounts = state.read_all_accounts().unwrap();


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Refactored `prepare_batch_with_execution_changes` method to accept owned changes, improving efficiency
- Eliminated unnecessary intermediate buffers, reducing memory usage
- Simplified the code by processing account and slot changes in a single loop
- Updated method signature to use generic `IntoIterator` for better flexibility
- Modified test cases to align with the new method signature
- Improved overall performance by reducing allocations and iterations


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rocks_state.rs</strong><dd><code>Optimize batch preparation for execution changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/rocks/rocks_state.rs

<li>Modified <code>prepare_batch_with_execution_changes</code> to accept owned changes<br> <li> Simplified code by removing unnecessary buffers and intermediate <br>vectors<br> <li> Improved performance by processing changes in a single loop<br> <li> Updated method calls in tests to use the new signature<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1679/files#diff-f7b822022d2c4fd93ec507cd6b5302dcf1646acbf0ee0dd077a047272b686009">+24/-29</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

