### PR TITLE
enha: refactor miner mode endpoint

### DIFF
--- a/src/eth/rpc/rpc_server.rs
+++ b/src/eth/rpc/rpc_server.rs
@@ -300,6 +300,7 @@ fn stratus_reset(_: Params<'_>, ctx: Arc<RpcContext>, _: Extensions) -> Result<J
 }
 
 async fn stratus_change_to_leader(_: Params<'_>, ctx: Arc<RpcContext>, ext: Extensions) -> Result<JsonValue, StratusError> {
+    const LEADER_MINER_INTERVAL: Duration = Duration::from_secs(1);
     const WAIT_DELAY: Duration = Duration::from_secs(5);
     tracing::info!("starting process to change node to leader");
 
@@ -331,7 +332,7 @@ async fn stratus_change_to_leader(_: Params<'_>, ctx: Arc<RpcContext>, ext: Exte
 
     GlobalState::set_miner_enabled(false);
 
-    let change_miner_mode_result = change_miner_mode(MinerMode::Interval(Duration::from_secs(1)), &ctx);
+    let change_miner_mode_result = change_miner_mode(MinerMode::Interval(LEADER_MINER_INTERVAL), &ctx);
     if let Err(e) = change_miner_mode_result {
         tracing::error!(reason = ?e, "failed to change miner mode");
         return Err(e);

--- a/src/eth/rpc/rpc_server.rs
+++ b/src/eth/rpc/rpc_server.rs
@@ -542,7 +542,7 @@ fn change_miner_mode(mode: MinerMode, ctx: &RpcContext) -> Result<JsonValue, Str
             tracing::info!("changing miner mode to External");
 
             let pending_txs = ctx.storage.pending_transactions();
-            if !pending_txs.is_empty() {
+            if not(pending_txs.is_empty()) {
                 tracing::error!(pending_txs = ?pending_txs.len(), "cannot change miner mode to External with pending transactions");
                 return Err(StratusError::PendingTransactionsExist {
                     pending_txs: pending_txs.len(),


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Refactored miner mode handling in RPC server:
  - Introduced `change_miner_mode` function to centralize mode changing logic
  - Updated `stratus_change_to_leader` and `stratus_change_to_follower` to use the new function
- Added `LEADER_MINER_INTERVAL` constant for leader miner interval
- Improved error handling and logging for miner mode changes
- Simplified parameter parsing in `stratus_change_miner_mode` function
- Removed redundant JSON parameter creation in leader and follower change functions


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rpc_server.rs</strong><dd><code>Refactor miner mode handling and improve RPC endpoints</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/rpc/rpc_server.rs

<li>Introduced <code>LEADER_MINER_INTERVAL</code> constant<br> <li> Refactored <code>stratus_change_to_leader</code> and <code>stratus_change_to_follower</code> <br>functions<br> <li> Created new <code>change_miner_mode</code> function<br> <li> Updated error handling in miner mode changes<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1699/files#diff-835ba255c9a5c1fe0e13285bc39e058e1c74422e5e03ebba483c9d8a15c45405">+13/-13</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

