### PR TITLE
enha: refactor init importer

### DIFF
--- a/src/eth/primitives/stratus_error.rs
+++ b/src/eth/primitives/stratus_error.rs
@@ -135,10 +135,6 @@ pub enum StratusError {
     #[strum(props(kind = "internal"))]
     MinerModeChangeUnsupported { miner_mode: &'static str },
 
-    #[error("Miner mode param is invalid.")]
-    #[strum(props(kind = "internal"))]
-    MinerModeParamInvalid,
-
     #[error("Miner is enabled.")]
     #[strum(props(kind = "internal"))]
     MinerEnabled,
@@ -153,10 +149,6 @@ pub enum StratusError {
     #[error("Importer is already shutdown.")]
     #[strum(props(kind = "internal"))]
     ImporterAlreadyShutdown,
-
-    #[error("Failed to parse importer configuration.")]
-    #[strum(props(kind = "client_request"))]
-    ImporterConfigParseError,
 
     #[error("Failed to initialize importer.")]
     #[strum(props(kind = "internal"))]

--- a/src/eth/primitives/stratus_error.rs
+++ b/src/eth/primitives/stratus_error.rs
@@ -135,6 +135,10 @@ pub enum StratusError {
     #[strum(props(kind = "internal"))]
     MinerModeChangeUnsupported { miner_mode: &'static str },
 
+    #[error("Miner mode param is invalid.")]
+    #[strum(props(kind = "internal"))]
+    MinerModeParamInvalid,
+
     #[error("Miner is enabled.")]
     #[strum(props(kind = "internal"))]
     MinerEnabled,
@@ -149,6 +153,10 @@ pub enum StratusError {
     #[error("Importer is already shutdown.")]
     #[strum(props(kind = "internal"))]
     ImporterAlreadyShutdown,
+
+    #[error("Failed to parse importer configuration.")]
+    #[strum(props(kind = "client_request"))]
+    ImporterConfigParseError,
 
     #[error("Failed to initialize importer.")]
     #[strum(props(kind = "internal"))]

--- a/src/eth/rpc/rpc_server.rs
+++ b/src/eth/rpc/rpc_server.rs
@@ -457,12 +457,12 @@ async fn stratus_init_importer(params: Params<'_>, ctx: Arc<RpcContext>, _: Exte
 
     let external_rpc_timeout = parse_duration(&raw_external_rpc_timeout).map_err(|e| {
         tracing::error!(reason = ?e, "failed to parse external_rpc_timeout");
-        StratusError::RpcParameterInvalid
+        StratusError::ImporterConfigParseError
     })?;
 
     let sync_interval = parse_duration(&raw_sync_interval).map_err(|e| {
         tracing::error!(reason = ?e, "failed to parse sync_interval");
-        StratusError::RpcParameterInvalid
+        StratusError::ImporterConfigParseError
     })?;
 
     let importer_config = ImporterConfig {
@@ -512,7 +512,7 @@ fn stratus_change_miner_mode(params: Params<'_>, ctx: &RpcContext, _: &Extension
     let (_, mode_str) = next_rpc_param::<String>(params.sequence())?;
     let mode = MinerMode::from_str(&mode_str).map_err(|e| {
         tracing::error!(reason = ?e, "failed to parse miner mode");
-        StratusError::RpcParameterInvalid
+        StratusError::MinerModeParamInvalid
     })?;
 
     change_miner_mode(mode, ctx)

--- a/src/eth/rpc/rpc_server.rs
+++ b/src/eth/rpc/rpc_server.rs
@@ -457,12 +457,12 @@ async fn stratus_init_importer(params: Params<'_>, ctx: Arc<RpcContext>, _: Exte
 
     let external_rpc_timeout = parse_duration(&raw_external_rpc_timeout).map_err(|e| {
         tracing::error!(reason = ?e, "failed to parse external_rpc_timeout");
-        StratusError::ImporterConfigParseError
+        StratusError::RpcParameterInvalid
     })?;
 
     let sync_interval = parse_duration(&raw_sync_interval).map_err(|e| {
         tracing::error!(reason = ?e, "failed to parse sync_interval");
-        StratusError::ImporterConfigParseError
+        StratusError::RpcParameterInvalid
     })?;
 
     let importer_config = ImporterConfig {
@@ -512,7 +512,7 @@ fn stratus_change_miner_mode(params: Params<'_>, ctx: &RpcContext, _: &Extension
     let (_, mode_str) = next_rpc_param::<String>(params.sequence())?;
     let mode = MinerMode::from_str(&mode_str).map_err(|e| {
         tracing::error!(reason = ?e, "failed to parse miner mode");
-        StratusError::MinerModeParamInvalid
+        StratusError::RpcParameterInvalid
     })?;
 
     change_miner_mode(mode, ctx)


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Refactored the importer initialization process in the RPC server:
  - Split `stratus_init_importer` into two functions for better separation of concerns
  - `stratus_init_importer` now handles parameter parsing and `ImporterConfig` creation
  - New `init_importer` function focuses on the actual initialization logic
- Improved code organization and maintainability
- No changes to the overall functionality or external API


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rpc_server.rs</strong><dd><code>Refactor importer initialization for better separation of concerns</code></dd></summary>
<hr>

src/eth/rpc/rpc_server.rs

<li>Refactored <code>stratus_init_importer</code> function into two separate functions: <br><code>init_importer</code> and <code>stratus_init_importer</code><br> <li> Moved importer configuration parsing and creation to <br><code>stratus_init_importer</code><br> <li> <code>init_importer</code> now takes <code>ImporterConfig</code> as a parameter instead of <br>parsing it from RPC params<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1700/files#diff-835ba255c9a5c1fe0e13285bc39e058e1c74422e5e03ebba483c9d8a15c45405">+27/-23</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

