### PR TITLE
chore: decrease amount of dynamic event named logs

### DIFF
--- a/src/eth/primitives/execution.rs
+++ b/src/eth/primitives/execution.rs
@@ -123,8 +123,8 @@ impl EvmExecution {
 
         // compare logs length
         if self.logs.len() != receipt.logs.len() {
-            tracing::trace!("execution logs: {:#?}", self.logs);
-            tracing::trace!("receipt logs: {:#?}", receipt.logs);
+            tracing::trace!(logs = ?self.logs, "execution logs");
+            tracing::trace!(logs = ?receipt.logs, "receipt logs");
             return log_and_err!(format!(
                 "logs length mismatch | hash={} execution={} receipt={}",
                 receipt.hash(),

--- a/src/eth/primitives/stratus_error.rs
+++ b/src/eth/primitives/stratus_error.rs
@@ -195,7 +195,7 @@ impl StratusError {
             Some("execution") => CALL_EXECUTION_FAILED_CODE,
             Some("internal") => INTERNAL_ERROR_CODE,
             Some(kind) => {
-                tracing::warn!("stratus error with unhandled kind: {kind}");
+                tracing::warn!(kind, "stratus error with unhandled kind");
                 INTERNAL_ERROR_CODE
             }
             None => {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -33,7 +33,7 @@ impl DropTimer {
 
 impl Drop for DropTimer {
     fn drop(&mut self) {
-        tracing::info!("Timer: '{}' ran for `{:?}`", self.scope_name, self.instant.elapsed());
+        tracing::info!(ran_for = ?self.instant.elapsed(), "Timer: '{}' finished", self.scope_name);
     }
 }
 


### PR DESCRIPTION
### **User description**
logs shouldn't have dynamic event names because that makes querying harder


___

### **PR Type**
Enhancement


___

### **Description**
- Implemented structured logging across multiple files to improve log querying and readability
- Updated tracing macros (trace!, warn!, info!) to use named parameters instead of string interpolation
- Reduced the use of dynamic event names in logs, making it easier to query and analyze log data
- Maintained consistent logging format across different components (EvmExecution, StratusError, DropTimer)


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>execution.rs</strong><dd><code>Enhance logging in EvmExecution comparison</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/execution.rs

<li>Modified tracing::trace! calls to use structured logging format<br> <li> Improved log readability by using named parameters<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1685/files#diff-cd13932ed3cbc97c18547275105d872a204eda4ad4bf0c2811b18553b48e9038">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>stratus_error.rs</strong><dd><code>Improve error logging in StratusError</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/stratus_error.rs

<li>Updated tracing::warn! call to use structured logging format<br> <li> Improved log clarity by using named parameter for unhandled kind<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1685/files#diff-301cded01d772388e3e5c08ede093b91c3e4478c08e11a48f70e3d44351385fb">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>utils.rs</strong><dd><code>Enhance DropTimer logging output</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/utils.rs

<li>Modified tracing::info! call in DropTimer to use structured logging <br>format<br> <li> Improved log readability by using named parameter for elapsed time<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1685/files#diff-23af5356f6001cd3993cd3c801fb7716ea02d1e504081b9fb569332db6107e80">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

