### PR TITLE
refactor: receive external block in mine_external methods

### DIFF
--- a/src/bin/importer_offline.rs
+++ b/src/bin/importer_offline.rs
@@ -157,10 +157,10 @@ fn execute_block_importer(
 
             // re-execute (and import) block
             batch_tx_len += block.transactions.len();
-            executor.execute_external_block(block, &mut receipts)?;
+            executor.execute_external_block(block.clone(), &mut receipts)?;
 
             // mine and save block
-            miner.mine_external_and_commit()?;
+            miner.mine_external_and_commit(block)?;
         }
         let batch_duration = before_block.elapsed();
 

--- a/src/eth/follower/importer/importer.rs
+++ b/src/eth/follower/importer/importer.rs
@@ -180,7 +180,7 @@ impl Importer {
             let mut receipts = ExternalReceipts::from(receipts);
             #[cfg(feature = "metrics")]
             let receipts_len = receipts.len();
-            if let Err(e) = executor.execute_external_block(block, &mut receipts) {
+            if let Err(e) = executor.execute_external_block(block.clone(), &mut receipts) {
                 let message = GlobalState::shutdown_from(TASK_NAME, "failed to reexecute external block");
                 return log_and_err!(reason = e, message);
             };
@@ -200,7 +200,7 @@ impl Importer {
                 );
             }
 
-            if let Err(e) = miner.mine_external_and_commit() {
+            if let Err(e) = miner.mine_external_and_commit(block) {
                 let message = GlobalState::shutdown_from(TASK_NAME, "failed to mine external block");
                 return log_and_err!(reason = e, message);
             };


### PR DESCRIPTION
### **User description**
Pass external_block to miner via parameter instead of temporary storage. The temporary storage methods will be removed in a next PR with unnecessary clones added in this PR.


___

### **PR Type**
Enhancement


___

### **Description**
- Refactored the `mine_external` and `mine_external_and_commit` methods to receive the external block as a parameter instead of retrieving it from temporary storage.
- Updated the `execute_external_block` calls to clone the block before passing it, to avoid unnecessary borrowing issues.
- Removed the code that retrieves the external block from `block.external_block` in the `mine_external` method.
- These changes improve the code structure and prepare for the removal of temporary storage methods in a future PR.
- Note: Some unnecessary clones were added in this PR and will be addressed in a subsequent PR.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>importer_offline.rs</strong><dd><code>Update block handling in offline importer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/bin/importer_offline.rs

<li>Modified <code>execute_external_block</code> to clone the block before passing it<br> <li> Updated <code>mine_external_and_commit</code> to pass the block as a parameter<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1731/files#diff-9fef7d584818c3db119ea1cd0952a57a953751f85f93ca813af861c4c737c53a">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>importer.rs</strong><dd><code>Refactor block execution and mining in importer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/follower/importer/importer.rs

<li>Modified <code>execute_external_block</code> to clone the block before passing it<br> <li> Updated <code>mine_external_and_commit</code> to pass the block as a parameter<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1731/files#diff-bd50f502f039aff8f75753bc780d281ae7d7936fadc9d53482084c647aec94ca">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>miner.rs</strong><dd><code>Refactor miner to receive external block as parameter</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/miner/miner.rs

<li>Modified <code>mine_external_and_commit</code> to accept <code>external_block</code> as a <br>parameter<br> <li> Updated <code>mine_external</code> to accept <code>external_block</code> as a parameter<br> <li> Removed the code that retrieves <code>external_block</code> from <br><code>block.external_block</code><br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1731/files#diff-16f448afc7dae3e8e802f676a86dbd7051e19f6c17cbbeb53eb730d726372629">+3/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information