### PR TITLE
chore: remove unnecessary lock

### DIFF
--- a/src/eth/miner/miner_config.rs
+++ b/src/eth/miner/miner_config.rs
@@ -6,7 +6,6 @@ use clap::Parser;
 use display_json::DebugAsJson;
 
 use crate::eth::miner::Miner;
-use crate::eth::primitives::StratusError;
 use crate::eth::storage::StratusStorage;
 use crate::ext::parse_duration;
 use crate::GlobalState;
@@ -56,18 +55,10 @@ impl MinerConfig {
         // set block number
         storage.set_pending_block_number_as_next_if_not_set()?;
 
-        let mode_lock = miner.mode.read().map_err(|_| {
-            tracing::error!("miner mode read lock was poisoned");
-            miner.mode.clear_poison();
-            StratusError::MinerModeLockFailed
-        })?;
-
         // enable interval miner
-        if mode_lock.is_interval() {
+        if mode.is_interval() {
             Arc::clone(&miner).spawn_interval_miner()?;
         }
-
-        drop(mode_lock);
 
         Ok(Arc::clone(&miner))
     }

--- a/src/eth/rpc/rpc_client_app.rs
+++ b/src/eth/rpc/rpc_client_app.rs
@@ -3,13 +3,12 @@ use std::fmt::Display;
 #[cfg(feature = "metrics")]
 use crate::infra::metrics::MetricLabelValue;
 
-#[derive(Debug, Clone, Default, strum::EnumIs, PartialEq)]
+#[derive(Debug, Clone, strum::EnumIs, PartialEq)]
 pub enum RpcClientApp {
     /// Client application identified itself.
     Identified(String),
 
     /// Client application is unknown.
-    #[default]
     Unknown,
 }
 

--- a/src/eth/rpc/rpc_http_middleware.rs
+++ b/src/eth/rpc/rpc_http_middleware.rs
@@ -99,5 +99,5 @@ fn parse_client_app(headers: &HeaderMap<HeaderValue>, uri: &Uri) -> RpcClientApp
     if let Some(app) = try_path(uri) {
         return app;
     }
-    RpcClientApp::default()
+    RpcClientApp::Unknown
 }

--- a/src/eth/rpc/rpc_parser.rs
+++ b/src/eth/rpc/rpc_parser.rs
@@ -20,7 +20,7 @@ pub trait RpcExtensionsExt {
 
 impl RpcExtensionsExt for Extensions {
     fn rpc_client(&self) -> RpcClientApp {
-        self.get::<RpcClientApp>().cloned().unwrap_or_default()
+        self.get::<RpcClientApp>().cloned().unwrap_or(RpcClientApp::Unknown)
     }
 
     fn enter_middleware_span(&self) -> Option<tracing::span::Entered<'_>> {


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Removed unnecessary lock and associated error handling in miner configuration
- Simplified miner mode checking by directly using `mode.is_interval()`
- Removed `Default` implementation for `RpcClientApp` enum
- Consistently use `RpcClientApp::Unknown` instead of `default()` across multiple files
- Improved code clarity and reduced potential for errors related to default implementations


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>miner_config.rs</strong><dd><code>Simplify miner mode checking and remove lock</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/miner/miner_config.rs

<li>Removed unnecessary <code>StratusError</code> import<br> <li> Eliminated <code>mode_lock</code> and associated error handling<br> <li> Simplified mode check by directly using <code>mode.is_interval()</code><br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1697/files#diff-ea3a8597b909e696993f7e791ab04e5ad784da8077b87088d9c78c804e1ef69d">+1/-10</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rpc_client_app.rs</strong><dd><code>Remove default implementation for RpcClientApp</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/rpc/rpc_client_app.rs

<li>Removed <code>Default</code> derive for <code>RpcClientApp</code> enum<br> <li> Removed <code>#[default]</code> attribute from <code>Unknown</code> variant<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1697/files#diff-58a4136b4354d7489c12136de37282c85be59f542ed4d605ceead0c00ba5ddc3">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rpc_http_middleware.rs</strong><dd><code>Use explicit Unknown variant for default RpcClientApp</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/rpc/rpc_http_middleware.rs

<li>Changed default <code>RpcClientApp</code> from <code>RpcClientApp::default()</code> to <br><code>RpcClientApp::Unknown</code><br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1697/files#diff-d7c94c23def8e9b10bd2dba867a617d426ea5819c94f8612e1705148a10972ba">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rpc_parser.rs</strong><dd><code>Replace default() with explicit Unknown in rpc_client method</code></dd></summary>
<hr>

src/eth/rpc/rpc_parser.rs

<li>Updated <code>rpc_client</code> method to use <code>RpcClientApp::Unknown</code> instead of <br><code>default()</code><br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1697/files#diff-2756485347ebcee6b3104300efc1ebc605d7ba6ede30878111e2a7d4dbe46b40">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

