### PR TITLE
feat: add rpc method change to follower

### DIFF
--- a/src/eth/rpc/rpc_server.rs
+++ b/src/eth/rpc/rpc_server.rs
@@ -180,6 +180,7 @@ fn register_methods(mut module: RpcModule<RpcContext>) -> anyhow::Result<RpcModu
     module.register_method("stratus_disableMiner", stratus_disable_miner)?;
     module.register_method("stratus_enableUnknownClients", stratus_enable_unknown_clients)?;
     module.register_method("stratus_disableUnknownClients", stratus_disable_unknown_clients)?;
+    module.register_method("stratus_changeToFollower", stratus_change_to_follower)?;
 
     // stratus state
     module.register_method("stratus_version", stratus_version)?;
@@ -516,11 +517,6 @@ fn stratus_disable_miner(_: Params<'_>, _: &RpcContext, _: &Extensions) -> bool 
     GlobalState::is_miner_enabled()
 }
 
-/// Returns the count of executed transactions waiting to enter the next block.
-fn stratus_pending_transactions_count(_: Params<'_>, ctx: &RpcContext, _: &Extensions) -> usize {
-    ctx.storage.pending_transactions().len()
-}
-
 // -----------------------------------------------------------------------------
 // Stratus - State
 // -----------------------------------------------------------------------------
@@ -551,6 +547,11 @@ async fn stratus_get_subscriptions(_: Params<'_>, ctx: Arc<RpcContext>, ext: Ext
         "logs": logs,
     });
     Ok(response)
+}
+
+/// Returns the count of executed transactions waiting to enter the next block.
+fn stratus_pending_transactions_count(_: Params<'_>, ctx: &RpcContext, _: &Extensions) -> usize {
+    ctx.storage.pending_transactions().len()
 }
 
 // -----------------------------------------------------------------------------

--- a/src/eth/rpc/rpc_server.rs
+++ b/src/eth/rpc/rpc_server.rs
@@ -165,7 +165,6 @@ fn register_methods(mut module: RpcModule<RpcContext>) -> anyhow::Result<RpcModu
         module.register_blocking_method("evm_mine", evm_mine)?;
         module.register_blocking_method("hardhat_reset", stratus_reset)?;
         module.register_blocking_method("stratus_reset", stratus_reset)?;
-        module.register_async_method("stratus_initImporter", stratus_init_importer)?;
         module.register_method("stratus_shutdownImporter", stratus_shutdown_importer)?;
         module.register_method("stratus_changeMinerMode", stratus_change_miner_mode)?;
     }
@@ -180,6 +179,7 @@ fn register_methods(mut module: RpcModule<RpcContext>) -> anyhow::Result<RpcModu
     module.register_method("stratus_disableMiner", stratus_disable_miner)?;
     module.register_method("stratus_enableUnknownClients", stratus_enable_unknown_clients)?;
     module.register_method("stratus_disableUnknownClients", stratus_disable_unknown_clients)?;
+    module.register_async_method("stratus_initImporter", stratus_init_importer)?;
     module.register_method("stratus_changeToFollower", stratus_change_to_follower)?;
 
     // stratus state
@@ -299,7 +299,6 @@ fn stratus_reset(_: Params<'_>, ctx: Arc<RpcContext>, _: Extensions) -> Result<J
     Ok(to_json_value(true))
 }
 
-#[cfg(feature = "dev")]
 async fn stratus_init_importer(params: Params<'_>, ctx: Arc<RpcContext>, _: Extensions) -> Result<JsonValue, StratusError> {
     if not(GlobalState::is_follower()) {
         tracing::error!("node is currently not a follower");


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added new RPC method `stratus_changeToFollower` to demote a leader node to a follower
- Moved `stratus_initImporter` out of the `dev` feature flag, making it available in all builds
- Implemented error handling and added a delay to ensure all transactions are processed before changing to follower
- Reorganized imports and removed some `dev` feature flags for better code organization
- Added `stratus_pending_transactions_count` function to check for pending transactions
- Improved error logging with `log_and_err` macro


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rpc_server.rs</strong><dd><code>Add follower transition RPC and refactor importer initialization</code></dd></summary>
<hr>

src/eth/rpc/rpc_server.rs

<li>Moved <code>stratus_initImporter</code> out of <code>dev</code> feature flag<br> <li> Added new RPC method <code>stratus_changeToFollower</code><br> <li> Reorganized imports and removed some feature flags<br> <li> Added error handling and logging improvements<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1693/files#diff-835ba255c9a5c1fe0e13285bc39e058e1c74422e5e03ebba483c9d8a15c45405">+31/-10</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

