### PR TITLE
chore: update justfile jeprof description

### DIFF
--- a/justfile
+++ b/justfile
@@ -94,8 +94,8 @@ stratus *args="":
 
 # Bin: Stratus main service as leader while performing memory-profiling, producing a heap dump every 2^32 allocated bytes (~4gb)
 # To produce a flamegraph of the memory usage use jeprof:
-#   * Diferential flamegraph: jeprof <binary> --base=./jeprof.<...>.i0.heap ./jeprof.<...>.i<n>.heap --collapsed | flamegraph.pl > leak.svg
-#   * Point in time flamegraph: jeprof <binary> ./jeprof.<...>.i<n>.heap --collapsed | flamegraph.pl > leak.svg
+#   * Diferential flamegraph: jeprof <binary> --base=./jeprof.<...>.i0.heap ./jeprof.<...>.i<n>.heap --collapsed | flamegraph.pl > mem_prof.svg
+#   * Point in time flamegraph: jeprof <binary> ./jeprof.<...>.i<n>.heap --collapsed | flamegraph.pl > mem_prof.svg
 stratus-memory-profiling *args="":
     _RJEM_MALLOC_CONF=prof:true,prof_final:true,prof_leak:true,prof_gdump:true,lg_prof_interval:32 cargo {{nightly_flag}} run --bin stratus {{release_flag}} --features dev,jeprof -- --leader {{args}}
 


### PR DESCRIPTION
### **User description**
leak.svg is not a good filename for the result of the commands


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Updated the example commands for generating memory profiling flamegraphs in the `justfile`
- Changed the output filename from `leak.svg` to `mem_prof.svg` for both differential and point-in-time flamegraphs
- Improved clarity and consistency in the documentation for memory profiling


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>justfile</strong><dd><code>Update memory profiling flamegraph commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

justfile

<li>Updated the example commands for generating memory profiling <br>flamegraphs<br> <li> Changed the output filename from <code>leak.svg</code> to <code>mem_prof.svg</code><br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1717/files#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

