### PR TITLE
test: small fix on test

### DIFF
--- a/src/eth/storage/rocks/rocks_state.rs
+++ b/src/eth/storage/rocks/rocks_state.rs
@@ -719,6 +719,7 @@ impl fmt::Debug for RocksStorageState {
 #[cfg(test)]
 mod tests {
     use std::collections::HashSet;
+    use std::iter;
 
     use fake::Fake;
     use fake::Faker;
@@ -737,9 +738,9 @@ mod tests {
         let account_slots: RocksCfRef<SlotIndex, SlotValue> = new_cf_ref(&db, "account_slots").unwrap();
 
         let slots: HashMap<SlotIndex, SlotValue> = (0..1000).map(|_| (Faker.fake(), Faker.fake())).collect();
-        let extra_slots: HashMap<SlotIndex, SlotValue> = (0..1000)
-            .map(|_| (Faker.fake(), Faker.fake()))
+        let extra_slots: HashMap<SlotIndex, SlotValue> = iter::repeat_with(|| (Faker.fake(), Faker.fake()))
             .filter(|(key, _)| !slots.contains_key(key))
+            .take(1000)
             .collect();
 
         let mut batch = WriteBatch::default();


### PR DESCRIPTION
### **User description**
to ensure that it actually generates slots that are extra and different from the previous ones


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Enhanced the test data generation for extra slots in the `rocks_state.rs` file:
  - Replaced the range-based approach with `iter::repeat_with()` for generating extra slots
  - Added a `.take(1000)` to ensure exactly 1000 extra slots are generated
  - This change guarantees that all generated extra slots are unique and different from the existing slots
- Improved code efficiency and readability in the test module
- Added `use std::iter;` import to support the new implementation


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rocks_state.rs</strong><dd><code>Improve test data generation for extra slots</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/rocks/rocks_state.rs

<li>Added <code>use std::iter;</code> import<br> <li> Modified <code>extra_slots</code> generation to use <code>iter::repeat_with()</code><br> <li> Added <code>.take(1000)</code> to ensure exactly 1000 extra slots are generated<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1683/files#diff-f7b822022d2c4fd93ec507cd6b5302dcf1646acbf0ee0dd077a047272b686009">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

