### PR TITLE
enha: improve error handling for Mutex

### DIFF
--- a/src/eth/executor/executor.rs
+++ b/src/eth/executor/executor.rs
@@ -392,7 +392,7 @@ impl Executor {
             ExecutorStrategy::Serial => {
                 // acquire serial execution lock
                 let _serial_lock = self.locks.serial.lock().unwrap_or_else(|poison| {
-                    tracing::warn!("executor serial lock was poisoned");
+                    tracing::error!("executor serial lock was poisoned");
                     self.locks.serial.clear_poison();
                     poison.into_inner()
                 });
@@ -401,7 +401,7 @@ impl Executor {
                 // this can be removed when we implement conflict detection for block number
                 let _miner_lock = if self.miner.mode.is_interval() {
                     let miner_lock = Some(self.miner.locks.mine_and_commit.lock().unwrap_or_else(|poison| {
-                        tracing::warn!("miner mine_and_commit lock was poisoned");
+                        tracing::error!("miner mine_and_commit lock was poisoned");
                         self.miner.locks.mine_and_commit.clear_poison();
                         poison.into_inner()
                     }));

--- a/src/eth/primitives/block_header.rs
+++ b/src/eth/primitives/block_header.rs
@@ -23,7 +23,7 @@ use crate::eth::primitives::Hash;
 use crate::eth::primitives::MinerNonce;
 use crate::eth::primitives::Size;
 use crate::eth::primitives::UnixTime;
-use crate::ext::ResultExt;
+use crate::ext::SerdeResultExt;
 
 /// Special hash used in block mining to indicate no uncle blocks.
 const HASH_EMPTY_UNCLES: Hash = Hash::new(hex!("1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"));


### PR DESCRIPTION
Now, no Mutex lock is called with an `unwrap()` anymore, it's either logged and the poison is cleared, or we wrap it in an error and return it

Plus, I promoted some warnings to errors, as poisons aren't expected and can be catastrophic.