### PR TITLE
enha: add more test coverage and script improvements

### DIFF
--- a/.github/workflows/e2e-leader-follower.yml
+++ b/.github/workflows/e2e-leader-follower.yml
@@ -80,7 +80,12 @@ jobs:
         run: just contracts-flatten --token
 
       - name: Run e2e tests
-        run: just e2e-leader-follower-up ${{ matrix.test }}
+        run: |
+          if [ "${{ matrix.test }}" == "deploy" ]; then
+            just e2e-leader-follower-up ${{ matrix.test }} --leader 0.0.0.0:3000 --follower 0.0.0.0:3001 --auto-approve
+          else
+            just e2e-leader-follower-up ${{ matrix.test }}
+          fi
         env:
           CARGO_PROFILE_RELEASE_DEBUG: 0
           RUST_LOG: error

--- a/.github/workflows/e2e-leader-follower.yml
+++ b/.github/workflows/e2e-leader-follower.yml
@@ -80,12 +80,7 @@ jobs:
         run: just contracts-flatten --token
 
       - name: Run e2e tests
-        run: |
-          if [ "${{ matrix.test }}" == "deploy" ]; then
-            just e2e-leader-follower-up ${{ matrix.test }} --leader 0.0.0.0:3000 --follower 0.0.0.0:3001 --auto-approve
-          else
-            just e2e-leader-follower-up ${{ matrix.test }}
-          fi
+        run: just e2e-leader-follower-up ${{ matrix.test }}
         env:
           CARGO_PROFILE_RELEASE_DEBUG: 0
           RUST_LOG: error

