### PR TITLE
refactor: TempStorage methods renamed and repurposed

### DIFF
--- a/src/eth/primitives/log_filter_input.rs
+++ b/src/eth/primitives/log_filter_input.rs
@@ -60,7 +60,7 @@ impl LogFilterInput {
 
         // translate point-in-time to block according to context
         let from = match from {
-            StoragePointInTime::Pending => storage.read_pending_block_number()?.unwrap_or_default(),
+            StoragePointInTime::Pending => storage.read_pending_block_header()?.unwrap_or_default().number,
             StoragePointInTime::Mined => storage.read_mined_block_number()?,
             StoragePointInTime::MinedPast(number) => number,
         };

--- a/src/eth/storage/inmemory/inmemory_temporary.rs
+++ b/src/eth/storage/inmemory/inmemory_temporary.rs
@@ -16,6 +16,7 @@ use crate::eth::primitives::ExecutionConflictsBuilder;
 use crate::eth::primitives::ExternalBlock;
 use crate::eth::primitives::Hash;
 use crate::eth::primitives::PendingBlock;
+use crate::eth::primitives::PendingBlockHeader;
 use crate::eth::primitives::Slot;
 use crate::eth::primitives::SlotIndex;
 use crate::eth::primitives::StratusError;
@@ -123,10 +124,10 @@ impl TemporaryStorage for InMemoryTemporaryStorage {
         Ok(())
     }
 
-    fn read_pending_block_number(&self) -> anyhow::Result<Option<BlockNumber>> {
+    fn read_pending_block_header(&self) -> anyhow::Result<Option<PendingBlockHeader>> {
         let states = self.lock_read();
         match &states.head.block {
-            Some(block) => Ok(Some(block.header.number)),
+            Some(block) => Ok(Some(block.header.clone())),
             None => Ok(None),
         }
     }
@@ -141,7 +142,7 @@ impl TemporaryStorage for InMemoryTemporaryStorage {
         Ok(())
     }
 
-    fn save_execution(&self, tx: TransactionExecution, check_conflicts: bool) -> Result<(), StratusError> {
+    fn save_pending_execution(&self, tx: TransactionExecution, check_conflicts: bool) -> Result<(), StratusError> {
         // check conflicts
         let mut states = self.lock_write();
         if check_conflicts {
@@ -186,7 +187,7 @@ impl TemporaryStorage for InMemoryTemporaryStorage {
         Ok(())
     }
 
-    fn pending_transactions(&self) -> Vec<TransactionExecution> {
+    fn read_pending_executions(&self) -> Vec<TransactionExecution> {
         self.lock_read()
             .head
             .block
@@ -212,7 +213,7 @@ impl TemporaryStorage for InMemoryTemporaryStorage {
         Ok(finished_block)
     }
 
-    fn read_transaction(&self, hash: &Hash) -> anyhow::Result<Option<TransactionExecution>> {
+    fn read_pending_execution(&self, hash: &Hash) -> anyhow::Result<Option<TransactionExecution>> {
         let states = self.lock_read();
         let Some(ref pending_block) = states.head.block else { return Ok(None) };
         match pending_block.transactions.get(hash) {

--- a/src/eth/storage/temporary_storage.rs
+++ b/src/eth/storage/temporary_storage.rs
@@ -10,6 +10,7 @@ use crate::eth::primitives::BlockNumber;
 use crate::eth::primitives::ExternalBlock;
 use crate::eth::primitives::Hash;
 use crate::eth::primitives::PendingBlock;
+use crate::eth::primitives::PendingBlockHeader;
 use crate::eth::primitives::Slot;
 use crate::eth::primitives::SlotIndex;
 use crate::eth::primitives::StratusError;
@@ -26,7 +27,7 @@ pub trait TemporaryStorage: Send + Sync + 'static {
     fn set_pending_block_number(&self, number: BlockNumber) -> anyhow::Result<()>;
 
     // Retrieves the block number being mined.
-    fn read_pending_block_number(&self) -> anyhow::Result<Option<BlockNumber>>;
+    fn read_pending_block_header(&self) -> anyhow::Result<Option<PendingBlockHeader>>;
 
     // -------------------------------------------------------------------------
     // Block and executions
@@ -35,17 +36,17 @@ pub trait TemporaryStorage: Send + Sync + 'static {
     /// Sets the pending external block being re-executed.
     fn set_pending_external_block(&self, block: ExternalBlock) -> anyhow::Result<()>;
 
-    /// Saves a re-executed transaction to the pending mined block.
-    fn save_execution(&self, tx: TransactionExecution, check_conflicts: bool) -> Result<(), StratusError>;
-
-    /// Retrieves the pending transactions of the pending block.
-    fn pending_transactions(&self) -> Vec<TransactionExecution>;
-
     /// Finishes the mining of the pending block and starts a new block.
     fn finish_pending_block(&self) -> anyhow::Result<PendingBlock>;
 
-    /// Retrieves a transaction from the storage.
-    fn read_transaction(&self, hash: &Hash) -> anyhow::Result<Option<TransactionExecution>>;
+    /// Saves a transaction execution to the pending mined block.
+    fn save_pending_execution(&self, tx: TransactionExecution, check_conflicts: bool) -> Result<(), StratusError>;
+
+    /// Retrieves all transaction executions from the pending block.
+    fn read_pending_executions(&self) -> Vec<TransactionExecution>;
+
+    /// Retrieves a single transaction execution from the pending block.
+    fn read_pending_execution(&self, hash: &Hash) -> anyhow::Result<Option<TransactionExecution>>;
 
     // -------------------------------------------------------------------------
     // Accounts and slots


### PR DESCRIPTION
### **User description**
* Renamed a few transaction execution methods.
* `read_pending_block_number` becomes `read_pending_block_header` so in a next PR we can also use it to read the pending block timestamp.


___

### **PR Type**
Enhancement, Refactoring


___

### **Description**
- Renamed `read_pending_block_number` to `read_pending_block_header` across multiple files to provide more comprehensive block information.
- Updated `EvmInput` creation in the executor to use `pending_header.number` instead of `pending_block_number`.
- Refactored `InMemoryTemporaryStorage` methods for consistency:
  - `save_execution` -> `save_pending_execution`
  - `pending_transactions` -> `read_pending_executions`
  - `read_transaction` -> `read_pending_execution`
- Updated `StratusStorage` to use new method names and adjust error handling accordingly.
- Refactored `TemporaryStorage` trait to reflect new method names and signatures.
- Updated `LogFilterInput` to use the new `read_pending_block_header` method.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>executor.rs</strong><dd><code>Update executor to use pending block header</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/executor/executor.rs

<li>Replaced <code>read_pending_block_number</code> with <code>read_pending_block_header</code><br> <li> Updated <code>EvmInput</code> creation to use <code>pending_header.number</code> instead of <br><code>pending_block_number</code><br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1726/files#diff-6b460d7dee8280c0287e8d9d9d59cf66a57ec9fed1bc003c6ede6fef60c7376b">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>log_filter_input.rs</strong><dd><code>Adjust log filter input for pending block header</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/log_filter_input.rs

<li>Updated <code>LogFilterInput</code> to use <br><code>read_pending_block_header().unwrap_or_default().number</code> instead of <br><code>read_pending_block_number()</code><br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1726/files#diff-1fc314c5ef2bb71e10a986847e852f50d787c67b002131aa6f4afae62ebd4555">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>stratus_storage.rs</strong><dd><code>Update StratusStorage for pending block header changes</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/stratus_storage.rs

<li>Updated <code>read_pending_block_number</code> to <code>read_pending_block_header</code><br> <li> Adjusted method calls and variable names to reflect new naming <br>conventions<br> <li> Updated error handling and logging to use new method names<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1726/files#diff-3b2e36e47959decdfe26b2c4fab90b41f9242bfdad29cc43b2377ee851f4f40a">+15/-14</a>&nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Refactoring</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>inmemory_temporary.rs</strong><dd><code>Refactor InMemoryTemporaryStorage methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/inmemory/inmemory_temporary.rs

<li>Renamed <code>read_pending_block_number</code> to <code>read_pending_block_header</code><br> <li> Renamed <code>save_execution</code> to <code>save_pending_execution</code><br> <li> Renamed <code>pending_transactions</code> to <code>read_pending_executions</code><br> <li> Renamed <code>read_transaction</code> to <code>read_pending_execution</code><br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1726/files#diff-6f4ee832c01927be4b428028743a37022368d351f09fd177f59e81a5a58dd661">+6/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>temporary_storage.rs</strong><dd><code>Refactor TemporaryStorage trait for consistency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/temporary_storage.rs

<li>Updated <code>TemporaryStorage</code> trait to reflect new method names and <br>signatures<br> <li> Renamed and reorganized methods related to pending block and <br>transaction execution<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1726/files#diff-58337f46f036f808e0166f195e0ed5dfbfdc092fc1665c3424f01d799a5195de">+10/-9</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information