### PR TITLE
Revert "enha: follower to leader change reversible"

### DIFF
--- a/src/eth/primitives/stratus_error.rs
+++ b/src/eth/primitives/stratus_error.rs
@@ -158,10 +158,6 @@ pub enum StratusError {
     #[strum(props(kind = "client_request"))]
     ImporterConfigParseError,
 
-    #[error("Importer configuration not found in app_config.")]
-    #[strum(props(kind = "client_request"))]
-    ImporterConfigNotFound,
-
     #[error("Failed to initialize importer.")]
     #[strum(props(kind = "internal"))]
     ImporterInitError,

--- a/src/eth/rpc/rpc_server.rs
+++ b/src/eth/rpc/rpc_server.rs
@@ -318,20 +318,6 @@ async fn stratus_change_to_leader(_: Params<'_>, ctx: Arc<RpcContext>, ext: Exte
         return Err(StratusError::RpcTransactionEnabled);
     }
 
-    let current_importer_config: ImporterConfig = match ctx.app_config.get("importer") {
-        Some(importer_value) => match serde_json::from_value(importer_value.clone()) {
-            Ok(config) => config,
-            Err(e) => {
-                tracing::error!(reason = ?e, "failed to parse current importer configuration");
-                return Err(StratusError::ImporterConfigParseError);
-            }
-        },
-        None => {
-            tracing::error!("current importer configuration not found in app_config");
-            return Err(StratusError::ImporterConfigNotFound);
-        }
-    };
-
     tracing::info!("shutting down importer");
     let shutdown_importer_result = stratus_shutdown_importer(Params::new(None), &ctx, &ext);
     match shutdown_importer_result {
@@ -340,8 +326,7 @@ async fn stratus_change_to_leader(_: Params<'_>, ctx: Arc<RpcContext>, ext: Exte
             tracing::warn!("importer is already shutdown, continuing");
         }
         Err(e) => {
-            tracing::error!(reason = ?e, "failed to shutdown importer. Restarting importer with current configuration");
-            current_importer_config.init_follower_importer(ctx).await?;
+            tracing::error!(reason = ?e, "failed to shutdown importer");
             return Err(e);
         }
     }
@@ -353,16 +338,7 @@ async fn stratus_change_to_leader(_: Params<'_>, ctx: Arc<RpcContext>, ext: Exte
 
     let change_miner_mode_result = change_miner_mode(MinerMode::Interval(LEADER_MINER_INTERVAL), &ctx);
     if let Err(e) = change_miner_mode_result {
-        tracing::error!(reason = ?e, "failed to change miner mode to interval(1s). Reverting miner mode to external");
-        let change_miner_mode_result = change_miner_mode(MinerMode::External, &ctx);
-        if let Err(e) = change_miner_mode_result {
-            tracing::error!(reason = ?e, "failed to revert miner mode to external");
-            return Err(e);
-        }
-        tracing::info!("wait for miner mode to revert to external");
-        traced_sleep(WAIT_DELAY, SleepReason::SyncData).await;
-        tracing::info!("reinitializing importer with current configuration");
-        current_importer_config.init_follower_importer(ctx).await?;
+        tracing::error!(reason = ?e, "failed to change miner mode");
         return Err(e);
     }
     tracing::info!("miner mode changed to interval(1s) successfully");


### PR DESCRIPTION
### **User description**
Reverts cloudwalk/stratus#1705


___

### **PR Type**
Enhancement


___

### **Description**
This PR reverts changes made in a previous commit (cloudwalk/stratus#1705) related to making the follower to leader change reversible. The main changes include:

- Removed `ImporterConfigNotFound` error variant from `StratusError` enum
- Simplified the `stratus_change_to_leader` function by removing:
  - Importer configuration parsing and handling
  - Rollback logic for miner mode changes
  - Importer reinitialization in case of errors
- Streamlined error handling in the leader change process
- Removed the ability to revert changes if errors occur during the leader change process

These changes simplify the code and remove the reversibility feature, potentially making the leader change process more straightforward but less fault-tolerant.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>stratus_error.rs</strong><dd><code>Remove ImporterConfigNotFound error</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/stratus_error.rs

<li>Removed <code>ImporterConfigNotFound</code> error variant from <code>StratusError</code> enum<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1706/files#diff-301cded01d772388e3e5c08ede093b91c3e4478c08e11a48f70e3d44351385fb">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rpc_server.rs</strong><dd><code>Simplify leader change process</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/rpc/rpc_server.rs

<li>Removed code for parsing and handling importer configuration<br> <li> Simplified error handling in <code>stratus_change_to_leader</code> function<br> <li> Removed rollback logic for miner mode changes and importer <br>reinitialization<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1706/files#diff-835ba255c9a5c1fe0e13285bc39e058e1c74422e5e03ebba483c9d8a15c45405">+2/-26</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

