### PR TITLE
fix: remove to_analysed being (wrongly) used

### DIFF
--- a/src/eth/executor/evm.rs
+++ b/src/eth/executor/evm.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use anyhow::anyhow;
 use itertools::Itertools;
 use revm::primitives::AccountInfo;
+use revm::primitives::AnalysisKind;
 use revm::primitives::EVMError;
 use revm::primitives::ExecutionResult as RevmExecutionResult;
 use revm::primitives::InvalidTransaction;
@@ -86,6 +87,7 @@ impl Evm {
         let cfg_env = evm.cfg_mut();
         cfg_env.chain_id = chain_id;
         cfg_env.limit_contract_code_size = Some(usize::MAX);
+        cfg_env.perf_analyse_created_bytecodes = AnalysisKind::Raw;
 
         // global block config
         let block_env = evm.block_mut();

--- a/src/eth/primitives/bytes.rs
+++ b/src/eth/primitives/bytes.rs
@@ -3,7 +3,6 @@ use std::ops::Deref;
 use std::ops::DerefMut;
 
 use display_json::DebugAsJson;
-use revm::interpreter::analysis::to_analysed;
 
 use crate::alias::EthersBytes;
 use crate::alias::RevmBytecode;
@@ -127,6 +126,6 @@ impl From<Bytes> for RevmBytes {
 
 impl From<Bytes> for RevmBytecode {
     fn from(value: Bytes) -> Self {
-        to_analysed(RevmBytecode::new_raw(value.0.into()))
+        RevmBytecode::new_raw(value.0.into())
     }
 }


### PR DESCRIPTION
### **User description**
This was causing a few issues:

1. We were double padding the bytecode, adding 66 0s to the end of it. This kept us from being able to verify contracts on blockscout.
2. Since we don't save the jump tables we took a performance hit for analyzing the bytecode, but none of the performance gains from storing the jump table to be used later.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed a critical bug where bytecode was being double padded, causing issues with contract verification on blockscout.
- Removed unnecessary bytecode analysis, improving performance by eliminating redundant processing.
- Updated EVM configuration to use raw bytecode analysis, ensuring proper handling of created bytecodes.
- Simplified `Bytes` to `RevmBytecode` conversion, removing the `to_analysed` step.
- These changes resolve performance issues and improve compatibility with external tools like blockscout.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>evm.rs</strong><dd><code>Configure EVM for raw bytecode analysis</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/executor/evm.rs

<li>Added import for <code>AnalysisKind</code> from <code>revm::primitives</code><br> <li> Set <code>cfg_env.perf_analyse_created_bytecodes</code> to <code>AnalysisKind::Raw</code><br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1686/files#diff-7fabd204a68cff51c55ee1391074463fa8ac005dc8ba443218bc83a9dda96658">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bytes.rs</strong><dd><code>Remove bytecode analysis in conversion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/bytes.rs

<li>Removed import of <code>to_analysed</code> from <code>revm::interpreter::analysis</code><br> <li> Modified <code>From<Bytes></code> implementation for <code>RevmBytecode</code> to use <code>new_raw</code> without <br><code>to_analysed</code><br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1686/files#diff-e2007d1ed9fa6978ef516d7b6abeb65ef67f8e856ad26f0efb9e9a1b46840677">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

