### PR TITLE
chore: remove misleading lock var name

### DIFF
--- a/src/eth/executor/executor.rs
+++ b/src/eth/executor/executor.rs
@@ -396,9 +396,7 @@ impl Executor {
                 // WORKAROUND: prevents interval miner mining blocks while a transaction is being executed.
                 // this can be removed when we implement conflict detection for block number
                 let _miner_lock = {
-                    let mode_lock = self.miner.mode();
-
-                    if mode_lock.is_interval() {
+                    if self.miner.mode().is_interval() {
                         let miner_lock = Some(self.miner.locks.mine_and_commit.lock_or_clear("miner mine_and_commit lock was poisoned"));
                         miner_lock
                     } else {


### PR DESCRIPTION
### **User description**
this var is not a lock anymore, but I left the `lock` suffix in the var name


___

### **PR Type**
Enhancement


___

### **Description**
- Simplified the logic for acquiring the miner lock in the `Executor` implementation
- Removed the redundant `mode_lock` variable, directly using `self.miner.mode()` in the condition
- Reduced code nesting, improving readability
- This change maintains the same functionality while making the code more concise and easier to understand


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>executor.rs</strong><dd><code>Simplify miner lock acquisition logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/executor/executor.rs

<li>Removed unnecessary <code>mode_lock</code> variable<br> <li> Simplified the condition for acquiring the miner lock<br> <li> Improved code readability by reducing nesting<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1704/files#diff-6b460d7dee8280c0287e8d9d9d59cf66a57ec9fed1bc003c6ede6fef60c7376b">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

