### PR TITLE
fix: change to external bug

### DIFF
--- a/e2e/cloudwalk-contracts/integration/test/leader-follower-change.test.ts
+++ b/e2e/cloudwalk-contracts/integration/test/leader-follower-change.test.ts
@@ -168,7 +168,7 @@ describe("Leader & Follower change integration test", function () {
         expect(response).to.equal(true);
         const leaderNode = await sendWithRetry("stratus_state", []);
         expect(leaderNode.is_importer_shutdown).to.equal(true);
-        //expect(leaderNode.is_interval_miner_running).to.equal(true);
+        expect(leaderNode.is_interval_miner_running).to.equal(true);
         expect(leaderNode.is_leader).to.equal(true);
         expect(leaderNode.miner_paused).to.equal(false);
         expect(leaderNode.transactions_enabled).to.equal(false);

--- a/src/eth/miner/miner.rs
+++ b/src/eth/miner/miner.rs
@@ -138,6 +138,7 @@ impl Miner {
             return;
         }
         self.shutdown_and_wait().await;
+        self.set_mode(MinerMode::External);
         self.unpause();
     }
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed a bug in the miner's `switch_to_external_mode` function by explicitly setting the mode to External
- Updated integration test expectations for the leader node state
- Ensured that the interval miner is running as expected in the leader-follower change test


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>miner.rs</strong><dd><code>Set miner mode to external when switching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/miner/miner.rs

<li>Added <code>self.set_mode(MinerMode::External);</code> in the <br><code>switch_to_external_mode</code> function<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1712/files#diff-16f448afc7dae3e8e802f676a86dbd7051e19f6c17cbbeb53eb730d726372629">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>leader-follower-change.test.ts</strong><dd><code>Update leader node test expectations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

e2e/cloudwalk-contracts/integration/test/leader-follower-change.test.ts

<li>Uncommented and updated an expectation for <code>is_interval_miner_running</code> <br>to be true<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1712/files#diff-7236d4b676b75ced96eb321337290326efe4e91a261edc4e83b688c4da09dd7c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

