### PR TITLE
chore: solve cargo doc warnings

### DIFF
--- a/src/eth/executor/executor.rs
+++ b/src/eth/executor/executor.rs
@@ -208,7 +208,6 @@ pub struct Executor {
 }
 
 impl Executor {
-    /// Creates a new [`Executor`].
     pub fn new(storage: Arc<StratusStorage>, miner: Arc<Miner>, config: ExecutorConfig) -> Self {
         tracing::info!(?config, "creating executor");
         let evms = Evms::spawn(Arc::clone(&storage), &config);

--- a/src/eth/follower/importer/importer.rs
+++ b/src/eth/follower/importer/importer.rs
@@ -82,7 +82,6 @@ pub struct Importer {
 }
 
 impl Importer {
-    /// Creates a new [`Importer`].
     pub fn new(executor: Arc<Executor>, miner: Arc<Miner>, storage: Arc<StratusStorage>, chain: Arc<BlockchainClient>, sync_interval: Duration) -> Self {
         tracing::info!("creating importer");
         Self {

--- a/src/eth/miner/miner.rs
+++ b/src/eth/miner/miner.rs
@@ -64,7 +64,6 @@ pub struct MinerLocks {
 }
 
 impl Miner {
-    /// Creates a new [`BlockMiner`].
     pub fn new(storage: Arc<StratusStorage>, mode: MinerMode) -> Self {
         tracing::info!(?mode, "creating block miner");
         Self {

--- a/src/eth/storage/storage_point_in_time.rs
+++ b/src/eth/storage/storage_point_in_time.rs
@@ -4,18 +4,18 @@ use crate::infra::metrics::MetricLabelValue;
 /// EVM storage point-in-time indicator.
 #[derive(Debug, strum::Display, Clone, Copy, Default, strum::EnumIs, serde::Serialize)]
 pub enum StoragePointInTime {
-    /// State of [`Account`] or [`Slot`] at the pending block being mined.
+    /// State of `Account` or `Slot` at the pending block being mined.
     ///
-    /// If state did not change, then it is the same as the [`Mined`] state.
+    /// If state did not change, then it is the same as the `Mined` state.
     #[strum(to_string = "pending")]
     Pending,
 
-    /// State of [`Account`] or [`Slot`] at the last mined block.
+    /// State of `Account` or `Slot` at the last mined block.
     #[default]
     #[strum(to_string = "mined")]
     Mined,
 
-    /// State of [`Account`] or [`Slot`] at some specific mined block in the past.
+    /// State of `Account` or `Slot` at some specific mined block in the past.
     #[strum(to_string = "mined-past")]
     MinedPast(BlockNumber),
 }

--- a/src/infra/tracing/tracing_services.rs
+++ b/src/infra/tracing/tracing_services.rs
@@ -326,7 +326,7 @@ macro_rules! log_and_err {
 
 /// Dynamic event logging based on the provided level.
 ///
-/// https://github.com/tokio-rs/tracing/issues/2730#issuecomment-1943022805
+/// <https://github.com/tokio-rs/tracing/issues/2730#issuecomment-1943022805>
 #[macro_export]
 macro_rules! event_with {
     ($lvl:ident, $($arg:tt)+) => {


### PR DESCRIPTION
### **PR Type**
Documentation, Enhancement


___

### **Description**
- Removed redundant documentation comments for `new` functions in multiple files (executor.rs, importer.rs, miner.rs)
- Improved documentation formatting in `storage_point_in_time.rs`:
  - Updated code references to use backticks instead of square brackets
  - Ensured consistent formatting for `Account`, `Slot`, and `Mined` references
- Enhanced URL formatting in `tracing_services.rs` by using angle brackets for proper linking
- These changes improve code documentation clarity and adhere to Rust documentation best practices


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>executor.rs</strong><dd><code>Remove redundant documentation for Executor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/executor/executor.rs

- Removed redundant documentation comment for the `new` function



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1680/files#diff-6b460d7dee8280c0287e8d9d9d59cf66a57ec9fed1bc003c6ede6fef60c7376b">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>importer.rs</strong><dd><code>Remove redundant documentation for Importer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/follower/importer/importer.rs

- Removed redundant documentation comment for the `new` function



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1680/files#diff-bd50f502f039aff8f75753bc780d281ae7d7936fadc9d53482084c647aec94ca">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>miner.rs</strong><dd><code>Remove redundant documentation for Miner</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/miner/miner.rs

- Removed redundant documentation comment for the `new` function



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1680/files#diff-16f448afc7dae3e8e802f676a86dbd7051e19f6c17cbbeb53eb730d726372629">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>storage_point_in_time.rs</strong><dd><code>Improve documentation formatting in StoragePointInTime</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/storage_point_in_time.rs

<li>Updated documentation comments to use backticks for code references<br> <li> Replaced square brackets with backticks for <code>Account</code> and <code>Slot</code> <br>references<br> <li> Updated <code>Mined</code> reference to use backticks instead of square brackets<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1680/files#diff-6ed365e4ae454005c89dabcf56be602bcdd775874af06a0ca6aa7e1c5c941abc">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>tracing_services.rs</strong><dd><code>Enhance URL formatting in tracing documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/infra/tracing/tracing_services.rs

<li>Updated the URL in the documentation comment to use angle brackets for <br>proper linking<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1680/files#diff-21c16d06019b3283856236ea996d455c4170d7bc0dcd40cfcc498842adde69c4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

