### PR TITLE
fix: corner case for miner shutdown check

### DIFF
--- a/src/eth/miner/miner.rs
+++ b/src/eth/miner/miner.rs
@@ -176,7 +176,7 @@ impl Miner {
     pub fn is_interval_miner_running(&self) -> bool {
         match self.interval_joinset.try_lock() {
             // check if the joinset of tasks has futures running
-            Ok(joinset) => joinset.is_some(),
+            Ok(joinset) => joinset.as_ref().is_some_and(|joinset| not(joinset.is_empty())),
             // if the joinset is locked, it's either trying to shutdown or turning on, so yes
             Err(_) => true,
         }


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed a corner case in the miner shutdown check logic
- Modified the `is_interval_miner_running` method in `src/eth/miner/miner.rs`
- Now checks if the joinset is both present and not empty
- Ensures more accurate detection of running miner tasks
- Prevents false positives when the joinset exists but contains no active tasks


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>miner.rs</strong><dd><code>Improve miner shutdown check accuracy</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/miner/miner.rs

<li>Modified the <code>is_interval_miner_running</code> method to check if the joinset <br>is not empty<br> <li> Replaced simple <code>is_some()</code> check with <code>is_some_and()</code> and <br><code>not(joinset.is_empty())</code><br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1715/files#diff-16f448afc7dae3e8e802f676a86dbd7051e19f6c17cbbeb53eb730d726372629">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

