### PR TITLE
refactor: remove set_pending_external_block

### DIFF
--- a/src/eth/executor/executor.rs
+++ b/src/eth/executor/executor.rs
@@ -241,7 +241,6 @@ impl Executor {
         let block_number = block.number();
         let block_timestamp = block.timestamp();
         let block_transactions = mem::take(&mut block.transactions);
-        self.storage.set_pending_external_block(block)?;
         self.storage.set_pending_block_number(block_number)?;
 
         // determine how to execute each transaction

--- a/src/eth/storage/inmemory/inmemory_temporary.rs
+++ b/src/eth/storage/inmemory/inmemory_temporary.rs
@@ -13,7 +13,6 @@ use crate::eth::primitives::BlockNumber;
 use crate::eth::primitives::EvmExecution;
 use crate::eth::primitives::ExecutionConflicts;
 use crate::eth::primitives::ExecutionConflictsBuilder;
-use crate::eth::primitives::ExternalBlock;
 use crate::eth::primitives::Hash;
 use crate::eth::primitives::PendingBlock;
 use crate::eth::primitives::PendingBlockHeader;
@@ -135,12 +134,6 @@ impl TemporaryStorage for InMemoryTemporaryStorage {
     // -------------------------------------------------------------------------
     // Block and executions
     // -------------------------------------------------------------------------
-
-    fn set_pending_external_block(&self, block: ExternalBlock) -> anyhow::Result<()> {
-        let mut states = self.lock_write();
-        states.head.require_pending_block_mut()?.external_block = Some(block);
-        Ok(())
-    }
 
     fn save_pending_execution(&self, tx: TransactionExecution, check_conflicts: bool) -> Result<(), StratusError> {
         // check conflicts

--- a/src/eth/storage/stratus_storage.rs
+++ b/src/eth/storage/stratus_storage.rs
@@ -9,7 +9,6 @@ use crate::eth::primitives::Address;
 use crate::eth::primitives::Block;
 use crate::eth::primitives::BlockFilter;
 use crate::eth::primitives::BlockNumber;
-use crate::eth::primitives::ExternalBlock;
 use crate::eth::primitives::Hash;
 use crate::eth::primitives::LogFilter;
 use crate::eth::primitives::LogMined;
@@ -183,19 +182,6 @@ impl StratusStorage {
     // -------------------------------------------------------------------------
     // Accounts and slots
     // -------------------------------------------------------------------------
-
-    pub fn set_pending_external_block(&self, block: ExternalBlock) -> Result<(), StratusError> {
-        tracing::debug!(storage = %label::TEMP, block_number = %block.number(), "setting pending external block");
-
-        timed(|| self.temp.set_pending_external_block(block))
-            .with(|m| {
-                metrics::inc_storage_set_pending_external_block(m.elapsed, label::TEMP, m.result.is_ok());
-                if let Err(ref e) = m.result {
-                    tracing::error!(reason = ?e, "failed to set pending external block");
-                }
-            })
-            .map_err(Into::into)
-    }
 
     pub fn save_accounts(&self, accounts: Vec<Account>) -> Result<(), StratusError> {
         #[cfg(feature = "tracing")]

--- a/src/eth/storage/temporary_storage.rs
+++ b/src/eth/storage/temporary_storage.rs
@@ -7,7 +7,6 @@ use display_json::DebugAsJson;
 use crate::eth::primitives::Account;
 use crate::eth::primitives::Address;
 use crate::eth::primitives::BlockNumber;
-use crate::eth::primitives::ExternalBlock;
 use crate::eth::primitives::Hash;
 use crate::eth::primitives::PendingBlock;
 use crate::eth::primitives::PendingBlockHeader;
@@ -32,9 +31,6 @@ pub trait TemporaryStorage: Send + Sync + 'static {
     // -------------------------------------------------------------------------
     // Block and executions
     // -------------------------------------------------------------------------
-
-    /// Sets the pending external block being re-executed.
-    fn set_pending_external_block(&self, block: ExternalBlock) -> anyhow::Result<()>;
 
     /// Finishes the mining of the pending block and starts a new block.
     fn finish_pending_block(&self) -> anyhow::Result<PendingBlock>;


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Removed the `set_pending_external_block` function and its usage across multiple files
- Eliminated the `ExternalBlock` import where it's no longer needed
- Removed associated logging and metrics for setting pending external blocks
- Updated the `TemporaryStorage` trait to remove the `set_pending_external_block` method
- This change simplifies the codebase by removing unused functionality related to external blocks


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>executor.rs</strong><dd><code>Remove external block setting in executor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/executor/executor.rs

<li>Removed the call to <code>self.storage.set_pending_external_block(block)</code><br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1732/files#diff-6b460d7dee8280c0287e8d9d9d59cf66a57ec9fed1bc003c6ede6fef60c7376b">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>inmemory_temporary.rs</strong><dd><code>Remove external block handling in temporary storage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/inmemory/inmemory_temporary.rs

<li>Removed import of <code>ExternalBlock</code><br> <li> Removed <code>set_pending_external_block</code> function<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1732/files#diff-6f4ee832c01927be4b428028743a37022368d351f09fd177f59e81a5a58dd661">+0/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>stratus_storage.rs</strong><dd><code>Remove external block handling in stratus storage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/stratus_storage.rs

<li>Removed import of <code>ExternalBlock</code><br> <li> Removed <code>set_pending_external_block</code> function and associated logging and <br>metrics<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1732/files#diff-3b2e36e47959decdfe26b2c4fab90b41f9242bfdad29cc43b2377ee851f4f40a">+0/-14</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>temporary_storage.rs</strong><dd><code>Remove external block trait method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/temporary_storage.rs

<li>Removed import of <code>ExternalBlock</code><br> <li> Removed <code>set_pending_external_block</code> function from <code>TemporaryStorage</code> <br>trait<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1732/files#diff-58337f46f036f808e0166f195e0ed5dfbfdc092fc1665c3424f01d799a5195de">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information