### PR TITLE
feat: compare_states binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -903,6 +903,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3477,6 +3487,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redis"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4800,6 +4830,7 @@ dependencies = [
  "pin-project",
  "prost-types",
  "rand",
+ "rayon",
  "redis",
  "reqwest 0.12.4",
  "revm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -751,6 +751,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "unicode-width",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "console-api"
 version = "0.6.0"
 source = "git+https://github.com/tokio-rs/console.git?rev=852a977bab71d0f6ae47c6c5c1c20b8679c9e576#852a977bab71d0f6ae47c6c5c1c20b8679c9e576"
@@ -1159,6 +1172,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
@@ -2101,6 +2120,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "763a5a8f45087d6bcea4222e7b72c291a054edf80e4ef6efd2a4979878c7bea3"
+dependencies = [
+ "console",
+ "instant",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2795,6 +2836,12 @@ checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
@@ -4731,6 +4778,7 @@ dependencies = [
  "hex_fmt",
  "humantime",
  "indexmap 2.2.6",
+ "indicatif",
  "itertools 0.13.0",
  "jsonrpsee",
  "keccak-hasher",
@@ -5429,6 +5477,12 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,10 +115,12 @@ sqlx = { version = "=0.8.2", features = [
 # test
 fake = { version = "=2.9.2", features = ["chrono", "derive"] }
 indicatif = "0.17.8"
+rayon = "1.10.0"
 
 # ------------------------------------------------------------------------------
 # Platform specific dependencies
 # ------------------------------------------------------------------------------
+
 
 [target.'cfg(not(all(target_arch = "aarch64", target_os = "linux")))'.dependencies]
 revm = { version = "=9.0.0", features = ["asm-keccak"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,6 +114,7 @@ sqlx = { version = "=0.8.2", features = [
 
 # test
 fake = { version = "=2.9.2", features = ["chrono", "derive"] }
+indicatif = "0.17.8"
 
 # ------------------------------------------------------------------------------
 # Platform specific dependencies

--- a/config/stratus.env.local
+++ b/config/stratus.env.local
@@ -3,5 +3,5 @@ RUST_LOG=info,stratus::eth::rpc::rpc_subscriptions::rx=off,stratus::eth::consens
 CHAIN_ID=2008
 EVMS=1
 
-PERM_STORAGE=inmemory
+PERM_STORAGE=rocks
 TEMP_STORAGE=inmemory

--- a/src/bin/compare_state.rs
+++ b/src/bin/compare_state.rs
@@ -68,13 +68,14 @@ fn main() -> anyhow::Result<()> {
             .unwrap()
             .progress_chars("#>-"),
     );
-    let max_block: BlockNumberRocksdb = args.max_block.into();
+
+
     println!("Starting state comparison");
 
     old_db_iter.par_bridge().try_for_each(|result| -> anyhow::Result<()> {
         let ((address, slot_index, block_number), value_old) = result.context("Error iterating over db2")?;
 
-        if BlockNumberRocksdb::from(block_number.0.as_u64()) > max_block {
+        if block_number.0.as_u64() > max_block {
             return Ok(());
         }
 

--- a/src/bin/compare_state.rs
+++ b/src/bin/compare_state.rs
@@ -52,7 +52,7 @@ fn main() -> anyhow::Result<()> {
         }
 
         if (address1, slot_index1, block_number1) != (address2, slot_index2, block_number2) {
-            println!("Mismatch in entry order:");
+            println!("Mismatched entries:");
             println!("  DB1: address: {:?}, slot: {:?}, block: {:?}", address1, slot_index1, block_number1);
             println!("  DB2: address: {:?}, slot: {:?}, block: {:?}", address2, slot_index2, block_number2);
             differences += 1;

--- a/src/bin/compare_state.rs
+++ b/src/bin/compare_state.rs
@@ -2,7 +2,6 @@ use anyhow::Context;
 use clap::Parser;
 use rocksdb::{DB, Options};
 use stratus::eth::storage::rocks::rocks_cf::RocksCfRef;
-use stratus::eth::storage::rocks::rocks_state::RocksStorageState;
 use stratus::eth::primitives::{Address, BlockNumber, SlotIndex, SlotValue};
 
 #[derive(Parser, Debug)]
@@ -29,20 +28,51 @@ fn main() -> anyhow::Result<()> {
 
     let mut differences = 0;
 
-    for result in cf1.iter_start() {
-        let ((address, slot_index, block_number), value1) = result.context("Error iterating over db1")?;
+    let mut iter1 = cf1.iter_start();
+    let mut iter2 = cf2.iter_start();
 
-        if block_number > args.max_block {
+    while let (Some(result1), Some(result2)) = (iter1.next(), iter2.next()) {
+        let ((address1, slot_index1, block_number1), value1) = result1.context("Error iterating over db1")?;
+        let ((address2, slot_index2, block_number2), value2) = result2.context("Error iterating over db2")?;
+
+        if block_number1 > args.max_block && block_number2 > args.max_block {
             continue;
         }
 
-        if let Some(value2) = cf2.get(&(address, slot_index, block_number))? {
-            if value1 != value2 {
-                println!("Difference found at address: {:?}, slot: {:?}, block: {:?}", address, slot_index, block_number);
-                differences += 1;
-            }
-        } else {
-            println!("Entry missing in db2 for address: {:?}, slot: {:?}, block: {:?}", address, slot_index, block_number);
+        if block_number1 > args.max_block {
+            iter1 = cf1.iter_from((address2, slot_index2, block_number2), rocksdb::Direction::Forward)?;
+            continue;
+        }
+
+        if block_number2 > args.max_block {
+            iter2 = cf2.iter_from((address1, slot_index1, block_number1), rocksdb::Direction::Forward)?;
+            continue;
+        }
+
+        if (address1, slot_index1, block_number1) != (address2, slot_index2, block_number2) {
+            println!("Mismatch in entry order:");
+            println!("  DB1: address: {:?}, slot: {:?}, block: {:?}", address1, slot_index1, block_number1);
+            println!("  DB2: address: {:?}, slot: {:?}, block: {:?}", address2, slot_index2, block_number2);
+            differences += 1;
+        } else if value1 != value2 {
+            println!("Difference found at address: {:?}, slot: {:?}, block: {:?}", address1, slot_index1, block_number1);
+            differences += 1;
+        }
+    }
+
+    // Check for any remaining entries in either database
+    while let Some(result) = iter1.next() {
+        let ((address, slot_index, block_number), _) = result.context("Error iterating over remaining db1 entries")?;
+        if block_number <= args.max_block {
+            println!("Extra entry in db1: address: {:?}, slot: {:?}, block: {:?}", address, slot_index, block_number);
+            differences += 1;
+        }
+    }
+
+    while let Some(result) = iter2.next() {
+        let ((address, slot_index, block_number), _) = result.context("Error iterating over remaining db2 entries")?;
+        if block_number <= args.max_block {
+            println!("Extra entry in db2: address: {:?}, slot: {:?}, block: {:?}", address, slot_index, block_number);
             differences += 1;
         }
     }

--- a/src/bin/compare_state.rs
+++ b/src/bin/compare_state.rs
@@ -59,6 +59,12 @@ fn main() -> anyhow::Result<()> {
     let old_db_iter = cf2.iter_start();
 
     let progress_bar = indicatif::ProgressBar::new(num_keys);
+    progress_bar.set_style(
+        indicatif::ProgressStyle::default_bar()
+            .template("{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] {pos}/{len} ({eta})")
+            .unwrap()
+            .progress_chars("#>-"),
+    );
     let max_block: BlockNumberRocksdb = args.max_block.into();
     println!("Starting state comparison");
     for result in progress_bar.wrap_iter(old_db_iter) {

--- a/src/bin/compare_state.rs
+++ b/src/bin/compare_state.rs
@@ -3,11 +3,12 @@ use clap::Parser;
 use rocksdb::properties::ESTIMATE_NUM_KEYS;
 use rocksdb::Options;
 use rocksdb::DB;
-use stratus::eth::primitives::Address;
 use stratus::eth::primitives::BlockNumber;
-use stratus::eth::primitives::SlotIndex;
-use stratus::eth::primitives::SlotValue;
 use stratus::eth::storage::rocks::rocks_cf::RocksCfRef;
+use stratus::eth::storage::rocks::types::AddressRocksdb;
+use stratus::eth::storage::rocks::types::BlockNumberRocksdb;
+use stratus::eth::storage::rocks::types::SlotIndexRocksdb;
+use stratus::eth::storage::rocks::types::SlotValueRocksdb;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -31,8 +32,8 @@ fn main() -> anyhow::Result<()> {
     let db2 = DB::open_cf_for_read_only(&Options::default(), &args.db2_path, ["account_slots_history"], false)?;
     println!("Opened db2");
 
-    let cf1: RocksCfRef<(Address, SlotIndex, BlockNumber), SlotValue> = RocksCfRef::new(db1.into(), "account_slots_history")?;
-    let cf2: RocksCfRef<(Address, SlotIndex, BlockNumber), SlotValue> = RocksCfRef::new(db2.into(), "account_slots_history")?;
+    let cf1: RocksCfRef<(AddressRocksdb, SlotIndexRocksdb, BlockNumberRocksdb), SlotValueRocksdb> = RocksCfRef::new(db1.into(), "account_slots_history")?;
+    let cf2: RocksCfRef<(AddressRocksdb, SlotIndexRocksdb, BlockNumberRocksdb), SlotValueRocksdb> = RocksCfRef::new(db2.into(), "account_slots_history")?;
     let num_keys1 = cf1.property_int_value(ESTIMATE_NUM_KEYS).unwrap().unwrap_or(0);
     let num_keys2 = cf2.property_int_value(ESTIMATE_NUM_KEYS).unwrap().unwrap_or(0);
     let num_keys = std::cmp::max(num_keys1, num_keys2);
@@ -43,26 +44,26 @@ fn main() -> anyhow::Result<()> {
     let mut iter2 = cf2.iter_start();
 
     let progress_bar = indicatif::ProgressBar::new(num_keys);
-
+    let max_block: BlockNumberRocksdb = args.max_block.into();
     println!("Starting state comparison");
     while let (Some(result1), Some(result2)) = (iter1.next(), iter2.next()) {
         let ((address1, slot_index1, block_number1), value1) = result1.context("Error iterating over db1")?;
         let ((address2, slot_index2, block_number2), value2) = result2.context("Error iterating over db2")?;
 
-        if block_number1 > args.max_block && block_number2 > args.max_block {
+        if block_number1 > max_block && block_number2 > max_block {
             progress_bar.inc(1);
             continue;
         }
 
         // If block_numberA > max_block but block_numberB < max_block then cfB does not have the entry for that (and presumably future) blocks
         // Therefore cfB is already in another slot and cfA need to iterate from that slot.
-        if block_number1 > args.max_block {
+        if block_number1 > max_block {
             iter1 = cf1.iter_from((address2, slot_index2, block_number2), rocksdb::Direction::Forward)?;
             progress_bar.inc(1);
             continue;
         }
 
-        if block_number2 > args.max_block {
+        if block_number2 > max_block {
             iter2 = cf2.iter_from((address1, slot_index1, block_number1), rocksdb::Direction::Forward)?;
             progress_bar.inc(1);
             continue;
@@ -89,7 +90,7 @@ fn main() -> anyhow::Result<()> {
     // Check for any remaining entries in either database
     for result in iter1 {
         let ((address, slot_index, block_number), _) = result.context("Error iterating over remaining db1 entries")?;
-        if block_number <= args.max_block {
+        if block_number <= max_block {
             println!("Extra entry in db1: address: {:?}, slot: {:?}, block: {:?}", address, slot_index, block_number);
             differences += 1;
         }
@@ -98,7 +99,7 @@ fn main() -> anyhow::Result<()> {
 
     for result in iter2 {
         let ((address, slot_index, block_number), _) = result.context("Error iterating over remaining db2 entries")?;
-        if block_number <= args.max_block {
+        if block_number <= max_block {
             println!("Extra entry in db2: address: {:?}, slot: {:?}, block: {:?}", address, slot_index, block_number);
             differences += 1;
         }

--- a/src/bin/compare_state.rs
+++ b/src/bin/compare_state.rs
@@ -67,7 +67,7 @@ fn main() -> anyhow::Result<()> {
     let progress_bar = indicatif::ProgressBar::new(num_keys);
     progress_bar.set_style(
         indicatif::ProgressStyle::default_bar()
-            .template("{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] {pos}/{len} ({percentage}%) ({eta})")
+            .template("{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] {human_pos}/{human_len} ({percent}%) ({eta})")
             .unwrap()
             .progress_chars("#>-"),
     );

--- a/src/bin/compare_state.rs
+++ b/src/bin/compare_state.rs
@@ -65,6 +65,8 @@ fn main() -> anyhow::Result<()> {
                 "Difference found at address: {:?}, slot: {:?}, block: {:?}",
                 address1, slot_index1, block_number1
             );
+            println!("  Value 1: {:?}", value1);
+            println!("  Value 2: {:?}", value2);
             differences += 1;
         }
     }

--- a/src/bin/compare_state.rs
+++ b/src/bin/compare_state.rs
@@ -1,0 +1,53 @@
+use anyhow::Context;
+use clap::Parser;
+use rocksdb::{DB, Options};
+use stratus::eth::storage::rocks::rocks_cf::RocksCfRef;
+use stratus::eth::storage::rocks::rocks_state::RocksStorageState;
+use stratus::eth::primitives::{Address, BlockNumber, SlotIndex, SlotValue};
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    #[arg(short, long)]
+    db1_path: String,
+
+    #[arg(short, long)]
+    db2_path: String,
+
+    #[arg(short, long)]
+    max_block: BlockNumber,
+}
+
+fn main() -> anyhow::Result<()> {
+    let args = Args::parse();
+
+    let db1 = DB::open_for_read_only(&Options::default(), &args.db1_path, false)?;
+    let db2 = DB::open_for_read_only(&Options::default(), &args.db2_path, false)?;
+
+    let cf1: RocksCfRef<(Address, SlotIndex, BlockNumber), SlotValue> = RocksCfRef::new(db1.into(), "account_slots_history")?;
+    let cf2: RocksCfRef<(Address, SlotIndex, BlockNumber), SlotValue> = RocksCfRef::new(db2.into(), "account_slots_history")?;
+
+    let mut differences = 0;
+
+    for result in cf1.iter_start() {
+        let ((address, slot_index, block_number), value1) = result.context("Error iterating over db1")?;
+
+        if block_number > args.max_block {
+            continue;
+        }
+
+        if let Some(value2) = cf2.get(&(address, slot_index, block_number))? {
+            if value1 != value2 {
+                println!("Difference found at address: {:?}, slot: {:?}, block: {:?}", address, slot_index, block_number);
+                differences += 1;
+            }
+        } else {
+            println!("Entry missing in db2 for address: {:?}, slot: {:?}, block: {:?}", address, slot_index, block_number);
+            differences += 1;
+        }
+    }
+
+    println!("Total differences found: {}", differences);
+
+    Ok(())
+}

--- a/src/bin/compare_state.rs
+++ b/src/bin/compare_state.rs
@@ -62,7 +62,7 @@ fn main() -> anyhow::Result<()> {
     let progress_bar = indicatif::ProgressBar::new(num_keys);
     progress_bar.set_style(
         indicatif::ProgressStyle::default_bar()
-            .template("{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] {pos}/{len} ({eta})")
+            .template("{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] {pos}/{len} ({percentage}%) ({eta})")
             .unwrap()
             .progress_chars("#>-"),
     );

--- a/src/bin/compare_state.rs
+++ b/src/bin/compare_state.rs
@@ -25,6 +25,8 @@ struct Args {
 fn main() -> anyhow::Result<()> {
     let args = Args::parse();
 
+    println!("Opening databases");
+
     let db1 = DB::open_for_read_only(&Options::default(), &args.db1_path, false)?;
     let db2 = DB::open_for_read_only(&Options::default(), &args.db2_path, false)?;
     let cf1: RocksCfRef<(Address, SlotIndex, BlockNumber), SlotValue> = RocksCfRef::new(db1.into(), "account_slots_history")?;
@@ -40,6 +42,7 @@ fn main() -> anyhow::Result<()> {
 
     let progress_bar = indicatif::ProgressBar::new(num_keys);
 
+    println!("Starting state comparison");
     while let (Some(result1), Some(result2)) = (iter1.next(), iter2.next()) {
         let ((address1, slot_index1, block_number1), value1) = result1.context("Error iterating over db1")?;
         let ((address2, slot_index2, block_number2), value2) = result2.context("Error iterating over db2")?;

--- a/src/bin/compare_state.rs
+++ b/src/bin/compare_state.rs
@@ -7,7 +7,6 @@ use rocksdb::properties::ESTIMATE_NUM_KEYS;
 use rocksdb::Options;
 use rocksdb::DB;
 use stratus::eth::primitives::Address;
-use stratus::eth::primitives::BlockNumber;
 use stratus::eth::primitives::SlotIndex;
 use stratus::eth::primitives::SlotValue;
 use stratus::eth::storage::rocks::cf_versions::CfAccountSlotsHistoryValue;
@@ -26,7 +25,7 @@ struct Args {
     old_db_path: String,
 
     #[arg(short, long)]
-    max_block: BlockNumber,
+    max_block: u64,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Debug, Hash, Eq, PartialEq)]

--- a/src/bin/compare_state.rs
+++ b/src/bin/compare_state.rs
@@ -28,7 +28,10 @@ fn main() -> anyhow::Result<()> {
     println!("Opening databases");
 
     let db1 = DB::open_for_read_only(&Options::default(), &args.db1_path, false)?;
+    println!("Opened db1");
     let db2 = DB::open_for_read_only(&Options::default(), &args.db2_path, false)?;
+    println!("Opened db2");
+
     let cf1: RocksCfRef<(Address, SlotIndex, BlockNumber), SlotValue> = RocksCfRef::new(db1.into(), "account_slots_history")?;
     let cf2: RocksCfRef<(Address, SlotIndex, BlockNumber), SlotValue> = RocksCfRef::new(db2.into(), "account_slots_history")?;
     let num_keys1 = cf1.property_int_value(ESTIMATE_NUM_KEYS).unwrap().unwrap_or(0);

--- a/src/bin/compare_state.rs
+++ b/src/bin/compare_state.rs
@@ -15,7 +15,6 @@ use stratus::eth::storage::rocks::rocks_cf::RocksCfRef;
 use stratus::eth::storage::rocks::types::AddressRocksdb;
 use stratus::eth::storage::rocks::types::BlockNumberRocksdb;
 use stratus::eth::storage::rocks::types::SlotIndexRocksdb;
-use stratus::eth::storage::rocks::types::SlotValueRocksdb;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -58,94 +57,44 @@ fn main() -> anyhow::Result<()> {
 
     let mut differences = 0;
 
-    let mut iter1 = cf1.iter_start();
-    let mut iter2 = cf2.iter_start();
+    let old_db_iter = cf2.iter_start();
 
     let progress_bar = indicatif::ProgressBar::new(num_keys);
     let max_block: BlockNumberRocksdb = args.max_block.into();
     println!("Starting state comparison");
-    while let (Some(result1), Some(result2)) = (iter1.next(), iter2.next()) {
-        let Ok(((address1, slot_index1, block_number1), value1)) = result1.context("Error iterating over db1") else {
-            continue;
-        };
-        let Ok(((address2, slot_index2, block_number2), value2)) = result2.context("Error iterating over db2") else {
+    for result in progress_bar.wrap_iter(old_db_iter) {
+        let Ok(((address, slot_index, block_number), value_old)) = result.context("Error iterating over db2") else {
             continue;
         };
 
-        if block_number1 > max_block && BlockNumberRocksdb::from(block_number2.0.as_u64()) > max_block {
-            progress_bar.inc(1);
+        if BlockNumberRocksdb::from(block_number.0.as_u64()) > max_block {
             continue;
         }
 
-        // If block_numberA > max_block but block_numberB < max_block then cfB does not have the entry for that (and presumably future) blocks
-        // Therefore cfB is already in another slot and cfA need to iterate from that slot.
-        if block_number1 > max_block {
-            iter1 = cf1.iter_from(
-                (
-                    Address::from(address2.0).into(),
-                    SlotIndex::from(slot_index2.0).into(),
-                    block_number2.0.as_u64().into(),
-                ),
-                rocksdb::Direction::Forward,
-            )?;
-            progress_bar.inc(1);
-            continue;
-        }
+        let key = (
+            Address::from(address.0).into(),
+            SlotIndex::from(slot_index.0).into(),
+            block_number.0.as_u64().into(),
+        );
 
-        if BlockNumberRocksdb::from(block_number2.0.as_u64()) > max_block {
-            iter2 = cf2.iter_from(
-                (
-                    AddressRocksdbOld(address1.0.into()),
-                    SlotIndexRocksdbOld(U256(slot_index1.0)),
-                    BlockNumberRocksdbOld(block_number1.0.into()),
-                ),
-                rocksdb::Direction::Forward,
-            )?;
-            progress_bar.inc(1);
-            continue;
+        match cf1.get(&key)? {
+            Some(value_new) => {
+                if value_new != SlotValue::from(value_old.0).into() {
+                    println!(
+                        "Difference found at address: {:?}, slot: {:?}, block: {:?}",
+                        address, slot_index, block_number
+                    );
+                    println!("  Value old: {:?}", value_old);
+                    println!("  Value new: {:?}", value_new);
+                    differences += 1;
+                }
+            }
+            None => {
+                println!("Entry missing in new DB:");
+                println!("  Old DB: address: {:?}, slot: {:?}, block: {:?}", address, slot_index, block_number);
+                differences += 1;
+            }
         }
-
-        if (address1, slot_index1, block_number1)
-            != (
-                Address::from(address2.0).into(),
-                SlotIndex::from(slot_index2.0).into(),
-                block_number2.0.as_u64().into(),
-            )
-        {
-            println!("Mismatched entries:");
-            println!("  DB1: address: {:?}, slot: {:?}, block: {:?}", address1, slot_index1, block_number1);
-            println!("  DB2: address: {:?}, slot: {:?}, block: {:?}", address2, slot_index2, block_number2);
-            differences += 1;
-        } else if value1 != SlotValue::from(value2.0).into() {
-            println!(
-                "Difference found at address: {:?}, slot: {:?}, block: {:?}",
-                address1, slot_index1, block_number1
-            );
-            println!("  Value 1: {:?}", value1);
-            println!("  Value 2: {:?}", value2);
-            differences += 1;
-        }
-
-        progress_bar.inc(1);
-    }
-
-    // Check for any remaining entries in either database
-    for result in iter1 {
-        let ((address, slot_index, block_number), _) = result.context("Error iterating over remaining db1 entries")?;
-        if block_number <= max_block {
-            println!("Extra entry in db1: address: {:?}, slot: {:?}, block: {:?}", address, slot_index, block_number);
-            differences += 1;
-        }
-        progress_bar.inc(1);
-    }
-
-    for result in iter2 {
-        let ((address, slot_index, block_number), _) = result.context("Error iterating over remaining db2 entries")?;
-        if BlockNumberRocksdb::from(block_number.0.as_u64()) <= max_block {
-            println!("Extra entry in db2: address: {:?}, slot: {:?}, block: {:?}", address, slot_index, block_number);
-            differences += 1;
-        }
-        progress_bar.inc(1);
     }
 
     progress_bar.finish();

--- a/src/bin/compare_state.rs
+++ b/src/bin/compare_state.rs
@@ -1,9 +1,16 @@
 use anyhow::Context;
 use clap::Parser;
+use ethereum_types::H160;
+use ethereum_types::U256;
+use ethereum_types::U64;
 use rocksdb::properties::ESTIMATE_NUM_KEYS;
 use rocksdb::Options;
 use rocksdb::DB;
+use stratus::eth::primitives::Address;
 use stratus::eth::primitives::BlockNumber;
+use stratus::eth::primitives::SlotIndex;
+use stratus::eth::primitives::SlotValue;
+use stratus::eth::storage::rocks::cf_versions::CfAccountSlotsHistoryValue;
 use stratus::eth::storage::rocks::rocks_cf::RocksCfRef;
 use stratus::eth::storage::rocks::types::AddressRocksdb;
 use stratus::eth::storage::rocks::types::BlockNumberRocksdb;
@@ -14,26 +21,37 @@ use stratus::eth::storage::rocks::types::SlotValueRocksdb;
 #[command(author, version, about, long_about = None)]
 struct Args {
     #[arg(short, long)]
-    db1_path: String,
+    new_db_path: String,
 
     #[arg(short, long)]
-    db2_path: String,
+    old_db_path: String,
 
     #[arg(short, long)]
     max_block: BlockNumber,
 }
 
+#[derive(serde::Serialize, serde::Deserialize, Debug, Hash, Eq, PartialEq)]
+struct AddressRocksdbOld(pub H160);
+#[derive(serde::Serialize, serde::Deserialize, Debug, Hash, Eq, PartialEq)]
+struct SlotIndexRocksdbOld(pub U256);
+#[derive(serde::Serialize, serde::Deserialize, Debug, Hash, Eq, PartialEq)]
+struct BlockNumberRocksdbOld(pub U64);
+#[derive(serde::Serialize, serde::Deserialize, Debug, Hash, Eq, PartialEq, Clone)]
+struct SlotValueRocksdbOld(pub U256);
+
 fn main() -> anyhow::Result<()> {
     let args = Args::parse();
     println!("Opening databases");
 
-    let db1 = DB::open_cf_for_read_only(&Options::default(), &args.db1_path, ["account_slots_history"], false)?;
+    let db1 = DB::open_cf_for_read_only(&Options::default(), &args.new_db_path, ["account_slots_history"], false)?;
     println!("Opened db1");
-    let db2 = DB::open_cf_for_read_only(&Options::default(), &args.db2_path, ["account_slots_history"], false)?;
+    let db2 = DB::open_cf_for_read_only(&Options::default(), &args.old_db_path, ["account_slots_history"], false)?;
     println!("Opened db2");
 
-    let cf1: RocksCfRef<(AddressRocksdb, SlotIndexRocksdb, BlockNumberRocksdb), SlotValueRocksdb> = RocksCfRef::new(db1.into(), "account_slots_history")?;
-    let cf2: RocksCfRef<(AddressRocksdb, SlotIndexRocksdb, BlockNumberRocksdb), SlotValueRocksdb> = RocksCfRef::new(db2.into(), "account_slots_history")?;
+    let cf1: RocksCfRef<(AddressRocksdb, SlotIndexRocksdb, BlockNumberRocksdb), CfAccountSlotsHistoryValue> =
+        RocksCfRef::new(db1.into(), "account_slots_history")?;
+    let cf2: RocksCfRef<(AddressRocksdbOld, SlotIndexRocksdbOld, BlockNumberRocksdbOld), SlotValueRocksdbOld> =
+        RocksCfRef::new(db2.into(), "account_slots_history")?;
     let num_keys1 = cf1.property_int_value(ESTIMATE_NUM_KEYS).unwrap().unwrap_or(0);
     let num_keys2 = cf2.property_int_value(ESTIMATE_NUM_KEYS).unwrap().unwrap_or(0);
     let num_keys = std::cmp::max(num_keys1, num_keys2);
@@ -47,10 +65,14 @@ fn main() -> anyhow::Result<()> {
     let max_block: BlockNumberRocksdb = args.max_block.into();
     println!("Starting state comparison");
     while let (Some(result1), Some(result2)) = (iter1.next(), iter2.next()) {
-        let Ok(((address1, slot_index1, block_number1), value1)) = result1.context("Error iterating over db1") else { continue };
-        let Ok(((address2, slot_index2, block_number2), value2)) = result2.context("Error iterating over db2") else { continue };
+        let Ok(((address1, slot_index1, block_number1), value1)) = result1.context("Error iterating over db1") else {
+            continue;
+        };
+        let Ok(((address2, slot_index2, block_number2), value2)) = result2.context("Error iterating over db2") else {
+            continue;
+        };
 
-        if block_number1 > max_block && block_number2 > max_block {
+        if block_number1 > max_block && BlockNumberRocksdb::from(block_number2.0.as_u64()) > max_block {
             progress_bar.inc(1);
             continue;
         }
@@ -58,23 +80,43 @@ fn main() -> anyhow::Result<()> {
         // If block_numberA > max_block but block_numberB < max_block then cfB does not have the entry for that (and presumably future) blocks
         // Therefore cfB is already in another slot and cfA need to iterate from that slot.
         if block_number1 > max_block {
-            iter1 = cf1.iter_from((address2, slot_index2, block_number2), rocksdb::Direction::Forward)?;
+            iter1 = cf1.iter_from(
+                (
+                    Address::from(address2.0).into(),
+                    SlotIndex::from(slot_index2.0).into(),
+                    block_number2.0.as_u64().into(),
+                ),
+                rocksdb::Direction::Forward,
+            )?;
             progress_bar.inc(1);
             continue;
         }
 
-        if block_number2 > max_block {
-            iter2 = cf2.iter_from((address1, slot_index1, block_number1), rocksdb::Direction::Forward)?;
+        if BlockNumberRocksdb::from(block_number2.0.as_u64()) > max_block {
+            iter2 = cf2.iter_from(
+                (
+                    AddressRocksdbOld(address1.0.into()),
+                    SlotIndexRocksdbOld(U256(slot_index1.0)),
+                    BlockNumberRocksdbOld(block_number1.0.into()),
+                ),
+                rocksdb::Direction::Forward,
+            )?;
             progress_bar.inc(1);
             continue;
         }
 
-        if (address1, slot_index1, block_number1) != (address2, slot_index2, block_number2) {
+        if (address1, slot_index1, block_number1)
+            != (
+                Address::from(address2.0).into(),
+                SlotIndex::from(slot_index2.0).into(),
+                block_number2.0.as_u64().into(),
+            )
+        {
             println!("Mismatched entries:");
             println!("  DB1: address: {:?}, slot: {:?}, block: {:?}", address1, slot_index1, block_number1);
             println!("  DB2: address: {:?}, slot: {:?}, block: {:?}", address2, slot_index2, block_number2);
             differences += 1;
-        } else if value1 != value2 {
+        } else if value1 != SlotValue::from(value2.0).into() {
             println!(
                 "Difference found at address: {:?}, slot: {:?}, block: {:?}",
                 address1, slot_index1, block_number1
@@ -99,7 +141,7 @@ fn main() -> anyhow::Result<()> {
 
     for result in iter2 {
         let ((address, slot_index, block_number), _) = result.context("Error iterating over remaining db2 entries")?;
-        if block_number <= max_block {
+        if BlockNumberRocksdb::from(block_number.0.as_u64()) <= max_block {
             println!("Extra entry in db2: address: {:?}, slot: {:?}, block: {:?}", address, slot_index, block_number);
             differences += 1;
         }

--- a/src/bin/compare_state.rs
+++ b/src/bin/compare_state.rs
@@ -87,7 +87,7 @@ fn main() -> anyhow::Result<()> {
                 if value_new != SlotValue::from(value_old.0).into() {
                     println!("Difference found at address: {:?}, slot: {:?}, block: {:?}", address, slot_index, block_number);
                     println!("  Value old: {:?}", value_old);
-                    println!("  Value new: {:?}", value_new);
+                    println!("  Value new: {:?}", U256(value_new.into_inner().0));
                     differences.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                 },
             None => {

--- a/src/bin/compare_state.rs
+++ b/src/bin/compare_state.rs
@@ -39,6 +39,8 @@ fn main() -> anyhow::Result<()> {
             continue;
         }
 
+        // If block_numberA > max_block but block_numberB < max_block then cfB does not have the entry for that (and presumably future) blocks
+        // Therefore cfB is already in another slot nad cfA need to iterate from that slot.
         if block_number1 > args.max_block {
             iter1 = cf1.iter_from((address2, slot_index2, block_number2), rocksdb::Direction::Forward)?;
             continue;

--- a/src/bin/compare_state.rs
+++ b/src/bin/compare_state.rs
@@ -24,12 +24,11 @@ struct Args {
 
 fn main() -> anyhow::Result<()> {
     let args = Args::parse();
-
     println!("Opening databases");
 
-    let db1 = DB::open_for_read_only(&Options::default(), &args.db1_path, false)?;
+    let db1 = DB::open_cf_for_read_only(&Options::default(), &args.db1_path, ["account_slots_history"], false)?;
     println!("Opened db1");
-    let db2 = DB::open_for_read_only(&Options::default(), &args.db2_path, false)?;
+    let db2 = DB::open_cf_for_read_only(&Options::default(), &args.db2_path, ["account_slots_history"], false)?;
     println!("Opened db2");
 
     let cf1: RocksCfRef<(Address, SlotIndex, BlockNumber), SlotValue> = RocksCfRef::new(db1.into(), "account_slots_history")?;

--- a/src/bin/compare_state.rs
+++ b/src/bin/compare_state.rs
@@ -44,7 +44,7 @@ fn main() -> anyhow::Result<()> {
         }
 
         // If block_numberA > max_block but block_numberB < max_block then cfB does not have the entry for that (and presumably future) blocks
-        // Therefore cfB is already in another slot nad cfA need to iterate from that slot.
+        // Therefore cfB is already in another slot and cfA need to iterate from that slot.
         if block_number1 > args.max_block {
             iter1 = cf1.iter_from((address2, slot_index2, block_number2), rocksdb::Direction::Forward)?;
             continue;

--- a/src/bin/compare_state.rs
+++ b/src/bin/compare_state.rs
@@ -47,8 +47,8 @@ fn main() -> anyhow::Result<()> {
     let max_block: BlockNumberRocksdb = args.max_block.into();
     println!("Starting state comparison");
     while let (Some(result1), Some(result2)) = (iter1.next(), iter2.next()) {
-        let ((address1, slot_index1, block_number1), value1) = result1.context("Error iterating over db1")?;
-        let ((address2, slot_index2, block_number2), value2) = result2.context("Error iterating over db2")?;
+        let Ok(((address1, slot_index1, block_number1), value1)) = result1.context("Error iterating over db1") else { continue };
+        let Ok(((address2, slot_index2, block_number2), value2)) = result2.context("Error iterating over db2") else { continue };
 
         if block_number1 > max_block && block_number2 > max_block {
             progress_bar.inc(1);

--- a/src/bin/compare_state.rs
+++ b/src/bin/compare_state.rs
@@ -1,8 +1,12 @@
 use anyhow::Context;
 use clap::Parser;
-use rocksdb::{DB, Options};
+use rocksdb::Options;
+use rocksdb::DB;
+use stratus::eth::primitives::Address;
+use stratus::eth::primitives::BlockNumber;
+use stratus::eth::primitives::SlotIndex;
+use stratus::eth::primitives::SlotValue;
 use stratus::eth::storage::rocks::rocks_cf::RocksCfRef;
-use stratus::eth::primitives::{Address, BlockNumber, SlotIndex, SlotValue};
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -57,13 +61,16 @@ fn main() -> anyhow::Result<()> {
             println!("  DB2: address: {:?}, slot: {:?}, block: {:?}", address2, slot_index2, block_number2);
             differences += 1;
         } else if value1 != value2 {
-            println!("Difference found at address: {:?}, slot: {:?}, block: {:?}", address1, slot_index1, block_number1);
+            println!(
+                "Difference found at address: {:?}, slot: {:?}, block: {:?}",
+                address1, slot_index1, block_number1
+            );
             differences += 1;
         }
     }
 
     // Check for any remaining entries in either database
-    while let Some(result) = iter1.next() {
+    for result in iter1 {
         let ((address, slot_index, block_number), _) = result.context("Error iterating over remaining db1 entries")?;
         if block_number <= args.max_block {
             println!("Extra entry in db1: address: {:?}, slot: {:?}, block: {:?}", address, slot_index, block_number);
@@ -71,7 +78,7 @@ fn main() -> anyhow::Result<()> {
         }
     }
 
-    while let Some(result) = iter2.next() {
+    for result in iter2 {
         let ((address, slot_index, block_number), _) = result.context("Error iterating over remaining db2 entries")?;
         if block_number <= args.max_block {
             println!("Extra entry in db2: address: {:?}, slot: {:?}, block: {:?}", address, slot_index, block_number);

--- a/src/eth/storage/rocks/mod.rs
+++ b/src/eth/storage/rocks/mod.rs
@@ -7,12 +7,12 @@ mod rocks_batch_writer;
 pub mod rocks_permanent;
 
 /// State handler for DB and column families.
-mod rocks_state;
+pub mod rocks_state;
 
 /// CFs versionated by value variant.
 mod cf_versions;
 /// Data manipulation for column families.
-mod rocks_cf;
+pub mod rocks_cf;
 /// Settings and tweaks for the database and column families.
 mod rocks_config;
 /// Functionalities related to the whole database.

--- a/src/eth/storage/rocks/mod.rs
+++ b/src/eth/storage/rocks/mod.rs
@@ -10,7 +10,7 @@ pub mod rocks_permanent;
 mod rocks_state;
 
 /// CFs versionated by value variant.
-mod cf_versions;
+pub mod cf_versions;
 /// Data manipulation for column families.
 pub mod rocks_cf;
 /// Settings and tweaks for the database and column families.

--- a/src/eth/storage/rocks/mod.rs
+++ b/src/eth/storage/rocks/mod.rs
@@ -7,7 +7,7 @@ mod rocks_batch_writer;
 pub mod rocks_permanent;
 
 /// State handler for DB and column families.
-pub mod rocks_state;
+mod rocks_state;
 
 /// CFs versionated by value variant.
 mod cf_versions;

--- a/src/eth/storage/rocks/mod.rs
+++ b/src/eth/storage/rocks/mod.rs
@@ -18,4 +18,4 @@ mod rocks_config;
 /// Functionalities related to the whole database.
 mod rocks_db;
 /// All types to be serialized and desserialized in the db.
-mod types;
+pub mod types;

--- a/src/eth/storage/rocks/rocks_cf.rs
+++ b/src/eth/storage/rocks/rocks_cf.rs
@@ -387,7 +387,7 @@ where
 }
 
 /// An iterator over K-V pairs in a CF.
-pub(super) struct RocksCfIter<'a, K, V> {
+pub struct RocksCfIter<'a, K, V> {
     iter: DBIteratorWithThreadMode<'a, DB>,
     column_family: &'a str,
     _marker: PhantomData<(K, V)>,

--- a/src/eth/storage/rocks/rocks_cf.rs
+++ b/src/eth/storage/rocks/rocks_cf.rs
@@ -455,7 +455,7 @@ where
 /// This iterator doesn't deserialize values, but the underlying RocksDB iterator still reads them.
 ///
 /// Created by calling `.keys()` on a `RocksCfIter`.
-pub(super) struct RocksCfKeysIter<'a, K> {
+pub struct RocksCfKeysIter<'a, K> {
     iter: DBIteratorWithThreadMode<'a, DB>,
     column_family: &'a str,
     _marker: PhantomData<K>,

--- a/src/eth/storage/rocks/rocks_cf.rs
+++ b/src/eth/storage/rocks/rocks_cf.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 use anyhow::anyhow;
 use anyhow::Context;
 use anyhow::Result;
+use rocksdb::properties::PropName;
 use rocksdb::BoundColumnFamily;
 use rocksdb::DBIteratorWithThreadMode;
 use rocksdb::IteratorMode;
@@ -362,7 +363,7 @@ where
         serialize_with_context(value).with_context(|| format!("failed to serialize value of cf '{}'", self.column_family))
     }
 
-    pub fn property_int_value(&self, name: &str) -> anyhow::Result<Option<u64>> {
+    pub fn property_int_value(&self, name: &PropName) -> anyhow::Result<Option<u64>> {
         let handle = self.handle();
         Ok(self.db.property_int_value_cf(&handle, name)?)
     }

--- a/src/eth/storage/rocks/rocks_cf.rs
+++ b/src/eth/storage/rocks/rocks_cf.rs
@@ -304,24 +304,12 @@ where
 
     #[cfg(feature = "metrics")]
     pub fn export_metrics(&self) {
-        let cur_size_active_mem_table = self
-            .property_int_value(rocksdb::properties::CUR_SIZE_ACTIVE_MEM_TABLE)
-            .unwrap_or_default();
-        let cur_size_all_mem_tables = self
-            .property_int_value(rocksdb::properties::CUR_SIZE_ALL_MEM_TABLES)
-            .unwrap_or_default();
-        let size_all_mem_tables = self
-            .property_int_value(rocksdb::properties::SIZE_ALL_MEM_TABLES)
-            .unwrap_or_default();
-        let block_cache_usage = self
-            .property_int_value(rocksdb::properties::BLOCK_CACHE_USAGE)
-            .unwrap_or_default();
-        let block_cache_capacity = self
-            .property_int_value(rocksdb::properties::BLOCK_CACHE_CAPACITY)
-            .unwrap_or_default();
-        let background_errors = self
-            .property_int_value(rocksdb::properties::BACKGROUND_ERRORS)
-            .unwrap_or_default();
+        let cur_size_active_mem_table = self.property_int_value(rocksdb::properties::CUR_SIZE_ACTIVE_MEM_TABLE).unwrap_or_default();
+        let cur_size_all_mem_tables = self.property_int_value(rocksdb::properties::CUR_SIZE_ALL_MEM_TABLES).unwrap_or_default();
+        let size_all_mem_tables = self.property_int_value(rocksdb::properties::SIZE_ALL_MEM_TABLES).unwrap_or_default();
+        let block_cache_usage = self.property_int_value(rocksdb::properties::BLOCK_CACHE_USAGE).unwrap_or_default();
+        let block_cache_capacity = self.property_int_value(rocksdb::properties::BLOCK_CACHE_CAPACITY).unwrap_or_default();
+        let background_errors = self.property_int_value(rocksdb::properties::BACKGROUND_ERRORS).unwrap_or_default();
 
         let cf_name = &self.column_family;
         if let Some(cur_size_active_mem_table) = cur_size_active_mem_table {

--- a/src/eth/storage/rocks/rocks_cf.rs
+++ b/src/eth/storage/rocks/rocks_cf.rs
@@ -303,30 +303,23 @@ where
 
     #[cfg(feature = "metrics")]
     pub fn export_metrics(&self) {
-        let handle = self.handle();
         let cur_size_active_mem_table = self
-            .db
-            .property_int_value_cf(&handle, rocksdb::properties::CUR_SIZE_ACTIVE_MEM_TABLE)
+            .property_int_value(rocksdb::properties::CUR_SIZE_ACTIVE_MEM_TABLE)
             .unwrap_or_default();
         let cur_size_all_mem_tables = self
-            .db
-            .property_int_value_cf(&handle, rocksdb::properties::CUR_SIZE_ALL_MEM_TABLES)
+            .property_int_value(rocksdb::properties::CUR_SIZE_ALL_MEM_TABLES)
             .unwrap_or_default();
         let size_all_mem_tables = self
-            .db
-            .property_int_value_cf(&handle, rocksdb::properties::SIZE_ALL_MEM_TABLES)
+            .property_int_value(rocksdb::properties::SIZE_ALL_MEM_TABLES)
             .unwrap_or_default();
         let block_cache_usage = self
-            .db
-            .property_int_value_cf(&handle, rocksdb::properties::BLOCK_CACHE_USAGE)
+            .property_int_value(rocksdb::properties::BLOCK_CACHE_USAGE)
             .unwrap_or_default();
         let block_cache_capacity = self
-            .db
-            .property_int_value_cf(&handle, rocksdb::properties::BLOCK_CACHE_CAPACITY)
+            .property_int_value(rocksdb::properties::BLOCK_CACHE_CAPACITY)
             .unwrap_or_default();
         let background_errors = self
-            .db
-            .property_int_value_cf(&handle, rocksdb::properties::BACKGROUND_ERRORS)
+            .property_int_value(rocksdb::properties::BACKGROUND_ERRORS)
             .unwrap_or_default();
 
         let cf_name = &self.column_family;
@@ -367,6 +360,11 @@ where
 
     fn serialize_value_with_context(&self, value: &V) -> Result<Vec<u8>> {
         serialize_with_context(value).with_context(|| format!("failed to serialize value of cf '{}'", self.column_family))
+    }
+
+    pub fn property_int_value(&self, name: &str) -> anyhow::Result<Option<u64>> {
+        let handle = self.handle();
+        Ok(self.db.property_int_value_cf(&handle, name)?)
     }
 }
 

--- a/src/eth/storage/rocks/types/address.rs
+++ b/src/eth/storage/rocks/types/address.rs
@@ -3,7 +3,7 @@ use std::fmt::Debug;
 use crate::eth::primitives::Address;
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize, fake::Dummy)]
-pub struct AddressRocksdb([u8; 20]);
+pub struct AddressRocksdb(pub [u8; 20]);
 
 impl AddressRocksdb {
     pub fn inner_value(&self) -> [u8; 20] {

--- a/src/eth/storage/rocks/types/slot.rs
+++ b/src/eth/storage/rocks/types/slot.rs
@@ -4,7 +4,7 @@ use crate::eth::primitives::SlotIndex;
 use crate::eth::primitives::SlotValue;
 
 #[derive(Clone, Debug, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize, fake::Dummy)]
-pub struct SlotValueRocksdb([u64; 4]);
+pub struct SlotValueRocksdb(pub [u64; 4]);
 
 impl From<SlotValue> for SlotValueRocksdb {
     fn from(item: SlotValue) -> Self {

--- a/src/eth/storage/rocks/types/slot.rs
+++ b/src/eth/storage/rocks/types/slot.rs
@@ -19,7 +19,7 @@ impl From<SlotValueRocksdb> for SlotValue {
 }
 
 #[derive(Clone, Debug, Copy, Default, Hash, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize, fake::Dummy)]
-pub struct SlotIndexRocksdb([u64; 4]);
+pub struct SlotIndexRocksdb(pub [u64; 4]);
 
 impl From<SlotIndex> for SlotIndexRocksdb {
     fn from(item: SlotIndex) -> Self {


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Introduced a new binary `compare_state` for comparing states between two RocksDB databases:
  - Implements command-line argument parsing using clap
  - Opens two databases in read-only mode
  - Iterates over both databases simultaneously, comparing entries up to a specified max block
  - Reports differences in entry order, values, and extra entries
  - Provides a summary of total differences found
- Made the `rocks_cf` module and `RocksCfIter` struct public to support the new binary
- Enhanced error handling and context reporting using anyhow
- Implemented efficient iteration and comparison logic to handle large databases


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>compare_state.rs</strong><dd><code>Implement compare_state binary for database comparison</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/bin/compare_state.rs

<li>Implements a new binary for comparing states between two RocksDB <br>databases<br> <li> Uses clap for command-line argument parsing<br> <li> Iterates over both databases simultaneously, comparing entries up to a <br>specified max block<br> <li> Reports differences in entry order, values, and extra entries<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1690/files#diff-5456ded3bff293f7327897df017eb5c25d06913772ea483397f774c7f44429c7">+85/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Make rocks_cf module public</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/rocks/mod.rs

<li>Changes the visibility of the <code>rocks_cf</code> module from private to public<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1690/files#diff-38613469ff37344dd2d68aa4da8280b321c01993e312518834dbf4834f9422bc">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rocks_cf.rs</strong><dd><code>Make RocksCfIter struct public</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/rocks/rocks_cf.rs

<li>Changes the visibility of the <code>RocksCfIter</code> struct from <code>pub(super)</code> to <br><code>pub</code><br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1690/files#diff-0eaed53baca4bd2355e2a54a150b305569904a45c93547da288208c6373d1df2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

