### PR TITLE
refac: make miner shutdown awaitable

### DIFF
--- a/e2e/cloudwalk-contracts/integration/test/leader-follower-change.test.ts
+++ b/e2e/cloudwalk-contracts/integration/test/leader-follower-change.test.ts
@@ -30,10 +30,10 @@ describe("Leader & Follower change integration test", function () {
         expect(followerHealth).to.equal(true);
     });
 
-    it("Change Leader to Leader should fail", async function () {
+    it("Change Leader to Leader should return false", async function () {
         updateProviderUrl("stratus");
         const response = await sendAndGetFullResponse("stratus_changeToLeader", []);
-        expect(response.data.result).to.equal(true);
+        expect(response.data.result).to.equal(false);
     });
 
     it("Change Leader to Follower with transactions enabled should fail", async function () {
@@ -71,7 +71,7 @@ describe("Leader & Follower change integration test", function () {
     it("Change Follower to Follower should fail", async function () {
         updateProviderUrl("stratus-follower");
         const response = await sendAndGetFullResponse("stratus_changeToFollower", []);
-        expect(response.data.result).to.equal(true);
+        expect(response.data.result).to.equal(false);
     });
 
     it("Change Follower to Leader with transactions enabled should fail", async function () {

--- a/e2e/cloudwalk-contracts/integration/test/leader-follower-miner.test.ts
+++ b/e2e/cloudwalk-contracts/integration/test/leader-follower-miner.test.ts
@@ -14,7 +14,7 @@ describe("Miner mode change integration test", function () {
         updateProviderUrl("stratus");
         const leaderNode = await sendWithRetry("stratus_state", []);
         expect(leaderNode.is_leader).to.equal(true);
-        expect(leaderNode.miner_enabled).to.equal(true);
+        expect(leaderNode.miner_paused).to.equal(false);
         expect(leaderNode.is_interval_miner_running).to.equal(true);
         expect(leaderNode.transactions_enabled).to.equal(true);
         const leaderHealth = await sendWithRetry("stratus_health", []);
@@ -25,7 +25,7 @@ describe("Miner mode change integration test", function () {
         updateProviderUrl("stratus-follower");
         const followerNode = await sendWithRetry("stratus_state", []);
         expect(followerNode.is_leader).to.equal(false);
-        expect(followerNode.miner_enabled).to.equal(true);
+        expect(followerNode.miner_paused).to.equal(false);
         expect(followerNode.is_interval_miner_running).to.equal(false);
         expect(followerNode.transactions_enabled).to.equal(true);
         const followerHealth = await sendWithRetry("stratus_health", []);
@@ -69,11 +69,11 @@ describe("Miner mode change integration test", function () {
         expect(response.data.error.message).eq("Miner is enabled.");
     });
 
-    it("Miner change to Interval on Follower should fail because miner is enabled", async function () {
+    it("Miner change to Interval on Follower should fail because importer wasn't stopped", async function () {
         updateProviderUrl("stratus-follower");
         const response = await sendAndGetFullResponse("stratus_changeMinerMode", ["1s"]);
         expect(response.data.error.code).eq(-32603);
-        expect(response.data.error.message).eq("Miner is enabled.");
+        expect(response.data.error.message).eq("Consensus is set.");
     });
 
     it("Disable miner on Leader", async function () {
@@ -81,7 +81,7 @@ describe("Miner mode change integration test", function () {
         const response = await sendAndGetFullResponse("stratus_disableMiner", []);
         expect(response.data.result).to.equal(false);
         const state = await sendWithRetry("stratus_state", []);
-        expect(state.miner_enabled).to.equal(false);
+        expect(state.miner_paused).to.equal(true);
     });
 
     it("Disable miner on Follower", async function () {
@@ -89,7 +89,7 @@ describe("Miner mode change integration test", function () {
         const response = await sendAndGetFullResponse("stratus_disableMiner", []);
         expect(response.data.result).to.equal(false);
         const state = await sendWithRetry("stratus_state", []);
-        expect(state.miner_enabled).to.equal(false);
+        expect(state.miner_paused).to.equal(true);
     });
 
     it("Miner change on Leader without params should fail", async function () {
@@ -134,7 +134,7 @@ describe("Miner mode change integration test", function () {
         expect(disableMinerResponse.data.result).to.equal(false);
         const leaderState = await sendWithRetry("stratus_state", []);
         expect(leaderState.transactions_enabled).to.equal(true);
-        expect(leaderState.miner_enabled).to.equal(false);
+        expect(leaderState.miner_paused).to.equal(true);
 
         // Enable Transactions on Follower
         updateProviderUrl("stratus-follower");
@@ -175,7 +175,7 @@ describe("Miner mode change integration test", function () {
 
         const leaderStateAfterCleanup = await sendWithRetry("stratus_state", []);
         expect(leaderStateAfterCleanup.transactions_enabled).to.equal(true);
-        expect(leaderStateAfterCleanup.miner_enabled).to.equal(true);
+        expect(leaderStateAfterCleanup.miner_paused).to.equal(false);
 
         await waitForFollowerToSyncWithLeader();
 

--- a/e2e/cloudwalk-contracts/integration/test/leader-follower-miner.test.ts
+++ b/e2e/cloudwalk-contracts/integration/test/leader-follower-miner.test.ts
@@ -15,7 +15,7 @@ describe("Miner mode change integration test", function () {
         const leaderNode = await sendWithRetry("stratus_state", []);
         expect(leaderNode.is_leader).to.equal(true);
         expect(leaderNode.miner_enabled).to.equal(true);
-        expect(leaderNode.is_interval_miner_shutdown).to.equal(false);
+        expect(leaderNode.is_interval_miner_running).to.equal(true);
         expect(leaderNode.transactions_enabled).to.equal(true);
         const leaderHealth = await sendWithRetry("stratus_health", []);
         expect(leaderHealth).to.equal(true);
@@ -26,7 +26,7 @@ describe("Miner mode change integration test", function () {
         const followerNode = await sendWithRetry("stratus_state", []);
         expect(followerNode.is_leader).to.equal(false);
         expect(followerNode.miner_enabled).to.equal(true);
-        expect(followerNode.is_interval_miner_shutdown).to.equal(true);
+        expect(followerNode.is_interval_miner_running).to.equal(false);
         expect(followerNode.transactions_enabled).to.equal(true);
         const followerHealth = await sendWithRetry("stratus_health", []);
         expect(followerHealth).to.equal(true);
@@ -197,7 +197,7 @@ describe("Miner mode change integration test", function () {
         const response = await sendAndGetFullResponse("stratus_changeMinerMode", ["external"]);
         expect(response.data.result).to.equal(true);
         const state = await sendWithRetry("stratus_state", []);
-        expect(state.is_interval_miner_shutdown).to.equal(true);
+        expect(state.is_interval_miner_running).to.equal(false);
     });
 
     it("Shutdown importer on Follower", async function () {
@@ -213,7 +213,7 @@ describe("Miner mode change integration test", function () {
         const response = await sendAndGetFullResponse("stratus_changeMinerMode", ["1s"]);
         expect(response.data.result).to.equal(true);
         const state = await sendWithRetry("stratus_state", []);
-        expect(state.is_interval_miner_shutdown).to.equal(false);
+        expect(state.is_interval_miner_running).to.equal(true);
         expect(state.is_importer_shutdown).to.equal(true);
     });
 

--- a/src/bin/importer_offline.rs
+++ b/src/bin/importer_offline.rs
@@ -55,7 +55,7 @@ async fn run(config: ImporterOfflineConfig) -> anyhow::Result<()> {
     // init services
     let rpc_storage = config.rpc_storage.init().await?;
     let storage = config.storage.init()?;
-    let miner = config.miner.init_with_mode(MinerMode::External, Arc::clone(&storage))?;
+    let miner = config.miner.init_with_mode(MinerMode::External, Arc::clone(&storage)).await?;
     let executor = config.executor.init(Arc::clone(&storage), Arc::clone(&miner));
 
     // init block range

--- a/src/eth/miner/miner.rs
+++ b/src/eth/miner/miner.rs
@@ -105,8 +105,8 @@ impl Miner {
     ///
     /// Also unpauses `Miner` if it was paused.
     pub async fn start_interval_mining(self: &Arc<Self>, block_time: Duration) {
-        if self.mode().is_interval() {
-            tracing::warn!(block_time = ?block_time.to_string_ext(), "trying to start interval mining, but it's already started, skipping");
+        if self.is_interval_miner_running() {
+            tracing::warn!(block_time = ?block_time.to_string_ext(), "tried to start interval mining, but it's already running, skipping");
             return;
         };
 

--- a/src/eth/miner/miner.rs
+++ b/src/eth/miner/miner.rs
@@ -88,19 +88,9 @@ impl Miner {
 
     /// Spawns a new thread that keep mining blocks in the specified interval.
     pub fn start_if_interval(self: &Arc<Self>) -> anyhow::Result<()> {
-        let block_time = {
-            let mode_lock = self.mode.read().map_err(|_| {
-                tracing::error!("miner mode read lock was poisoned");
-                self.mode.clear_poison();
-                StratusError::MinerModeLockFailed
-            })?;
-
-            let MinerMode::Interval(block_time) = *mode_lock else {
-                // Don't do anything
-                return Ok(());
-            };
-
-            block_time
+        let MinerMode::Interval(block_time) = self.mode() else {
+            // Don't do anything
+            return Ok(());
         };
 
         tracing::info!(block_time = %block_time.to_string_ext(), "spawning interval miner");
@@ -150,14 +140,7 @@ impl Miner {
         let _span = info_span!("miner::save_execution", %tx_hash).entered();
 
         // Check if automine is enabled
-        let is_automine = {
-            let mode_lock = self.mode.read().map_err(|_| {
-                tracing::error!("miner mode read lock was poisoned");
-                self.mode.clear_poison();
-                StratusError::MinerModeLockFailed
-            })?;
-            mode_lock.is_automine()
-        };
+        let is_automine = self.mode().is_automine();
 
         // if automine is enabled, only one transaction can enter the block at a time.
         let _save_execution_lock = if is_automine {

--- a/src/eth/miner/miner.rs
+++ b/src/eth/miner/miner.rs
@@ -129,14 +129,17 @@ impl Miner {
         Ok(())
     }
 
+    // Unpause interval miner (if in interval mode)
     pub fn unpause(&self) {
         self.is_paused.store(false, Ordering::Relaxed);
     }
 
+    // Pause interval miner (if in interval mode)
     pub fn pause(&self) {
         self.is_paused.store(true, Ordering::Relaxed);
     }
 
+    // Whether or not interval miner is paused (means nothing if not in interval mode)
     pub fn is_paused(&self) -> bool {
         self.is_paused.load(Ordering::Relaxed)
     }

--- a/src/eth/miner/miner_config.rs
+++ b/src/eth/miner/miner_config.rs
@@ -31,7 +31,7 @@ impl MinerConfig {
         let mode = match GlobalState::get_node_mode() {
             NodeMode::Follower => {
                 if not(self.block_mode.is_external()) {
-                    tracing::warn!(block_mode = ?self.block_mode, "ignoring block-mode, follower miner can only start as external");
+                    tracing::error!(block_mode = ?self.block_mode, "invalid block-mode, a follower's miner can only start as external!");
                 }
                 MinerMode::External
             }

--- a/src/eth/miner/miner_config.rs
+++ b/src/eth/miner/miner_config.rs
@@ -25,7 +25,7 @@ pub struct MinerConfig {
 
 impl MinerConfig {
     /// Inits [`Miner`] with the appropriate mining mode based on the node mode.
-    pub fn init(&self, storage: Arc<StratusStorage>) -> anyhow::Result<Arc<Miner>> {
+    pub async fn init(&self, storage: Arc<StratusStorage>) -> anyhow::Result<Arc<Miner>> {
         tracing::info!(config = ?self, "creating block miner");
 
         let mode = match GlobalState::get_node_mode() {
@@ -38,17 +38,17 @@ impl MinerConfig {
             NodeMode::Leader => self.block_mode,
         };
 
-        self.init_with_mode(mode, storage)
+        self.init_with_mode(mode, storage).await
     }
 
     /// Inits [`Miner`] with a specific mining mode, regardless of node mode.
-    pub fn init_with_mode(&self, mode: MinerMode, storage: Arc<StratusStorage>) -> anyhow::Result<Arc<Miner>> {
+    pub async fn init_with_mode(&self, mode: MinerMode, storage: Arc<StratusStorage>) -> anyhow::Result<Arc<Miner>> {
         tracing::info!(config = ?self, mode = ?mode, "creating block miner with specific mode");
 
         // create miner
         let miner = Miner::new(Arc::clone(&storage), mode);
         let miner = Arc::new(miner);
-        miner.start_if_interval()?;
+        miner.start_if_interval().await?;
 
         Ok(miner)
     }

--- a/src/eth/miner/miner_config.rs
+++ b/src/eth/miner/miner_config.rs
@@ -48,7 +48,10 @@ impl MinerConfig {
         // create miner
         let miner = Miner::new(Arc::clone(&storage), mode);
         let miner = Arc::new(miner);
-        miner.start_if_interval().await?;
+
+        if let MinerMode::Interval(block_time) = mode {
+            miner.start_interval_mining(block_time).await;
+        }
 
         Ok(miner)
     }

--- a/src/eth/rpc/rpc_server.rs
+++ b/src/eth/rpc/rpc_server.rs
@@ -310,7 +310,7 @@ async fn stratus_change_to_leader(_: Params<'_>, ctx: Arc<RpcContext>, ext: Exte
 
     if GlobalState::get_node_mode() == NodeMode::Leader {
         tracing::info!("node is already in leader mode, no changes made");
-        return Ok(json!(true));
+        return Ok(json!(false));
     }
 
     if GlobalState::is_transactions_enabled() {
@@ -355,7 +355,7 @@ async fn stratus_change_to_follower(params: Params<'_>, ctx: Arc<RpcContext>, ex
 
     if GlobalState::get_node_mode() == NodeMode::Follower {
         tracing::info!("node is already in follower mode, no changes made");
-        return Ok(json!(true));
+        return Ok(json!(false));
     }
 
     if GlobalState::is_transactions_enabled() {

--- a/src/eth/rpc/rpc_server.rs
+++ b/src/eth/rpc/rpc_server.rs
@@ -504,9 +504,7 @@ async fn change_miner_mode(new_mode: MinerMode, ctx: &RpcContext) -> Result<Json
                 });
             }
 
-            ctx.miner.set_mode(MinerMode::External);
-            tracing::warn!("shutting down Interval miner to change it to External mode");
-            ctx.miner.shutdown_and_wait().await;
+            ctx.miner.switch_to_external_mode().await;
         }
         MinerMode::Interval(duration) => {
             tracing::info!(duration = ?duration, "changing miner mode to Interval");
@@ -523,8 +521,7 @@ async fn change_miner_mode(new_mode: MinerMode, ctx: &RpcContext) -> Result<Json
                 }
             }
 
-            ctx.miner.set_mode(MinerMode::Interval(duration));
-            ctx.miner.start_if_interval().await?;
+            ctx.miner.start_interval_mining(duration).await;
         }
         MinerMode::Automine => {
             tracing::error!("automine mode is not supported");

--- a/src/eth/rpc/rpc_server.rs
+++ b/src/eth/rpc/rpc_server.rs
@@ -372,6 +372,9 @@ async fn stratus_change_to_follower(params: Params<'_>, ctx: Arc<RpcContext>, ex
         });
     }
 
+    // pause miner so that `change_miner_mode` doesn't fail
+    ctx.miner.pause();
+
     let change_miner_mode_result = change_miner_mode(MinerMode::External, &ctx).await;
     if let Err(e) = change_miner_mode_result {
         tracing::error!(reason = ?e, "failed to change miner mode");

--- a/src/globals.rs
+++ b/src/globals.rs
@@ -263,7 +263,7 @@ impl GlobalState {
             "is_importer_shutdown": Self::is_importer_shutdown(),
             "is_interval_miner_running": ctx.miner.is_interval_miner_running(),
             "transactions_enabled": Self::is_transactions_enabled(),
-            "miner_enabled": ctx.miner.is_enabled(),
+            "miner_paused": ctx.miner.is_paused(),
             "unknown_client_enabled": Self::is_unknown_client_enabled(),
         })
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ async fn run(config: StratusConfig) -> anyhow::Result<()> {
     let storage = config.storage.init()?;
 
     // Init miner
-    let miner = config.miner.init(Arc::clone(&storage))?;
+    let miner = config.miner.init(Arc::clone(&storage)).await?;
 
     // Init executor
     let executor = config.executor.init(Arc::clone(&storage), Arc::clone(&miner));


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Refactored the Miner struct and related components to support asynchronous shutdown and more robust interval mining:
  - Implemented new methods like start_interval_mining, switch_to_external_mode, and shutdown_and_wait
  - Changed is_enabled to is_paused for better clarity
  - Added interval_joinset for managing interval mining tasks
- Updated MinerConfig to support async initialization
- Refactored RPC server to handle async miner mode changes
- Simplified global state management by removing INTERVAL_MINER_SHUTDOWN and renaming STRATUS_SHUTDOWN
- Fixed various bugs related to miner mode changes and shutdown processes
- Updated integration tests to reflect new miner state checks


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>miner.rs</strong><dd><code>Refactor Miner for async shutdown and interval mining</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/miner/miner.rs

<li>Refactored Miner struct to support async shutdown<br> <li> Added interval_joinset for managing interval mining tasks<br> <li> Implemented start_interval_mining, switch_to_external_mode, and <br>shutdown_and_wait methods<br> <li> Changed is_enabled to is_paused for clarity<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1707/files#diff-16f448afc7dae3e8e802f676a86dbd7051e19f6c17cbbeb53eb730d726372629">+113/-66</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>miner_config.rs</strong><dd><code>Update MinerConfig for async initialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/miner/miner_config.rs

<li>Made init and init_with_mode methods async<br> <li> Updated to use new start_interval_mining method<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1707/files#diff-ea3a8597b909e696993f7e791ab04e5ad784da8077b87088d9c78c804e1ef69d">+8/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rpc_server.rs</strong><dd><code>Refactor RPC server for async miner mode changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/rpc/rpc_server.rs

<li>Made stratus_change_miner_mode method async<br> <li> Updated change_miner_mode to use new Miner methods<br> <li> Fixed logic for changing miner modes<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1707/files#diff-835ba255c9a5c1fe0e13285bc39e058e1c74422e5e03ebba483c9d8a15c45405">+19/-26</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>globals.rs</strong><dd><code>Simplify global state and shutdown mechanism</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/globals.rs

<li>Removed INTERVAL_MINER_SHUTDOWN global state<br> <li> Renamed STRATUS_SHUTDOWN to STRATUS_SHUTDOWN_SIGNAL<br> <li> Updated related methods to use new shutdown mechanism<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1707/files#diff-48d6fbc3a4ed67100952dcccfada858623c931e73d6de32984d4d1457e68d3a9">+6/-43</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>leader-follower-miner.test.ts</strong><dd><code>Update integration tests for new miner state</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

e2e/cloudwalk-contracts/integration/test/leader-follower-miner.test.ts

<li>Updated tests to check for is_interval_miner_running instead of <br>is_interval_miner_shutdown<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1707/files#diff-4b1c5fc9f33c8088178dffe2234e70df03667bf90fa3a5663fd17c3dabfe13a5">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

