### PR TITLE
feat: add rpc method for pending transactions count

### DIFF
--- a/src/eth/rpc/rpc_server.rs
+++ b/src/eth/rpc/rpc_server.rs
@@ -186,6 +186,7 @@ fn register_methods(mut module: RpcModule<RpcContext>) -> anyhow::Result<RpcModu
     module.register_method("stratus_state", stratus_state)?;
 
     module.register_async_method("stratus_getSubscriptions", stratus_get_subscriptions)?;
+    module.register_method("stratus_pendingTransactionsCount", stratus_pending_transactions_count)?;
 
     // blockchain
     module.register_method("net_version", net_version)?;
@@ -512,6 +513,11 @@ fn stratus_enable_miner(_: Params<'_>, _: &RpcContext, _: &Extensions) -> bool {
 fn stratus_disable_miner(_: Params<'_>, _: &RpcContext, _: &Extensions) -> bool {
     GlobalState::set_miner_enabled(false);
     GlobalState::is_miner_enabled()
+}
+
+/// Returns the count of executed transactions waiting to enter the next block.
+fn stratus_pending_transactions_count(_: Params<'_>, ctx: &RpcContext, _: &Extensions) -> usize {
+    ctx.storage.pending_transactions().len()
 }
 
 // -----------------------------------------------------------------------------

--- a/src/eth/rpc/rpc_server.rs
+++ b/src/eth/rpc/rpc_server.rs
@@ -428,7 +428,7 @@ fn stratus_change_miner_mode(params: Params<'_>, ctx: &RpcContext, _: &Extension
         MinerMode::External => {
             tracing::info!("changing miner mode to External");
 
-            let pending_txs = ctx.storage.pending_transactions()?;
+            let pending_txs = ctx.storage.pending_transactions();
             if not(pending_txs.is_empty()) {
                 tracing::error!(pending_txs = ?pending_txs.len(), "cannot change miner mode to External with pending transactions");
                 return Err(StratusError::PendingTransactionsExist {

--- a/src/eth/storage/inmemory/inmemory_temporary.rs
+++ b/src/eth/storage/inmemory/inmemory_temporary.rs
@@ -186,10 +186,13 @@ impl TemporaryStorage for InMemoryTemporaryStorage {
         Ok(())
     }
 
-    fn pending_transactions(&self) -> anyhow::Result<Vec<TransactionExecution>> {
-        let states = self.lock_read();
-        let Some(ref pending_block) = states.head.block else { return Ok(vec![]) };
-        Ok(pending_block.transactions.iter().map(|(_, tx)| tx.clone()).collect())
+    fn pending_transactions(&self) -> Vec<TransactionExecution> {
+        self.lock_read()
+            .head
+            .block
+            .as_ref()
+            .map(|pending_block| pending_block.transactions.iter().map(|(_, tx)| tx.clone()).collect())
+            .unwrap_or_default()
     }
 
     /// TODO: we cannot allow more than one pending block. Where to put this check?

--- a/src/eth/storage/inmemory/inmemory_temporary.rs
+++ b/src/eth/storage/inmemory/inmemory_temporary.rs
@@ -189,7 +189,7 @@ impl TemporaryStorage for InMemoryTemporaryStorage {
     fn pending_transactions(&self) -> anyhow::Result<Vec<TransactionExecution>> {
         let states = self.lock_read();
         let Some(ref pending_block) = states.head.block else { return Ok(vec![]) };
-        Ok(pending_block.transactions.clone().into_iter().map(|(_, tx)| tx.clone()).collect())
+        Ok(pending_block.transactions.iter().map(|(_, tx)| tx.clone()).collect())
     }
 
     /// TODO: we cannot allow more than one pending block. Where to put this check?

--- a/src/eth/storage/stratus_storage.rs
+++ b/src/eth/storage/stratus_storage.rs
@@ -305,8 +305,8 @@ impl StratusStorage {
     }
 
     /// Retrieves pending transactions being mined.
-    pub fn pending_transactions(&self) -> Result<Vec<TransactionExecution>, StratusError> {
-        self.temp.pending_transactions().map_err(Into::into)
+    pub fn pending_transactions(&self) -> Vec<TransactionExecution> {
+        self.temp.pending_transactions()
     }
 
     pub fn finish_pending_block(&self) -> Result<PendingBlock, StratusError> {

--- a/src/eth/storage/temporary_storage.rs
+++ b/src/eth/storage/temporary_storage.rs
@@ -39,7 +39,7 @@ pub trait TemporaryStorage: Send + Sync + 'static {
     fn save_execution(&self, tx: TransactionExecution, check_conflicts: bool) -> Result<(), StratusError>;
 
     /// Retrieves the pending transactions of the pending block.
-    fn pending_transactions(&self) -> anyhow::Result<Vec<TransactionExecution>>;
+    fn pending_transactions(&self) -> Vec<TransactionExecution>;
 
     /// Finishes the mining of the pending block and starts a new block.
     fn finish_pending_block(&self) -> anyhow::Result<PendingBlock>;


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added new RPC method `stratus_pendingTransactionsCount` to retrieve the count of executed transactions waiting to enter the next block
- Refactored `pending_transactions` method in various storage-related files to return `Vec<TransactionExecution>` directly, removing the `Result` wrapper
- Simplified the implementation of `pending_transactions` in `InMemoryTemporaryStorage` using iterator methods
- Updated the `TemporaryStorage` trait to reflect the changes in the `pending_transactions` method signature
- These changes improve error handling and make the API more straightforward for retrieving pending transactions


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rpc_server.rs</strong><dd><code>Add RPC method for pending transactions count</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/rpc/rpc_server.rs

<li>Added new RPC method <code>stratus_pendingTransactionsCount</code><br> <li> Implemented function to return count of pending transactions<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1691/files#diff-835ba255c9a5c1fe0e13285bc39e058e1c74422e5e03ebba483c9d8a15c45405">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>inmemory_temporary.rs</strong><dd><code>Refactor pending transactions retrieval</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/inmemory/inmemory_temporary.rs

<li>Modified <code>pending_transactions</code> method to return <code>Vec<TransactionExecution></code> instead of <br><code>anyhow::Result<Vec<TransactionExecution>></code><br> <li> Simplified implementation using iterator methods<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1691/files#diff-6f4ee832c01927be4b428028743a37022368d351f09fd177f59e81a5a58dd661">+7/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>stratus_storage.rs</strong><dd><code>Update pending transactions return type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/stratus_storage.rs

<li>Updated <code>pending_transactions</code> method to return <code>Vec<TransactionExecution></code> instead of <code>Result<Vec<TransactionExecution>, </code><br><code>StratusError></code><br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1691/files#diff-3b2e36e47959decdfe26b2c4fab90b41f9242bfdad29cc43b2377ee851f4f40a">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>temporary_storage.rs</strong><dd><code>Update TemporaryStorage trait for pending transactions</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/temporary_storage.rs

<li>Modified <code>pending_transactions</code> trait method to return <code>Vec<TransactionExecution></code> instead of <br><code>anyhow::Result<Vec<TransactionExecution>></code><br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1691/files#diff-58337f46f036f808e0166f195e0ed5dfbfdc092fc1665c3424f01d799a5195de">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

