### PR TITLE
enha: execution error types

### DIFF
--- a/src/eth/primitives/stratus_error.rs
+++ b/src/eth/primitives/stratus_error.rs
@@ -21,7 +21,7 @@ use crate::ext::to_json_value;
 /// * server_state:   request is valid, global server rules rejects it.
 /// * execution:      request is valid, but failed in executor/evm.
 /// * internal:       request is valid, but a an internal component failed.
-#[derive(Debug, thiserror::Error, strum::EnumProperty)]
+#[derive(Debug, thiserror::Error, strum::EnumProperty, strum::IntoStaticStr)]
 pub enum StratusError {
     // -------------------------------------------------------------------------
     // RPC

--- a/src/eth/rpc/mod.rs
+++ b/src/eth/rpc/mod.rs
@@ -4,6 +4,7 @@ mod rpc_client_app;
 mod rpc_config;
 mod rpc_context;
 mod rpc_http_middleware;
+mod rpc_method_wrapper;
 mod rpc_middleware;
 mod rpc_parser;
 mod rpc_server;

--- a/src/eth/rpc/rpc_method_wrapper.rs
+++ b/src/eth/rpc/rpc_method_wrapper.rs
@@ -1,0 +1,19 @@
+use std::sync::Arc;
+
+use jsonrpsee::types::Params;
+use jsonrpsee::Extensions;
+
+use super::RpcContext;
+use crate::eth::primitives::StratusError;
+use crate::infra::metrics::inc_executor_transaction_error_types;
+
+pub fn call_error_metrics_wrapper<F, T>(function: F) -> impl Fn(Params<'_>, Arc<RpcContext>, Extensions) -> Result<T, StratusError> + Clone
+where
+    F: Fn(Params<'_>, Arc<RpcContext>, Extensions) -> Result<T, StratusError> + Clone,
+{
+    move |params, ctx, extensions| {
+        function(params, ctx, extensions).inspect_err(|e| {
+            inc_executor_transaction_error_types(<&'static str>::from(e));
+        })
+    }
+}

--- a/src/eth/rpc/rpc_server.rs
+++ b/src/eth/rpc/rpc_server.rs
@@ -27,6 +27,7 @@ use tracing::info_span;
 use tracing::Instrument;
 use tracing::Span;
 
+use super::rpc_method_wrapper::call_error_metrics_wrapper;
 use crate::alias::JsonValue;
 use crate::eth::executor::Executor;
 use crate::eth::follower::consensus::Consensus;
@@ -200,8 +201,8 @@ fn register_methods(mut module: RpcModule<RpcContext>) -> anyhow::Result<RpcModu
     module.register_blocking_method("eth_getTransactionByHash", eth_get_transaction_by_hash)?;
     module.register_blocking_method("eth_getTransactionReceipt", eth_get_transaction_receipt)?;
     module.register_blocking_method("eth_estimateGas", eth_estimate_gas)?;
-    module.register_blocking_method("eth_call", eth_call)?;
-    module.register_blocking_method("eth_sendRawTransaction", eth_send_raw_transaction)?;
+    module.register_blocking_method("eth_call", call_error_metrics_wrapper(eth_call))?;
+    module.register_blocking_method("eth_sendRawTransaction", call_error_metrics_wrapper(eth_send_raw_transaction))?;
 
     // logs
     module.register_blocking_method("eth_getLogs", eth_get_logs)?;

--- a/src/infra/metrics/metrics_definitions.rs
+++ b/src/infra/metrics/metrics_definitions.rs
@@ -130,7 +130,10 @@ metrics! {
     histogram_counter executor_local_call_slot_reads{function},
 
     "Gas spent executing a local call."
-    histogram_counter executor_local_call_gas{function}
+    histogram_counter executor_local_call_gas{function},
+
+    "Count types of errors when executing a transaction."
+    counter executor_transaction_error_types{error_type}
 }
 
 metrics! {


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Implemented error metrics for RPC methods, specifically for transaction errors
- Added a new `rpc_method_wrapper` module with a `call_error_metrics_wrapper` function
- Applied the error metrics wrapper to `eth_call` and `eth_sendRawTransaction` methods
- Added a new counter metric `executor_transaction_error_types` to track different error types
- Enhanced `StratusError` enum with `strum::IntoStaticStr` derive for easier conversion to static strings


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>stratus_error.rs</strong><dd><code>Add IntoStaticStr derive for StratusError</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/stratus_error.rs

- Added `strum::IntoStaticStr` derive macro to `StratusError` enum



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1687/files#diff-301cded01d772388e3e5c08ede093b91c3e4478c08e11a48f70e3d44351385fb">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Add new RPC method wrapper module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/rpc/mod.rs

- Added a new module `rpc_method_wrapper`



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1687/files#diff-0a0c2af8f16ac3beb803893d128781f7a3a203e12dcd6738e7ac439cd78493cd">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rpc_method_wrapper.rs</strong><dd><code>Implement error metrics wrapper for RPC methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/rpc/rpc_method_wrapper.rs

<li>Implemented a new function <code>call_error_metrics_wrapper</code><br> <li> This wrapper function increments error metrics for transaction errors<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1687/files#diff-0bbd6e729eb4e018401d1475a5dd64871ecb654be7b3d125c48c204fbddc9545">+19/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rpc_server.rs</strong><dd><code>Apply error metrics wrapper to RPC methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/rpc/rpc_server.rs

<li>Imported <code>call_error_metrics_wrapper</code> function<br> <li> Applied the wrapper to <code>eth_call</code> and <code>eth_sendRawTransaction</code> methods<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1687/files#diff-835ba255c9a5c1fe0e13285bc39e058e1c74422e5e03ebba483c9d8a15c45405">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>metrics_definitions.rs</strong><dd><code>Add new transaction error types metric</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/infra/metrics/metrics_definitions.rs

- Added a new counter metric `executor_transaction_error_types`



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1687/files#diff-2ca1adc579301e6de5f9e1d69eb1ed2f70aeee0f3b54fe113346040b4eab652b">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

