### PR TITLE
chore: decrease RwLock retention

### DIFF
--- a/src/eth/rpc/rpc_server.rs
+++ b/src/eth/rpc/rpc_server.rs
@@ -63,6 +63,7 @@ use crate::eth::storage::StratusStorage;
 use crate::ext::not;
 use crate::ext::to_json_string;
 use crate::ext::to_json_value;
+use crate::ext::SerdeResultExt;
 use crate::infra::build_info;
 use crate::infra::metrics;
 use crate::infra::tracing::SpanExt;
@@ -533,11 +534,15 @@ fn stratus_state(_: Params<'_>, _: &RpcContext, _: &Extensions) -> Result<JsonVa
 async fn stratus_get_subscriptions(_: Params<'_>, ctx: Arc<RpcContext>, ext: Extensions) -> Result<JsonValue, StratusError> {
     reject_unknown_client(ext.rpc_client())?;
 
-    let (pending_txs, new_heads, logs) = join!(ctx.subs.new_heads.read(), ctx.subs.pending_txs.read(), ctx.subs.logs.read());
+    // NOTE: this is a workaround for holding only one lock at a time
+    let pending_txs = serde_json::to_value(ctx.subs.new_heads.read().await.values().collect_vec()).expect_infallible();
+    let new_heads = serde_json::to_value(ctx.subs.pending_txs.read().await.values().collect_vec()).expect_infallible();
+    let logs = serde_json::to_value(ctx.subs.logs.read().await.values().flat_map(HashMap::values).collect_vec()).expect_infallible();
+
     let response = json!({
-        "newPendingTransactions": pending_txs.values().collect_vec(),
-        "newHeads": new_heads.values().collect_vec(),
-        "logs": logs.values().flat_map(HashMap::values).collect_vec()
+        "newPendingTransactions": pending_txs,
+        "newHeads": new_heads,
+        "logs": logs,
     });
     Ok(response)
 }


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Improved performance by reducing RwLock retention in the `stratus_get_subscriptions` function
- Modified the approach to read subscription data sequentially instead of simultaneously
- Implemented serialization of subscription data outside of lock scope
- Added error handling for serialization using `expect_infallible()`
- Simplified the JSON response construction by using pre-serialized values


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rpc_server.rs</strong><dd><code>Optimize RwLock usage in subscription data retrieval</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/rpc/rpc_server.rs

<li>Imported <code>SerdeResultExt</code> from <code>crate::ext</code><br> <li> Modified <code>stratus_get_subscriptions</code> function to reduce lock retention<br> <li> Replaced simultaneous lock reads with sequential reads and <br>serialization<br> <li> Used <code>expect_infallible()</code> for error handling in serialization<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1692/files#diff-835ba255c9a5c1fe0e13285bc39e058e1c74422e5e03ebba483c9d8a15c45405">+9/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

