### PR TITLE
fix: use pending block timestamp instead of current system timestamp

### DIFF
--- a/src/eth/executor/evm_input.rs
+++ b/src/eth/executor/evm_input.rs
@@ -10,6 +10,7 @@ use crate::eth::primitives::ExternalReceipt;
 use crate::eth::primitives::ExternalTransaction;
 use crate::eth::primitives::Gas;
 use crate::eth::primitives::Nonce;
+use crate::eth::primitives::PendingBlockHeader;
 use crate::eth::primitives::TransactionInput;
 use crate::eth::primitives::UnixTime;
 use crate::eth::primitives::Wei;
@@ -81,7 +82,7 @@ pub struct EvmInput {
 
 impl EvmInput {
     /// Creates from a transaction that was sent directly to Stratus with `eth_sendRawTransaction`.
-    pub fn from_eth_transaction(input: TransactionInput, pending_block_number: BlockNumber) -> Self {
+    pub fn from_eth_transaction(input: TransactionInput, pending_header: PendingBlockHeader) -> Self {
         Self {
             from: input.signer,
             to: input.to,
@@ -90,8 +91,8 @@ impl EvmInput {
             gas_limit: Gas::MAX,
             gas_price: Wei::ZERO,
             nonce: Some(input.nonce),
-            block_number: pending_block_number,
-            block_timestamp: UnixTime::now(), // TODO: this should come from the pending block
+            block_number: pending_header.number,
+            block_timestamp: pending_header.timestamp,
             point_in_time: StoragePointInTime::Pending,
             chain_id: input.chain_id,
         }
@@ -101,7 +102,7 @@ impl EvmInput {
     pub fn from_eth_call(
         input: CallInput,
         point_in_time: StoragePointInTime,
-        pending_block_number: BlockNumber,
+        pending_header: PendingBlockHeader,
         mined_block: Option<Block>,
     ) -> anyhow::Result<Self> {
         Ok(Self {
@@ -113,11 +114,11 @@ impl EvmInput {
             gas_price: Wei::ZERO,
             nonce: None,
             block_number: match point_in_time {
-                StoragePointInTime::Mined | StoragePointInTime::Pending => pending_block_number,
+                StoragePointInTime::Mined | StoragePointInTime::Pending => pending_header.number,
                 StoragePointInTime::MinedPast(number) => number,
             },
             block_timestamp: match point_in_time {
-                StoragePointInTime::Mined | StoragePointInTime::Pending => UnixTime::now(),
+                StoragePointInTime::Mined | StoragePointInTime::Pending => pending_header.timestamp,
                 StoragePointInTime::MinedPast(_) => match mined_block {
                     Some(block) => block.header.timestamp,
                     None => return log_and_err!("failed to create EvmInput because cannot determine mined block timestamp"),

--- a/src/eth/executor/executor.rs
+++ b/src/eth/executor/executor.rs
@@ -477,7 +477,7 @@ impl Executor {
 
             // prepare evm input
             let pending_header = self.storage.read_pending_block_header()?.unwrap_or_default();
-            let evm_input = EvmInput::from_eth_transaction(tx_input.clone(), pending_header.number);
+            let evm_input = EvmInput::from_eth_transaction(tx_input.clone(), pending_header);
 
             // execute transaction in evm (retry only in case of conflict, but do not retry on other failures)
             tracing::info!(
@@ -546,7 +546,7 @@ impl Executor {
         };
 
         // execute
-        let evm_input = EvmInput::from_eth_call(call_input.clone(), point_in_time, pending_header.number, mined_block)?;
+        let evm_input = EvmInput::from_eth_call(call_input.clone(), point_in_time, pending_header, mined_block)?;
         let evm_route = match point_in_time {
             StoragePointInTime::Mined | StoragePointInTime::Pending => EvmRoute::CallPresent,
             StoragePointInTime::MinedPast(_) => EvmRoute::CallPast,

--- a/src/eth/executor/executor.rs
+++ b/src/eth/executor/executor.rs
@@ -26,6 +26,7 @@ use crate::eth::primitives::ExternalReceipt;
 use crate::eth::primitives::ExternalReceipts;
 use crate::eth::primitives::ExternalTransaction;
 use crate::eth::primitives::ExternalTransactionExecution;
+use crate::eth::primitives::PendingBlockHeader;
 use crate::eth::primitives::StratusError;
 use crate::eth::primitives::TransactionExecution;
 use crate::eth::primitives::TransactionInput;
@@ -241,8 +242,9 @@ impl Executor {
         let block_number = block.number();
         let block_timestamp = block.timestamp();
         let block_transactions = mem::take(&mut block.transactions);
-        self.storage.set_pending_external_block(block)?;
-        self.storage.set_pending_block_number(block_number)?;
+        self.storage
+            .set_pending_block_header(PendingBlockHeader::new(block.number(), block.timestamp()))?;
+        self.storage.set_pending_external_block(block.clone())?;
 
         // determine how to execute each transaction
         for tx in block_transactions {

--- a/src/eth/miner/miner.rs
+++ b/src/eth/miner/miner.rs
@@ -25,11 +25,11 @@ use crate::eth::primitives::Hash;
 use crate::eth::primitives::Index;
 use crate::eth::primitives::LocalTransactionExecution;
 use crate::eth::primitives::LogMined;
+use crate::eth::primitives::PendingBlockHeader;
 use crate::eth::primitives::Size;
 use crate::eth::primitives::StratusError;
 use crate::eth::primitives::TransactionExecution;
 use crate::eth::primitives::TransactionMined;
-use crate::eth::primitives::UnixTime;
 use crate::eth::storage::StratusStorage;
 use crate::ext::not;
 use crate::ext::DisplayExt;
@@ -309,7 +309,7 @@ impl Miner {
             }
         }
 
-        block_from_local(block.header.number, local_txs)
+        block_from_local(block.header, local_txs)
     }
 
     /// Persists a mined block to permanent storage and prepares new block.
@@ -378,14 +378,8 @@ fn block_from_external(external_block: ExternalBlock, mined_txs: Vec<Transaction
     })
 }
 
-pub fn block_from_local(number: BlockNumber, txs: Vec<LocalTransactionExecution>) -> anyhow::Result<Block> {
-    // TODO: block timestamp should be set in the PendingBlock instead of being retrieved from the execution
-    let block_timestamp = match txs.first() {
-        Some(tx) => tx.result.execution.block_timestamp,
-        None => UnixTime::now(),
-    };
-
-    let mut block = Block::new(number, block_timestamp);
+pub fn block_from_local(pending_header: PendingBlockHeader, txs: Vec<LocalTransactionExecution>) -> anyhow::Result<Block> {
+    let mut block = Block::new(pending_header.number, pending_header.timestamp);
     block.transactions.reserve(txs.len());
     block.header.size = Size::from(txs.len() as u64);
 

--- a/src/eth/primitives/log_filter_input.rs
+++ b/src/eth/primitives/log_filter_input.rs
@@ -60,7 +60,7 @@ impl LogFilterInput {
 
         // translate point-in-time to block according to context
         let from = match from {
-            StoragePointInTime::Pending => storage.read_pending_block_number()?.unwrap_or_default(),
+            StoragePointInTime::Pending => storage.read_pending_block_header()?.unwrap_or_default().number,
             StoragePointInTime::Mined => storage.read_mined_block_number()?,
             StoragePointInTime::MinedPast(number) => number,
         };

--- a/src/eth/primitives/pending_block.rs
+++ b/src/eth/primitives/pending_block.rs
@@ -17,9 +17,18 @@ pub struct PendingBlock {
 
 impl PendingBlock {
     /// Creates a new [`PendingBlock`] with the specified number.
-    pub fn new_at_now(number: BlockNumber) -> Self {
+    pub fn new_with_number(number: BlockNumber) -> Self {
         Self {
-            header: PendingBlockHeader::new_at_now(number),
+            header: PendingBlockHeader::new_with_number(number),
+            transactions: IndexMap::new(),
+            external_block: None,
+        }
+    }
+
+    /// Creates a new [`PendingBlock`] with the specified header.
+    pub fn new_with_header(pending_header: PendingBlockHeader) -> Self {
+        Self {
+            header: pending_header,
             transactions: IndexMap::new(),
             external_block: None,
         }

--- a/src/eth/primitives/pending_block_header.rs
+++ b/src/eth/primitives/pending_block_header.rs
@@ -11,8 +11,13 @@ pub struct PendingBlockHeader {
 }
 
 impl PendingBlockHeader {
+    /// Creates a new [`PendingBlockHeader`] with the specified number and timestamp.
+    pub fn new(number: BlockNumber, timestamp: UnixTime) -> Self {
+        Self { number, timestamp }
+    }
+
     /// Creates a new [`PendingBlockHeader`] with the specified number and the current timestamp.
-    pub fn new_at_now(number: BlockNumber) -> Self {
+    pub fn new_with_number(number: BlockNumber) -> Self {
         Self {
             number,
             timestamp: UnixTime::now(),

--- a/src/eth/rpc/rpc_middleware.rs
+++ b/src/eth/rpc/rpc_middleware.rs
@@ -62,6 +62,7 @@ impl<'a> RpcServiceT<'a> for RpcMiddleware {
     fn call(&self, mut request: jsonrpsee::types::Request<'a>) -> Self::Future {
         // track request
         let span = info_span!(
+            parent: None,
             "rpc::request",
             cid = %new_cid(),
             rpc_client = field::Empty,

--- a/src/eth/storage/inmemory/inmemory_temporary.rs
+++ b/src/eth/storage/inmemory/inmemory_temporary.rs
@@ -16,6 +16,7 @@ use crate::eth::primitives::ExecutionConflictsBuilder;
 use crate::eth::primitives::ExternalBlock;
 use crate::eth::primitives::Hash;
 use crate::eth::primitives::PendingBlock;
+use crate::eth::primitives::PendingBlockHeader;
 use crate::eth::primitives::Slot;
 use crate::eth::primitives::SlotIndex;
 use crate::eth::primitives::StratusError;
@@ -123,10 +124,10 @@ impl TemporaryStorage for InMemoryTemporaryStorage {
         Ok(())
     }
 
-    fn read_pending_block_number(&self) -> anyhow::Result<Option<BlockNumber>> {
+    fn read_pending_block_header(&self) -> anyhow::Result<Option<PendingBlockHeader>> {
         let states = self.lock_read();
         match &states.head.block {
-            Some(block) => Ok(Some(block.header.number)),
+            Some(block) => Ok(Some(block.header.clone())),
             None => Ok(None),
         }
     }
@@ -141,7 +142,7 @@ impl TemporaryStorage for InMemoryTemporaryStorage {
         Ok(())
     }
 
-    fn save_execution(&self, tx: TransactionExecution, check_conflicts: bool) -> Result<(), StratusError> {
+    fn save_pending_execution(&self, tx: TransactionExecution, check_conflicts: bool) -> Result<(), StratusError> {
         // check conflicts
         let mut states = self.lock_write();
         if check_conflicts {
@@ -186,7 +187,7 @@ impl TemporaryStorage for InMemoryTemporaryStorage {
         Ok(())
     }
 
-    fn pending_transactions(&self) -> Vec<TransactionExecution> {
+    fn read_pending_executions(&self) -> Vec<TransactionExecution> {
         self.lock_read()
             .head
             .block
@@ -212,7 +213,7 @@ impl TemporaryStorage for InMemoryTemporaryStorage {
         Ok(finished_block)
     }
 
-    fn read_transaction(&self, hash: &Hash) -> anyhow::Result<Option<TransactionExecution>> {
+    fn read_pending_execution(&self, hash: &Hash) -> anyhow::Result<Option<TransactionExecution>> {
         let states = self.lock_read();
         let Some(ref pending_block) = states.head.block else { return Ok(None) };
         match pending_block.transactions.get(hash) {

--- a/src/eth/storage/inmemory/inmemory_temporary.rs
+++ b/src/eth/storage/inmemory/inmemory_temporary.rs
@@ -9,7 +9,6 @@ use nonempty::NonEmpty;
 
 use crate::eth::primitives::Account;
 use crate::eth::primitives::Address;
-use crate::eth::primitives::BlockNumber;
 use crate::eth::primitives::EvmExecution;
 use crate::eth::primitives::ExecutionConflicts;
 use crate::eth::primitives::ExecutionConflictsBuilder;
@@ -113,12 +112,12 @@ impl TemporaryStorage for InMemoryTemporaryStorage {
     // Block number
     // -------------------------------------------------------------------------
 
-    fn set_pending_block_number(&self, number: BlockNumber) -> anyhow::Result<()> {
+    fn set_pending_block_header(&self, pending_header: PendingBlockHeader) -> anyhow::Result<()> {
         let mut states = self.lock_write();
         match states.head.block.as_mut() {
-            Some(block) => block.header.number = number,
+            Some(block) => block.header = pending_header,
             None => {
-                states.head.block = Some(PendingBlock::new_at_now(number));
+                states.head.block = Some(PendingBlock::new_with_header(pending_header));
             }
         }
         Ok(())
@@ -208,7 +207,7 @@ impl TemporaryStorage for InMemoryTemporaryStorage {
 
         // create new state
         states.insert(0, InMemoryTemporaryStorageState::default());
-        states.head.block = Some(PendingBlock::new_at_now(finished_block.header.number.next_block_number()));
+        states.head.block = Some(PendingBlock::new_with_number(finished_block.header.number.next_block_number()));
 
         Ok(finished_block)
     }

--- a/src/eth/storage/temporary_storage.rs
+++ b/src/eth/storage/temporary_storage.rs
@@ -10,6 +10,7 @@ use crate::eth::primitives::BlockNumber;
 use crate::eth::primitives::ExternalBlock;
 use crate::eth::primitives::Hash;
 use crate::eth::primitives::PendingBlock;
+use crate::eth::primitives::PendingBlockHeader;
 use crate::eth::primitives::Slot;
 use crate::eth::primitives::SlotIndex;
 use crate::eth::primitives::StratusError;
@@ -26,7 +27,7 @@ pub trait TemporaryStorage: Send + Sync + 'static {
     fn set_pending_block_number(&self, number: BlockNumber) -> anyhow::Result<()>;
 
     // Retrieves the block number being mined.
-    fn read_pending_block_number(&self) -> anyhow::Result<Option<BlockNumber>>;
+    fn read_pending_block_header(&self) -> anyhow::Result<Option<PendingBlockHeader>>;
 
     // -------------------------------------------------------------------------
     // Block and executions
@@ -35,17 +36,17 @@ pub trait TemporaryStorage: Send + Sync + 'static {
     /// Sets the pending external block being re-executed.
     fn set_pending_external_block(&self, block: ExternalBlock) -> anyhow::Result<()>;
 
-    /// Saves a re-executed transaction to the pending mined block.
-    fn save_execution(&self, tx: TransactionExecution, check_conflicts: bool) -> Result<(), StratusError>;
-
-    /// Retrieves the pending transactions of the pending block.
-    fn pending_transactions(&self) -> Vec<TransactionExecution>;
-
     /// Finishes the mining of the pending block and starts a new block.
     fn finish_pending_block(&self) -> anyhow::Result<PendingBlock>;
 
-    /// Retrieves a transaction from the storage.
-    fn read_transaction(&self, hash: &Hash) -> anyhow::Result<Option<TransactionExecution>>;
+    /// Saves a transaction execution to the pending mined block.
+    fn save_pending_execution(&self, tx: TransactionExecution, check_conflicts: bool) -> Result<(), StratusError>;
+
+    /// Retrieves all transaction executions from the pending block.
+    fn read_pending_executions(&self) -> Vec<TransactionExecution>;
+
+    /// Retrieves a single transaction execution from the pending block.
+    fn read_pending_execution(&self, hash: &Hash) -> anyhow::Result<Option<TransactionExecution>>;
 
     // -------------------------------------------------------------------------
     // Accounts and slots

--- a/src/eth/storage/temporary_storage.rs
+++ b/src/eth/storage/temporary_storage.rs
@@ -6,7 +6,6 @@ use display_json::DebugAsJson;
 
 use crate::eth::primitives::Account;
 use crate::eth::primitives::Address;
-use crate::eth::primitives::BlockNumber;
 use crate::eth::primitives::ExternalBlock;
 use crate::eth::primitives::Hash;
 use crate::eth::primitives::PendingBlock;
@@ -20,13 +19,13 @@ use crate::eth::storage::InMemoryTemporaryStorage;
 /// Temporary storage (in-between blocks) operations.
 pub trait TemporaryStorage: Send + Sync + 'static {
     // -------------------------------------------------------------------------
-    // Block number
+    // Block header
     // -------------------------------------------------------------------------
 
-    /// Sets the block number being mined.
-    fn set_pending_block_number(&self, number: BlockNumber) -> anyhow::Result<()>;
+    /// Sets the block header being mined.
+    fn set_pending_block_header(&self, header: PendingBlockHeader) -> anyhow::Result<()>;
 
-    // Retrieves the block number being mined.
+    // Retrieves the block header being mined.
     fn read_pending_block_header(&self) -> anyhow::Result<Option<PendingBlockHeader>>;
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Updated `EvmInput` creation to use `PendingBlockHeader` instead of separate `BlockNumber` and current system time
- Modified `Executor` to pass full `PendingBlockHeader` to `EvmInput` creation functions
- Refactored `block_from_local` in `Miner` to use `PendingBlockHeader` for block creation
- Removed unnecessary logic to determine block timestamp from transactions
- Ensures consistent use of pending block timestamp across the codebase


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>evm_input.rs</strong><dd><code>Use pending block timestamp in EvmInput</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/executor/evm_input.rs

<li>Updated <code>EvmInput::from_eth_transaction</code> to use <code>PendingBlockHeader</code> <br>instead of just <code>BlockNumber</code><br> <li> Modified <code>block_timestamp</code> to use <code>pending_header.timestamp</code> instead of <br><code>UnixTime::now()</code><br> <li> Updated <code>EvmInput::from_eth_call</code> to use <code>PendingBlockHeader</code><br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1728/files#diff-9dbdf7472d01464e439067cbd23dfe3648c7fb38a307bee0cf8642ad16a1a252">+7/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>executor.rs</strong><dd><code>Update Executor to use PendingBlockHeader</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/executor/executor.rs

<li>Updated <code>Executor::execute_transaction</code> to pass <code>pending_header</code> instead <br>of <code>pending_header.number</code><br> <li> Modified <code>Executor::execute_call</code> to pass <code>pending_header</code> instead of <br><code>pending_header.number</code><br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1728/files#diff-6b460d7dee8280c0287e8d9d9d59cf66a57ec9fed1bc003c6ede6fef60c7376b">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>miner.rs</strong><dd><code>Refactor block creation to use PendingBlockHeader</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/miner/miner.rs

<li>Updated <code>block_from_local</code> function to use <code>PendingBlockHeader</code> instead of <br><code>BlockNumber</code><br> <li> Removed the logic to determine <code>block_timestamp</code> from transactions<br> <li> Used <code>pending_header.timestamp</code> directly in <code>Block::new</code><br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1728/files#diff-16f448afc7dae3e8e802f676a86dbd7051e19f6c17cbbeb53eb730d726372629">+4/-10</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information