### PR TITLE
enha: add flag for rocks shutdown timeout duration

### DIFF
--- a/src/bin/rocks_revert_to_block.rs
+++ b/src/bin/rocks_revert_to_block.rs
@@ -6,6 +6,7 @@
 //! was just processed, that is, before the next ones were processed.
 
 use std::cmp::Ordering;
+use std::time::Duration;
 
 use anyhow::bail;
 use stratus::config::RocksRevertToBlockConfig;
@@ -27,7 +28,7 @@ fn main() -> anyhow::Result<()> {
 fn run(config: RocksRevertToBlockConfig) -> anyhow::Result<()> {
     let _timer = DropTimer::start("rocks-revert-to-block");
 
-    let rocks = RocksPermanentStorage::new(config.rocks_path_prefix)?;
+    let rocks = RocksPermanentStorage::new(config.rocks_path_prefix, Duration::from_secs(30))?;
 
     let target_block = config.block_number;
     let current_block = rocks.read_mined_block_number()?.as_u64();

--- a/src/eth/storage/rocks/rocks_permanent.rs
+++ b/src/eth/storage/rocks/rocks_permanent.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
+use std::time::Duration;
 
 use anyhow::bail;
 
@@ -26,7 +27,7 @@ pub struct RocksPermanentStorage {
 }
 
 impl RocksPermanentStorage {
-    pub fn new(rocks_path_prefix: Option<String>) -> anyhow::Result<Self> {
+    pub fn new(rocks_path_prefix: Option<String>, shutdown_timeout: Duration) -> anyhow::Result<Self> {
         tracing::info!("setting up rocksdb storage");
 
         let path = if let Some(prefix) = rocks_path_prefix {
@@ -47,7 +48,7 @@ impl RocksPermanentStorage {
             "data/rocksdb".to_string()
         };
 
-        let state = RocksStorageState::new(path)?;
+        let state = RocksStorageState::new(path, shutdown_timeout)?;
         let block_number = state.preload_block_number()?;
 
         Ok(Self { state, block_number })


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added a new configurable option `rocks_shutdown_timeout` to control the maximum time to wait for RocksDB compaction during shutdown.
- Modified `RocksPermanentStorage` and `RocksStorageState` to accept and use the new shutdown timeout parameter.
- Updated the `Drop` implementation for `RocksStorageState` to use the configurable timeout instead of a hard-coded 4-minute value.
- Added necessary imports and adjusted function signatures across multiple files to accommodate the new timeout feature.
- Updated test cases to include the new timeout parameter (using `Duration::ZERO` for tests).


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rocks_revert_to_block.rs</strong><dd><code>Add shutdown timeout to RocksPermanentStorage initialization</code></dd></summary>
<hr>

src/bin/rocks_revert_to_block.rs

<li>Added import for <code>Duration</code> from <code>std::time</code><br> <li> Modified <code>RocksPermanentStorage::new()</code> call to include a 30-second <br>duration parameter<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1716/files#diff-9edb1344ae783fdd07dc1896fcccc9374d542df7f2bafaebd5f3b5866887f89b">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>permanent_storage.rs</strong><dd><code>Implement configurable RocksDB shutdown timeout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/permanent_storage.rs

<li>Added import for <code>Duration</code> from <code>std::time</code><br> <li> Added new <code>rocks_shutdown_timeout</code> field to <code>PermanentStorageConfig</code> <br>struct<br> <li> Modified <code>PermanentStorageConfig::new_storage()</code> to pass shutdown <br>timeout to <code>RocksPermanentStorage::new()</code><br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1716/files#diff-7b27a17201e5a4916214bb7bebbeaba2874cce309edd6f628018abe45f88a1c5">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rocks_permanent.rs</strong><dd><code>Add shutdown timeout parameter to RocksPermanentStorage</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/rocks/rocks_permanent.rs

<li>Added import for <code>Duration</code> from <code>std::time</code><br> <li> Modified <code>RocksPermanentStorage::new()</code> to accept a <code>shutdown_timeout</code> <br>parameter<br> <li> Updated <code>RocksStorageState::new()</code> call to include the <code>shutdown_timeout</code><br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1716/files#diff-c129c50a85915e0c5154c4e048a4577bd45ce6ae9ec98e95acbcad09ff79b3c6">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rocks_state.rs</strong><dd><code>Implement configurable shutdown timeout in RocksStorageState</code></dd></summary>
<hr>

src/eth/storage/rocks/rocks_state.rs

<li>Added <code>shutdown_timeout</code> field to <code>RocksStorageState</code> struct<br> <li> Modified <code>RocksStorageState::new()</code> to accept a <code>shutdown_timeout</code> <br>parameter<br> <li> Updated <code>Drop</code> implementation to use the configurable <code>shutdown_timeout</code><br> <li> Modified test cases to include <code>Duration::ZERO</code> in <br><code>RocksStorageState::new()</code> calls<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1716/files#diff-f7b822022d2c4fd93ec507cd6b5302dcf1646acbf0ee0dd077a047272b686009">+9/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

