### PR TITLE
enha: control change to mode endpoints concurrency

### DIFF
--- a/src/eth/primitives/stratus_error.rs
+++ b/src/eth/primitives/stratus_error.rs
@@ -206,6 +206,10 @@ pub enum StratusError {
     #[error("Stratus node is not a follower.")]
     #[strum(props(kind = "server_state"))]
     StratusNotFollower,
+
+    #[error("Stratus node is already in the process of changing mode.")]
+    #[strum(props(kind = "server_state"))]
+    ModeChangeInProgress,
 }
 
 impl StratusError {


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Implemented concurrency control for mode change endpoints (`stratus_change_to_leader` and `stratus_change_to_follower`) using a semaphore
- Added new `ModeChangeInProgress` error to handle concurrent mode change attempts
- Created E2E test to verify the prevention of concurrent mode changes with 1000 simultaneous requests
- Ensured proper error handling and response for concurrent mode change attempts
- Removed unused imports and cleaned up code in the test file


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>stratus_error.rs</strong><dd><code>Add new error for concurrent mode changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/stratus_error.rs

<li>Added new error variant <code>ModeChangeInProgress</code> to <code>StratusError</code> enum<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1725/files#diff-301cded01d772388e3e5c08ede093b91c3e4478c08e11a48f70e3d44351385fb">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rpc_server.rs</strong><dd><code>Implement concurrency control for mode change endpoints</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/eth/rpc/rpc_server.rs

<li>Implemented concurrency control for mode change endpoints using a <br>semaphore<br> <li> Added error handling for concurrent mode change attempts<br> <li> Applied semaphore to both <code>stratus_change_to_leader</code> and <br><code>stratus_change_to_follower</code> functions<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1725/files#diff-835ba255c9a5c1fe0e13285bc39e058e1c74422e5e03ebba483c9d8a15c45405">+17/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>leader-follower-change.test.ts</strong><dd><code>Add E2E test for concurrent mode change prevention</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

e2e/cloudwalk-contracts/integration/test/leader-follower-change.test.ts

<li>Added new test case to verify prevention of concurrent requests to <br>change mode endpoints<br> <li> Implemented test with 1000 concurrent requests to both leader and <br>follower change endpoints<br> <li> Verified correct error handling for concurrent mode change attempts<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1725/files#diff-7236d4b676b75ced96eb321337290326efe4e91a261edc4e83b688c4da09dd7c">+42/-11</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information