### PR TITLE
enha: follower to leader change reversible

### DIFF
--- a/src/eth/primitives/stratus_error.rs
+++ b/src/eth/primitives/stratus_error.rs
@@ -158,6 +158,10 @@ pub enum StratusError {
     #[strum(props(kind = "client_request"))]
     ImporterConfigParseError,
 
+    #[error("Importer configuration not found in app_config.")]
+    #[strum(props(kind = "client_request"))]
+    ImporterConfigNotFound,
+
     #[error("Failed to initialize importer.")]
     #[strum(props(kind = "internal"))]
     ImporterInitError,


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Improved error handling in the process of changing a node from follower to leader:
  - Added new `ImporterConfigNotFound` error for cases where importer configuration is missing
  - Implemented parsing and error handling for current importer configuration
- Enhanced rollback mechanism:
  - On failure to change miner mode, the system now reverts to the previous state
  - Restarts the importer with the current configuration if errors occur during the process
- Improved logging throughout the function for better debugging and monitoring
- Overall, these changes make the follower-to-leader transition more robust and reversible


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>stratus_error.rs</strong><dd><code>Add new error variant for missing importer config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/stratus_error.rs

<li>Added new error variant <code>ImporterConfigNotFound</code> to <code>StratusError</code> enum<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1705/files#diff-301cded01d772388e3e5c08ede093b91c3e4478c08e11a48f70e3d44351385fb">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rpc_server.rs</strong><dd><code>Enhance error handling and rollback in leader change process</code></dd></summary>
<hr>

src/eth/rpc/rpc_server.rs

<li>Added error handling for parsing current importer configuration<br> <li> Implemented rollback mechanism for failed miner mode change<br> <li> Added logic to restart importer with current configuration on failure<br> <li> Improved error logging and handling throughout the function<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1705/files#diff-835ba255c9a5c1fe0e13285bc39e058e1c74422e5e03ebba483c9d8a15c45405">+26/-2</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

