### PR TITLE
chore: remove redundant deserialization

### DIFF
--- a/src/eth/rpc/rpc_server.rs
+++ b/src/eth/rpc/rpc_server.rs
@@ -20,8 +20,6 @@ use jsonrpsee::Extensions;
 use jsonrpsee::IntoSubscriptionCloseResponse;
 use jsonrpsee::PendingSubscriptionSink;
 use serde_json::json;
-#[cfg(feature = "dev")]
-use serde_json::Value;
 use tokio::runtime::Handle;
 use tokio::select;
 use tracing::field;
@@ -310,15 +308,7 @@ async fn stratus_init_importer(params: Params<'_>, ctx: Arc<RpcContext>, _: Exte
         return Err(StratusError::ImporterAlreadyRunning);
     }
 
-    let app_config: Value = match serde_json::from_value(ctx.app_config.clone()) {
-        Ok(config) => config,
-        Err(e) => {
-            tracing::error!(reason = ?e, "failed to parse app_config");
-            return Err(StratusError::AppConfigParseError);
-        }
-    };
-
-    let importer_config: ImporterConfig = match app_config.get("importer") {
+    let importer_config: ImporterConfig = match ctx.app_config.get("importer") {
         Some(importer_value) => match serde_json::from_value(importer_value.clone()) {
             Ok(config) => config,
             Err(e) => {


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Removed redundant deserialization of `app_config` in the `stratus_init_importer` function
- Simplified the process of extracting and parsing the importer configuration
- Removed unused import of `serde_json::Value`, which was only used in the dev feature
- Improved code efficiency and readability by directly accessing the `app_config` field


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rpc_server.rs</strong><dd><code>Optimize RPC server configuration parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/rpc/rpc_server.rs

<li>Removed redundant deserialization of <code>app_config</code><br> <li> Simplified error handling for importer configuration parsing<br> <li> Removed unused import of <code>serde_json::Value</code><br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1694/files#diff-835ba255c9a5c1fe0e13285bc39e058e1c74422e5e03ebba483c9d8a15c45405">+1/-11</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

