### PR TITLE
enha: make importer-online shutdown awaitable

### DIFF
--- a/src/eth/follower/importer/importer.rs
+++ b/src/eth/follower/importer/importer.rs
@@ -26,6 +26,7 @@ use crate::ext::spawn_named;
 use crate::ext::traced_sleep;
 use crate::ext::DisplayExt;
 use crate::ext::SleepReason;
+use crate::globals::IMPORTER_ONLINE_TASKS_SEMAPHORE;
 use crate::if_else;
 #[cfg(feature = "metrics")]
 use crate::infra::metrics;
@@ -156,6 +157,7 @@ impl Importer {
         mut backlog_rx: mpsc::UnboundedReceiver<(ExternalBlock, Vec<ExternalReceipt>)>,
     ) -> anyhow::Result<()> {
         const TASK_NAME: &str = "block-executor";
+        let _permit = IMPORTER_ONLINE_TASKS_SEMAPHORE.acquire().await;
 
         loop {
             if Self::should_shutdown(TASK_NAME) {
@@ -221,6 +223,7 @@ impl Importer {
     /// Retrieves the blockchain current block number.
     async fn start_number_fetcher(chain: Arc<BlockchainClient>, sync_interval: Duration) -> anyhow::Result<()> {
         const TASK_NAME: &str = "external-number-fetcher";
+        let _permit = IMPORTER_ONLINE_TASKS_SEMAPHORE.acquire().await;
 
         // initial newHeads subscriptions.
         // abort application if cannot subscribe.
@@ -334,6 +337,7 @@ impl Importer {
         mut importer_block_number: BlockNumber,
     ) -> anyhow::Result<()> {
         const TASK_NAME: &str = "external-block-fetcher";
+        let _permit = IMPORTER_ONLINE_TASKS_SEMAPHORE.acquire().await;
 
         loop {
             if Self::should_shutdown(TASK_NAME) {


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Implemented a semaphore system to manage importer tasks:
  - Added `IMPORTER_ONLINE_TASKS_SEMAPHORE` with 3 permits
  - Modified importer functions to acquire semaphore permits
- Created `wait_for_importer_to_finish` function to ensure all importer tasks are completed
- Updated `stratus_change_to_leader` to use the new wait function instead of a fixed sleep
- Removed unused imports and constants


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>importer.rs</strong><dd><code>Implement semaphore for importer tasks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/follower/importer/importer.rs

<li>Added <code>IMPORTER_ONLINE_TASKS_SEMAPHORE</code> import<br> <li> Implemented semaphore acquisition in <code>start_block_executor</code>, <br><code>start_number_fetcher</code>, and <code>start_block_fetcher</code> functions<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1714/files#diff-bd50f502f039aff8f75753bc780d281ae7d7936fadc9d53482084c647aec94ca">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rpc_server.rs</strong><dd><code>Update importer shutdown process</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/rpc/rpc_server.rs

<li>Removed unused imports<br> <li> Replaced <code>traced_sleep</code> with <code>GlobalState::wait_for_importer_to_finish()</code> <br>in <code>stratus_change_to_leader</code> function<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1714/files#diff-835ba255c9a5c1fe0e13285bc39e058e1c74422e5e03ebba483c9d8a15c45405">+1/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>globals.rs</strong><dd><code>Add semaphore and wait function for importer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/globals.rs

<li>Added <code>Semaphore</code> import and created <code>IMPORTER_ONLINE_TASKS_SEMAPHORE</code><br> <li> Implemented <code>wait_for_importer_to_finish</code> function in <code>GlobalState</code><br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1714/files#diff-48d6fbc3a4ed67100952dcccfada858623c931e73d6de32984d4d1457e68d3a9">+14/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

