### PR TITLE
enha: add block sync check

### DIFF
--- a/e2e/cloudwalk-contracts/integration/test/leader-follower-change.test.ts
+++ b/e2e/cloudwalk-contracts/integration/test/leader-follower-change.test.ts
@@ -48,9 +48,22 @@ describe("Leader & Follower change integration test", function () {
         expect(response.data.error.message).to.equal("Transaction processing is enabled.");
     });
 
-    it("Change Leader to Follower should succeed", async function () {
+    it("Change Leader to Follower should fail with miner enabled", async function () {
         updateProviderUrl("stratus");
         await sendWithRetry("stratus_disableTransactions", []);
+        const response = await sendAndGetFullResponse("stratus_changeToFollower", [
+            "http://0.0.0.0:3001/",
+            "ws://0.0.0.0:3001/",
+            "2s",
+            "100ms",
+        ]);
+        expect(response.data.result).to.equal(true);
+    });
+
+    it("Change Leader to Follower should succeed", async function () {
+        updateProviderUrl("stratus");
+        await sendWithRetry("stratus_disableMiner", []);
+        await new Promise((resolve) => setTimeout(resolve, 10000));
         const response = await sendAndGetFullResponse("stratus_changeToFollower", [
             "http://0.0.0.0:3001/",
             "ws://0.0.0.0:3001/",

--- a/e2e/cloudwalk-contracts/integration/test/leader-follower-change.test.ts
+++ b/e2e/cloudwalk-contracts/integration/test/leader-follower-change.test.ts
@@ -48,7 +48,7 @@ describe("Leader & Follower change integration test", function () {
         expect(response.data.error.message).to.equal("Transaction processing is enabled.");
     });
 
-    it("Change Leader to Follower should fail with miner enabled", async function () {
+    it("Change Leader to Follower with miner enabled should fail ", async function () {
         updateProviderUrl("stratus");
         await sendWithRetry("stratus_disableTransactions", []);
         const response = await sendAndGetFullResponse("stratus_changeToFollower", [
@@ -57,7 +57,8 @@ describe("Leader & Follower change integration test", function () {
             "2s",
             "100ms",
         ]);
-        expect(response.data.result).to.equal(true);
+        expect(response.data.error.code).to.equal(-32603);
+        expect(response.data.error.message).to.equal("Miner is enabled.");
     });
 
     it("Change Leader to Follower should succeed", async function () {

--- a/src/eth/rpc/rpc_server.rs
+++ b/src/eth/rpc/rpc_server.rs
@@ -373,9 +373,6 @@ async fn stratus_change_to_follower(params: Params<'_>, ctx: Arc<RpcContext>, ex
         return Err(StratusError::MinerEnabled);
     }
 
-    // pause miner so that `change_miner_mode` doesn't fail
-    ctx.miner.pause();
-
     let change_miner_mode_result = change_miner_mode(MinerMode::External, &ctx).await;
     if let Err(e) = change_miner_mode_result {
         tracing::error!(reason = ?e, "failed to change miner mode");

--- a/src/eth/rpc/rpc_server.rs
+++ b/src/eth/rpc/rpc_server.rs
@@ -348,7 +348,6 @@ async fn stratus_change_to_leader(_: Params<'_>, ctx: Arc<RpcContext>, ext: Exte
 }
 
 async fn stratus_change_to_follower(params: Params<'_>, ctx: Arc<RpcContext>, ext: Extensions) -> Result<JsonValue, StratusError> {
-    const WAIT_DELAY: Duration = Duration::from_secs(5);
     tracing::info!("starting process to change node to follower");
 
     if GlobalState::get_node_mode() == NodeMode::Follower {
@@ -361,15 +360,17 @@ async fn stratus_change_to_follower(params: Params<'_>, ctx: Arc<RpcContext>, ex
         return Err(StratusError::RpcTransactionEnabled);
     }
 
-    tracing::info!("wait for pending transactions to be mined");
-    traced_sleep(WAIT_DELAY, SleepReason::SyncData).await;
-
     let pending_txs = ctx.storage.pending_transactions();
     if not(pending_txs.is_empty()) {
         tracing::error!(pending_txs = ?pending_txs.len(), "cannot change to follower mode with pending transactions");
         return Err(StratusError::PendingTransactionsExist {
             pending_txs: pending_txs.len(),
         });
+    }
+
+    if not(ctx.miner.is_paused()) {
+        tracing::error!("miner is currently not paused, cannot change node mode");
+        return Err(StratusError::MinerEnabled);
     }
 
     // pause miner so that `change_miner_mode` doesn't fail
@@ -380,9 +381,6 @@ async fn stratus_change_to_follower(params: Params<'_>, ctx: Arc<RpcContext>, ex
         tracing::error!(reason = ?e, "failed to change miner mode");
         return Err(e);
     }
-
-    tracing::info!("wait for miner mode to change to external");
-    traced_sleep(WAIT_DELAY, SleepReason::SyncData).await;
     tracing::info!("miner mode changed to external successfully");
 
     GlobalState::set_node_mode(NodeMode::Follower);

--- a/utils/deploy.sh
+++ b/utils/deploy.sh
@@ -13,7 +13,7 @@ SYNC_INTERVAL="100ms"
 
 # Pending Transactions total check attempts, required consecutive checks and sleep interval
 TOTAL_CHECK_ATTEMPTS=10
-REQUIRED_CONSECUTIVE_CHECKS=4
+REQUIRED_CONSECUTIVE_CHECKS=3
 SLEEP_INTERVAL=0.5
 
 # Define colors

--- a/utils/deploy.sh
+++ b/utils/deploy.sh
@@ -11,7 +11,7 @@ FOLLOWER_ADDRESS="0.0.0.0:3001"
 EXTERNAL_RPC_TIMEOUT="2s"
 SYNC_INTERVAL="100ms"
 
-# Pending Transactions total check attempts, required consecutive checks and sleep interval
+# Pending Transactions and Miner total check attempts, required consecutive checks and sleep interval
 TOTAL_CHECK_ATTEMPTS=10
 REQUIRED_CONSECUTIVE_CHECKS=3
 SLEEP_INTERVAL=0.5

--- a/utils/deploy.sh
+++ b/utils/deploy.sh
@@ -177,7 +177,10 @@ for i in $(seq 1 $TOTAL_CHECK_ATTEMPTS); do
     leader_block_number_result=$(echo $leader_block_number | jq -r '.result')
     follower_block_number_result=$(echo $follower_block_number | jq -r '.result')
     
-    if [ "$leader_block_number_result" == "$follower_block_number_result" ] && [ "$leader_block_number_result" == "$previous_block_number" ]; then
+    if [ -z "$previous_block_number" ]; then
+        previous_block_number=$leader_block_number_result
+        log "First check, setting previous block number (Attempt $i)." "$LEADER_ADDRESS" "$follower_block_number"
+    elif [ "$leader_block_number_result" == "$follower_block_number_result" ] && [ "$leader_block_number_result" == "$previous_block_number" ]; then
         import_success_count=$((import_success_count + 1))
         log "Follower is in sync with the Leader (Attempt $i)." "$FOLLOWER_ADDRESS" "$follower_block_number"
     else


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Improved the process of changing a node from leader to follower mode:
  - Added a check to ensure the miner is paused before changing to follower mode
  - Removed unnecessary wait delays, making the transition more efficient
- Enhanced the deploy script with additional checks and safeguards:
  - Added logic to pause the miner on the leader node
  - Implemented a block synchronization check between leader and follower
- Updated integration tests to reflect new behavior:
  - Added a test case for changing to follower mode with miner enabled
  - Modified existing test to disable miner before changing to follower
- Improved error handling and logging throughout the changes


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rpc_server.rs</strong><dd><code>Improve follower mode transition logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/rpc/rpc_server.rs

<li>Removed wait delay for pending transactions<br> <li> Added check for miner pause before changing to follower mode<br> <li> Removed unnecessary sleep after changing miner mode<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1710/files#diff-835ba255c9a5c1fe0e13285bc39e058e1c74422e5e03ebba483c9d8a15c45405">+5/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>deploy.sh</strong><dd><code>Enhance deploy script with miner pause and sync checks</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

utils/deploy.sh

<li>Added logic to pause miner on leader node<br> <li> Implemented block synchronization check between leader and follower<br> <li> Added error handling and logging for new checks<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1710/files#diff-2aa8d59f723e2655e12c5f84050efa57222d0f4b4931f9176d2cf09bff13d017">+52/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>leader-follower-change.test.ts</strong><dd><code>Update leader-follower change tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

e2e/cloudwalk-contracts/integration/test/leader-follower-change.test.ts

<li>Added new test case for changing to follower with miner enabled<br> <li> Modified existing test to disable miner before changing to follower<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1710/files#diff-7236d4b676b75ced96eb321337290326efe4e91a261edc4e83b688c4da09dd7c">+15/-1</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