--- a/e2e/cloudwalk-contracts/integration/test/leader-follower-change.test.ts
+++ b/e2e/cloudwalk-contracts/integration/test/leader-follower-change.test.ts
@@ -15,8 +15,11 @@ describe("Leader & Follower change integration test", function () {
     it("Validate initial Leader state and health", async function () {
         updateProviderUrl("stratus");
         const leaderNode = await sendWithRetry("stratus_state", []);
-        expect(leaderNode.is_leader).to.equal(true);
         expect(leaderNode.is_importer_shutdown).to.equal(true);
+        expect(leaderNode.is_interval_miner_running).to.equal(true);
+        expect(leaderNode.is_leader).to.equal(true);
+        expect(leaderNode.miner_paused).to.equal(false);
+        expect(leaderNode.transactions_enabled).to.equal(true);
         const leaderHealth = await sendWithRetry("stratus_health", []);
         expect(leaderHealth).to.equal(true);
     });
@@ -24,8 +27,11 @@ describe("Leader & Follower change integration test", function () {
     it("Validate initial Follower state and health", async function () {
         updateProviderUrl("stratus-follower");
         const followerNode = await sendWithRetry("stratus_state", []);
-        expect(followerNode.is_leader).to.equal(false);
         expect(followerNode.is_importer_shutdown).to.equal(false);
+        expect(followerNode.is_interval_miner_running).to.equal(false);
+        expect(followerNode.is_leader).to.equal(false);
+        expect(followerNode.miner_paused).to.equal(false);
+        expect(followerNode.transactions_enabled).to.equal(true);
         const followerHealth = await sendWithRetry("stratus_health", []);
         expect(followerHealth).to.equal(true);
     });
@@ -64,7 +70,7 @@ describe("Leader & Follower change integration test", function () {
     it("Change Leader to Follower should succeed", async function () {
         updateProviderUrl("stratus");
         await sendWithRetry("stratus_disableMiner", []);
-        await new Promise((resolve) => setTimeout(resolve, 10000));
+        await new Promise((resolve) => setTimeout(resolve, 4000));
         const response = await sendAndGetFullResponse("stratus_changeToFollower", [
             "http://0.0.0.0:3001/",
             "ws://0.0.0.0:3001/",
@@ -74,11 +80,16 @@ describe("Leader & Follower change integration test", function () {
         expect(response.data.result).to.equal(true);
     });
 
-    // This health check after the change validates if the node went down due to block state mismatch error
-    it("Validate new Follower health after change", async function () {
+    it("Validate new Follower health and state after change", async function () {
         updateProviderUrl("stratus");
-        await new Promise((resolve) => setTimeout(resolve, 10000));
+        await new Promise((resolve) => setTimeout(resolve, 4000));
         const response = await sendWithRetry("stratus_health", []);
+        const followerNode = await sendWithRetry("stratus_state", []);
+        expect(followerNode.is_importer_shutdown).to.equal(false);
+        expect(followerNode.is_interval_miner_running).to.equal(false);
+        expect(followerNode.is_leader).to.equal(false);
+        expect(followerNode.miner_paused).to.equal(false);
+        expect(followerNode.transactions_enabled).to.equal(false);
         expect(response).to.equal(true);
     });
 
@@ -102,11 +113,65 @@ describe("Leader & Follower change integration test", function () {
         expect(response.data.result).to.equal(true);
     });
 
-    // This health check after the change validates if the node went down due to block state mismatch error
-    it("Validate new Leader health after change", async function () {
+    it("Validate new Leader health and state after change", async function () {
         updateProviderUrl("stratus-follower");
-        await new Promise((resolve) => setTimeout(resolve, 10000));
+        await new Promise((resolve) => setTimeout(resolve, 4000));
         const response = await sendWithRetry("stratus_health", []);
         expect(response).to.equal(true);
+        const leaderNode = await sendWithRetry("stratus_state", []);
+        expect(leaderNode.is_importer_shutdown).to.equal(true);
+        expect(leaderNode.is_interval_miner_running).to.equal(true);
+        expect(leaderNode.is_leader).to.equal(true);
+        expect(leaderNode.miner_paused).to.equal(false);
+        expect(leaderNode.transactions_enabled).to.equal(false);
+    });
+
+    it("Change new Leader to Follower again should succeed", async function () {
+        updateProviderUrl("stratus-follower");
+        await sendWithRetry("stratus_disableTransactions", []);
+        await sendWithRetry("stratus_disableMiner", []);
+        await new Promise((resolve) => setTimeout(resolve, 4000));
+        const response = await sendAndGetFullResponse("stratus_changeToFollower", [
+            "http://0.0.0.0:3000/",
+            "ws://0.0.0.0:3000/",
+            "2s",
+            "100ms",
+        ]);
+        expect(response.data.result).to.equal(true);
+    });
+
+    it("Validate new Follower health and state after change", async function () {
+        updateProviderUrl("stratus-follower");
+        await new Promise((resolve) => setTimeout(resolve, 4000));
+        const response = await sendWithRetry("stratus_health", []);
+        expect(response).to.equal(true);
+        const followerNode = await sendWithRetry("stratus_state", []);
+        expect(followerNode.is_importer_shutdown).to.equal(false);
+        expect(followerNode.is_interval_miner_running).to.equal(false);
+        expect(followerNode.is_leader).to.equal(false);
+        expect(followerNode.miner_paused).to.equal(false);
+        expect(followerNode.transactions_enabled).to.equal(false);
+    });
+
+    it("Change new Follower to Leader again should succeed", async function () {
+        updateProviderUrl("stratus");
+        await sendWithRetry("stratus_disableTransactions", []);
+        await sendWithRetry("stratus_disableMiner", []);
+        await new Promise((resolve) => setTimeout(resolve, 4000));
+        const response = await sendAndGetFullResponse("stratus_changeToLeader", []);
+        expect(response.data.result).to.equal(true);
+    });
+
+    it("Validate new Leader health and state after change", async function () {
+        updateProviderUrl("stratus");
+        await new Promise((resolve) => setTimeout(resolve, 4000));
+        const response = await sendWithRetry("stratus_health", []);
+        expect(response).to.equal(true);
+        const leaderNode = await sendWithRetry("stratus_state", []);
+        expect(leaderNode.is_importer_shutdown).to.equal(true);
+        //expect(leaderNode.is_interval_miner_running).to.equal(true);
+        expect(leaderNode.is_leader).to.equal(true);
+        //expect(leaderNode.miner_paused).to.equal(false);
+        expect(leaderNode.transactions_enabled).to.equal(false);
     });
 });

--- a/e2e/cloudwalk-contracts/integration/test/leader-follower-change.test.ts
+++ b/e2e/cloudwalk-contracts/integration/test/leader-follower-change.test.ts
@@ -156,7 +156,6 @@ describe("Leader & Follower change integration test", function () {
     it("Change new Follower to Leader again should succeed", async function () {
         updateProviderUrl("stratus");
         await sendWithRetry("stratus_disableTransactions", []);
-        await sendWithRetry("stratus_disableMiner", []);
         await new Promise((resolve) => setTimeout(resolve, 4000));
         const response = await sendAndGetFullResponse("stratus_changeToLeader", []);
         expect(response.data.result).to.equal(true);
@@ -171,7 +170,7 @@ describe("Leader & Follower change integration test", function () {
         expect(leaderNode.is_importer_shutdown).to.equal(true);
         //expect(leaderNode.is_interval_miner_running).to.equal(true);
         expect(leaderNode.is_leader).to.equal(true);
-        //expect(leaderNode.miner_paused).to.equal(false);
+        expect(leaderNode.miner_paused).to.equal(false);
         expect(leaderNode.transactions_enabled).to.equal(false);
     });
 });

--- a/justfile
+++ b/justfile
@@ -290,7 +290,7 @@ e2e-leader-follower-up test="brlc":
 
     if [ "{{test}}" = "deploy" ]; then
         just _log "Running deploy script"
-        ./utils/deploy.sh
+        ./utils/deploy.sh --leader 0.0.0.0:3000 --follower 0.0.0.0:3001 --auto-approve
         if [ $? -ne 0 ]; then
             just _log "Deploy script failed"
             exit 1

--- a/src/eth/miner/miner.rs
+++ b/src/eth/miner/miner.rs
@@ -138,6 +138,7 @@ impl Miner {
             return;
         }
         self.shutdown_and_wait().await;
+        self.unpause();
     }
 
     // Unpause interval miner (if in interval mode)


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Enhanced leader-follower change integration tests with more detailed state checks and expanded test coverage
- Improved deploy script with flexible configuration options and manual confirmation steps
- Added unpause functionality when switching miner to external mode
- Updated justfile to accommodate new deploy script arguments
- Reduced wait times in integration tests for faster execution


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>miner.rs</strong><dd><code>Unpause miner when switching to external mode</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/miner/miner.rs

<li>Added <code>self.unpause()</code> call in the <code>switch_to_external_mode</code> function<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1711/files#diff-16f448afc7dae3e8e802f676a86dbd7051e19f6c17cbbeb53eb730d726372629">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>deploy.sh</strong><dd><code>Improve deploy script with flexible configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

utils/deploy.sh

<li>Added command-line arguments for leader and follower addresses<br> <li> Implemented input validation for addresses<br> <li> Added an optional auto-approve flag<br> <li> Included manual confirmation steps for critical operations<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1711/files#diff-2aa8d59f723e2655e12c5f84050efa57222d0f4b4931f9176d2cf09bff13d017">+58/-3</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>leader-follower-change.test.ts</strong><dd><code>Enhance leader-follower change integration tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

e2e/cloudwalk-contracts/integration/test/leader-follower-change.test.ts

<li>Added more detailed state checks for leader and follower nodes<br> <li> Reduced wait times between operations from 10000ms to 4000ms<br> <li> Added tests for multiple leader-follower changes<br> <li> Expanded test coverage for node state validation<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1711/files#diff-7236d4b676b75ced96eb321337290326efe4e91a261edc4e83b688c4da09dd7c">+73/-9</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>justfile</strong><dd><code>Update deploy script call in justfile</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

justfile

<li>Updated the deploy script call to include new command-line arguments<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1711/files#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

