### PR TITLE
refac: move things from GlobalState to Miner

### DIFF
--- a/e2e/cloudwalk-contracts/integration/test/leader-follower-miner.test.ts
+++ b/e2e/cloudwalk-contracts/integration/test/leader-follower-miner.test.ts
@@ -106,18 +106,16 @@ describe("Miner mode change integration test", function () {
         expect(response.data.error.message).eq("Miner mode param is invalid.");
     });
 
-    it("Miner change on Leader with same mode should fail", async function () {
+    it("Miner change on Leader with same mode should return false", async function () {
         updateProviderUrl("stratus");
         const response = await sendAndGetFullResponse("stratus_changeMinerMode", ["1s"]);
-        expect(response.data.error.code).eq(-32603);
-        expect(response.data.error.message).eq("Requested miner mode conflicts with current miner mode.");
+        expect(response.data.result).to.equal(false);
     });
 
-    it("Miner change on Follower with same mode should fail", async function () {
+    it("Miner change on Follower with same mode should return false", async function () {
         updateProviderUrl("stratus-follower");
         const response = await sendAndGetFullResponse("stratus_changeMinerMode", ["external"]);
-        expect(response.data.error.code).eq(-32603);
-        expect(response.data.error.message).eq("Requested miner mode conflicts with current miner mode.");
+        expect(response.data.result).to.equal(false);
     });
 
     it("Miner change on Leader to Automine should fail because it is not supported", async function () {

--- a/src/eth/executor/executor.rs
+++ b/src/eth/executor/executor.rs
@@ -396,11 +396,7 @@ impl Executor {
                 // WORKAROUND: prevents interval miner mining blocks while a transaction is being executed.
                 // this can be removed when we implement conflict detection for block number
                 let _miner_lock = {
-                    let mode_lock = self.miner.mode.read().unwrap_or_else(|poison| {
-                        tracing::error!("miner mode lock was poisoned");
-                        self.miner.mode.clear_poison();
-                        poison.into_inner()
-                    });
+                    let mode_lock = self.miner.mode();
 
                     if mode_lock.is_interval() {
                         let miner_lock = Some(self.miner.locks.mine_and_commit.lock_or_clear("miner mine_and_commit lock was poisoned"));

--- a/src/eth/miner/miner.rs
+++ b/src/eth/miner/miner.rs
@@ -107,7 +107,7 @@ impl Miner {
 
         // spawn miner and ticker
         let (ticks_tx, ticks_rx) = mpsc::channel();
-        let miner_clone = Arc::clone(&self);
+        let miner_clone = Arc::clone(self);
         spawn_thread("miner-miner", move || interval_miner::run(miner_clone, ticks_rx));
         spawn_thread("miner-ticker", move || interval_miner_ticker::run(block_time, ticks_tx));
         Ok(())

--- a/src/eth/miner/miner_config.rs
+++ b/src/eth/miner/miner_config.rs
@@ -45,18 +45,6 @@ impl MinerConfig {
     pub fn init_with_mode(&self, mode: MinerMode, storage: Arc<StratusStorage>) -> anyhow::Result<Arc<Miner>> {
         tracing::info!(config = ?self, mode = ?mode, "creating block miner with specific mode");
 
-        // create genesis block and accounts if necessary
-        #[cfg(feature = "dev")]
-        {
-            let genesis = storage.read_block(&crate::eth::primitives::BlockFilter::Number(crate::eth::primitives::BlockNumber::ZERO))?;
-            if genesis.is_none() {
-                storage.reset_to_genesis()?;
-            }
-        }
-
-        // set block number
-        storage.set_pending_block_number_as_next_if_not_set()?;
-
         // create miner
         let miner = Miner::new(Arc::clone(&storage), mode);
         let miner = Arc::new(miner);

--- a/src/eth/miner/miner_config.rs
+++ b/src/eth/miner/miner_config.rs
@@ -7,6 +7,7 @@ use display_json::DebugAsJson;
 
 use crate::eth::miner::Miner;
 use crate::eth::storage::StratusStorage;
+use crate::ext::not;
 use crate::ext::parse_duration;
 use crate::GlobalState;
 use crate::NodeMode;
@@ -28,7 +29,12 @@ impl MinerConfig {
         tracing::info!(config = ?self, "creating block miner");
 
         let mode = match GlobalState::get_node_mode() {
-            NodeMode::Follower => MinerMode::External,
+            NodeMode::Follower => {
+                if not(self.block_mode.is_external()) {
+                    tracing::warn!(block_mode = ?self.block_mode, "ignoring block-mode, follower miner can only start as external");
+                }
+                MinerMode::External
+            }
             NodeMode::Leader => self.block_mode,
         };
 

--- a/src/eth/primitives/log_filter.rs
+++ b/src/eth/primitives/log_filter.rs
@@ -107,7 +107,7 @@ mod tests {
     fn build_filter(addresses: Vec<Address>, topics_nested: Vec<Vec<Option<LogTopic>>>) -> LogFilter {
         let topics_map = |topics: Vec<Option<LogTopic>>| LogFilterInputTopic(topics.into_iter().collect());
 
-        let storage = StratusStorage::new(Box::<InMemoryTemporaryStorage>::default(), Box::<InMemoryPermanentStorage>::default());
+        let storage = StratusStorage::new(Box::<InMemoryTemporaryStorage>::default(), Box::<InMemoryPermanentStorage>::default()).unwrap();
 
         LogFilterInput {
             address: addresses,

--- a/src/eth/rpc/rpc_server.rs
+++ b/src/eth/rpc/rpc_server.rs
@@ -541,10 +541,10 @@ fn change_miner_mode(mode: MinerMode, ctx: &RpcContext) -> Result<JsonValue, Str
                     StratusError::MinerModeLockFailed
                 })?;
                 GlobalState::set_interval_miner_shutdown(false);
-                *miner_mode_lock = mode;
+                *miner_mode_lock = MinerMode::Interval(duration);
             }
 
-            Arc::clone(&ctx.miner).spawn_interval_miner()?;
+            ctx.miner.start_if_interval()?;
         }
         MinerMode::Automine => {
             tracing::error!("automine mode is not supported");

--- a/src/eth/rpc/rpc_server.rs
+++ b/src/eth/rpc/rpc_server.rs
@@ -471,7 +471,7 @@ fn stratus_change_miner_mode(params: Params<'_>, ctx: &RpcContext, _: &Extension
     change_miner_mode(mode, ctx)
 }
 
-/// Tries changing miner mode, returns `Ok(true)` if changed, and `Ok(false)` if no changing was necessary
+/// Tries changing miner mode, returns `Ok(true)` if changed, and `Ok(false)` if no changing was necessary.
 ///
 /// This function also enables the miner after changing it.
 fn change_miner_mode(new_mode: MinerMode, ctx: &RpcContext) -> Result<JsonValue, StratusError> {
@@ -502,11 +502,9 @@ fn change_miner_mode(new_mode: MinerMode, ctx: &RpcContext) -> Result<JsonValue,
                 });
             }
 
-            {
-                ctx.miner.set_mode(MinerMode::External);
-                const TASK_NAME: &str = "rpc-server::miner-shutdown";
-                GlobalState::shutdown_interval_miner_from(TASK_NAME, "received miner shutdown request");
-            }
+            ctx.miner.set_mode(MinerMode::External);
+            const TASK_NAME: &str = "rpc-server::miner-shutdown";
+            GlobalState::shutdown_interval_miner_from(TASK_NAME, "received miner shutdown request");
         }
         MinerMode::Interval(duration) => {
             tracing::info!(duration = ?duration, "changing miner mode to Interval");
@@ -523,11 +521,8 @@ fn change_miner_mode(new_mode: MinerMode, ctx: &RpcContext) -> Result<JsonValue,
                 }
             }
 
-            {
-                GlobalState::set_interval_miner_shutdown(false);
-                ctx.miner.set_mode(MinerMode::Interval(duration));
-            }
-
+            GlobalState::set_interval_miner_shutdown(false);
+            ctx.miner.set_mode(MinerMode::Interval(duration));
             ctx.miner.start_if_interval()?;
         }
         MinerMode::Automine => {

--- a/src/eth/rpc/rpc_subscriptions.rs
+++ b/src/eth/rpc/rpc_subscriptions.rs
@@ -235,7 +235,8 @@ impl RpcSubscriptions {
         let msg = match msg.try_into() {
             Ok(msg) => msg,
             Err(e) => {
-                tracing::error!(parent: None, reason = ?e, "failed to convert message into subscription message");
+                // TODO: remove format!() after rust analyzer bug is fixed
+                tracing::error!(parent: None, reason = format!("{e:?}"), "failed to convert message into subscription message");
                 return;
             }
         };

--- a/src/globals.rs
+++ b/src/globals.rs
@@ -118,15 +118,7 @@ static UNKNOWN_CLIENT_ENABLED: AtomicBool = AtomicBool::new(true);
 static IS_LEADER: AtomicBool = AtomicBool::new(false);
 
 #[derive(Serialize, Deserialize, Debug)]
-pub struct GlobalState {
-    pub is_leader: bool,
-    pub is_shutdown: bool,
-    pub is_importer_shutdown: bool,
-    pub is_interval_miner_shutdown: bool,
-    pub transactions_enabled: bool,
-    pub miner_enabled: bool,
-    pub unknown_client_enabled: bool,
-}
+pub struct GlobalState;
 
 impl GlobalState {
     // -------------------------------------------------------------------------
@@ -314,16 +306,14 @@ impl GlobalState {
     // -------------------------------------------------------------------------
 
     pub fn get_global_state_as_json() -> JsonValue {
-        let state = GlobalState {
-            is_leader: Self::is_leader(),
-            is_shutdown: Self::is_shutdown(),
-            is_importer_shutdown: Self::is_importer_shutdown(),
-            is_interval_miner_shutdown: Self::is_interval_miner_shutdown(),
-            transactions_enabled: Self::is_transactions_enabled(),
-            miner_enabled: Self::is_miner_enabled(),
-            unknown_client_enabled: Self::is_unknown_client_enabled(),
-        };
-
-        json!(state)
+        json!({
+            "is_leader": Self::is_leader(),
+            "is_shutdown": Self::is_shutdown(),
+            "is_importer_shutdown": Self::is_importer_shutdown(),
+            "is_interval_miner_shutdown": Self::is_interval_miner_shutdown(),
+            "transactions_enabled": Self::is_transactions_enabled(),
+            "miner_enabled": Self::is_miner_enabled(),
+            "unknown_client_enabled": Self::is_unknown_client_enabled(),
+        })
     }
 }

--- a/src/globals.rs
+++ b/src/globals.rs
@@ -14,6 +14,7 @@ use crate::alias::JsonValue;
 use crate::config;
 use crate::config::StratusConfig;
 use crate::config::WithCommonConfig;
+use crate::eth::rpc::RpcContext;
 use crate::ext::spawn_signal_handler;
 use crate::infra::tracing::warn_task_cancellation;
 
@@ -107,9 +108,6 @@ static INTERVAL_MINER_SHUTDOWN: AtomicBool = AtomicBool::new(false);
 
 /// Transaction should be accepted?
 static TRANSACTIONS_ENABLED: AtomicBool = AtomicBool::new(true);
-
-/// Miner should mine new blocks?
-static MINER_ENABLED: AtomicBool = AtomicBool::new(true);
 
 /// Unknown clients can interact with the application?
 static UNKNOWN_CLIENT_ENABLED: AtomicBool = AtomicBool::new(true);
@@ -209,16 +207,6 @@ impl GlobalState {
     // Miner
     // -------------------------------------------------------------------------
 
-    /// Enables or disables the miner.
-    pub fn set_miner_enabled(enabled: bool) {
-        MINER_ENABLED.store(enabled, Ordering::Relaxed);
-    }
-
-    /// Checks if the miner is enabled.
-    pub fn is_miner_enabled() -> bool {
-        MINER_ENABLED.load(Ordering::Relaxed)
-    }
-
     /// Shutdown the miner.
     ///
     /// Returns the formatted reason for miner shutdown.
@@ -305,14 +293,14 @@ impl GlobalState {
     // JSON State
     // -------------------------------------------------------------------------
 
-    pub fn get_global_state_as_json() -> JsonValue {
+    pub fn get_global_state_as_json(ctx: &RpcContext) -> JsonValue {
         json!({
             "is_leader": Self::is_leader(),
             "is_shutdown": Self::is_shutdown(),
             "is_importer_shutdown": Self::is_importer_shutdown(),
             "is_interval_miner_shutdown": Self::is_interval_miner_shutdown(),
             "transactions_enabled": Self::is_transactions_enabled(),
-            "miner_enabled": Self::is_miner_enabled(),
+            "miner_enabled": ctx.miner.is_enabled(),
             "unknown_client_enabled": Self::is_unknown_client_enabled(),
         })
     }


### PR DESCRIPTION
### **User description**
Also move things from Miner to Storage.
Also, simplify interface.
Also, make some functions not fail.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Refactored miner control from global state to Miner struct methods
- Enhanced Miner struct with new control methods (enable, disable, set_mode)
- Simplified miner mode access and change logic in RPC server
- Improved error handling in miner and storage initialization
- Removed unnecessary global state for miner control
- Updated various components to use new miner control methods
- Minor improvements in error logging and test initialization


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>executor.rs</strong><dd><code>Simplify miner mode access in executor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/executor/executor.rs

<li>Simplified miner mode access by replacing read lock with a direct <br>method call<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1703/files#diff-6b460d7dee8280c0287e8d9d9d59cf66a57ec9fed1bc003c6ede6fef60c7376b">+1/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>miner.rs</strong><dd><code>Enhance Miner struct with new control methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/miner/miner.rs

<li>Added <code>is_enabled</code> flag to Miner struct<br> <li> Implemented methods for enabling/disabling miner and accessing/setting <br>miner mode<br> <li> Modified <code>spawn_interval_miner</code> to <code>start_if_interval</code> with improved error <br>handling<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1703/files#diff-16f448afc7dae3e8e802f676a86dbd7051e19f6c17cbbeb53eb730d726372629">+46/-14</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>miner_config.rs</strong><dd><code>Refactor miner configuration initialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/miner/miner_config.rs

<li>Modified <code>init</code> method to handle follower mode configuration<br> <li> Simplified <code>init_with_mode</code> by removing genesis block creation and block <br>number setting<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1703/files#diff-ea3a8597b909e696993f7e791ab04e5ad784da8077b87088d9c78c804e1ef69d">+9/-19</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rpc_server.rs</strong><dd><code>Refactor RPC server to use direct miner control</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/rpc/rpc_server.rs

<li>Replaced global state miner control with direct miner method calls<br> <li> Simplified miner mode change logic<br> <li> Updated RPC methods to use new miner control methods<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1703/files#diff-835ba255c9a5c1fe0e13285bc39e058e1c74422e5e03ebba483c9d8a15c45405">+26/-48</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rpc_subscriptions.rs</strong><dd><code>Improve error logging in RPC subscriptions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/rpc/rpc_subscriptions.rs

- Modified error logging to use `format!()` macro



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1703/files#diff-a07ba1157cec6586a0520b8dfb11e9d073359af24471ac286ff5eaa2669d355c">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>stratus_storage.rs</strong><dd><code>Enhance StratusStorage initialization process</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/stratus_storage.rs

<li>Modified <code>new</code> method to handle initialization tasks and return Result<br> <li> Updated <code>init</code> method in StratusStorageConfig to handle potential errors<br> <br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1703/files#diff-3b2e36e47959decdfe26b2c4fab90b41f9242bfdad29cc43b2377ee851f4f40a">+16/-3</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>globals.rs</strong><dd><code>Remove global miner state and simplify GlobalState</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/globals.rs

<li>Removed <code>MINER_ENABLED</code> global state<br> <li> Simplified <code>GlobalState</code> struct<br> <li> Updated <code>get_global_state_as_json</code> to use miner methods directly<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1703/files#diff-48d6fbc3a4ed67100952dcccfada858623c931e73d6de32984d4d1457e68d3a9">+12/-34</a>&nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>log_filter.rs</strong><dd><code>Update StratusStorage initialization in tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/log_filter.rs

<li>Updated StratusStorage initialization in test function to handle <br>potential errors<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1703/files#diff-8a77d8af3c5d907f1763771a0823aa4cab0b90e55eb6b7b173943381b7388ff8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

