### PR TITLE
enha: add client identification to subscription metrics

### DIFF
--- a/src/eth/rpc/rpc_client_app.rs
+++ b/src/eth/rpc/rpc_client_app.rs
@@ -3,7 +3,7 @@ use std::fmt::Display;
 #[cfg(feature = "metrics")]
 use crate::infra::metrics::MetricLabelValue;
 
-#[derive(Debug, Clone, strum::EnumIs, PartialEq)]
+#[derive(Debug, Clone, strum::EnumIs, PartialEq, Eq, Hash)]
 pub enum RpcClientApp {
     /// Client application identified itself.
     Identified(String),

--- a/src/eth/rpc/rpc_server.rs
+++ b/src/eth/rpc/rpc_server.rs
@@ -1103,19 +1103,28 @@ async fn eth_subscribe(params: Params<'_>, pending: PendingSubscriptionSink, ctx
     match event.deref() {
         "newPendingTransactions" => {
             drop(method_enter);
-            ctx.subs.add_new_pending_txs(client, pending.accept().await?).instrument(method_span).await;
+            ctx.subs
+                .add_new_pending_txs_subscription(client, pending.accept().await?)
+                .instrument(method_span)
+                .await;
         }
 
         "newHeads" => {
             drop(method_enter);
-            ctx.subs.add_new_heads(client, pending.accept().await?).instrument(method_span).await;
+            ctx.subs
+                .add_new_heads_subscription(client, pending.accept().await?)
+                .instrument(method_span)
+                .await;
         }
 
         "logs" => {
             let (_, filter) = next_rpc_param_or_default::<LogFilterInput>(params)?;
             let filter = filter.parse(&ctx.storage)?;
             drop(method_enter);
-            ctx.subs.add_logs(client, filter, pending.accept().await?).instrument(method_span).await;
+            ctx.subs
+                .add_logs_subscription(client, filter, pending.accept().await?)
+                .instrument(method_span)
+                .await;
         }
 
         // unsupported

--- a/src/eth/rpc/rpc_subscriptions.rs
+++ b/src/eth/rpc/rpc_subscriptions.rs
@@ -426,7 +426,15 @@ impl RpcSubscriptionsConnected {
 
 #[cfg(feature = "metrics")]
 mod sub_metrics {
-    use super::*;
+    use super::label;
+    use super::metrics;
+    use super::ConnectionId;
+    use super::HashMap;
+    use super::Itertools;
+    use super::LogFilter;
+    use super::RpcClientApp;
+    use super::Subscription;
+    use super::SubscriptionWithFilter;
 
     pub fn update_new_pending_txs_subscription_metrics(subs: &HashMap<ConnectionId, Subscription>) {
         update_subscription_count(label::PENDING_TXS, subs.values());

--- a/src/infra/metrics/metrics_definitions.rs
+++ b/src/infra/metrics/metrics_definitions.rs
@@ -14,7 +14,7 @@ metrics! {
     histogram_duration rpc_requests_finished{client, method, contract, function, result, result_code, success},
 
     "Number of JSON-RPC subscriptions active right now."
-    gauge rpc_subscriptions_active{subscription}
+    gauge rpc_subscriptions_active{subscription, client}
 }
 
 // Storage reads.


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Implemented client-specific metrics for RPC subscriptions, allowing for more granular tracking of subscription activity.
- Refactored subscription-related methods for consistency and improved naming conventions.
- Enhanced `RpcClientApp` enum with additional trait derivations (`Eq` and `Hash`) for better functionality.
- Introduced a new `sub_metrics` module to centralize and organize subscription metric updates.
- Updated the `rpc_subscriptions_active` gauge metric to include a `client` parameter for more detailed monitoring.
- Improved code organization and readability throughout the affected files.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rpc_client_app.rs</strong><dd><code>Enhance RpcClientApp enum traits</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/rpc/rpc_client_app.rs

- Added `Eq` and `Hash` trait derivations to `RpcClientApp` enum



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1733/files#diff-58a4136b4354d7489c12136de37282c85be59f542ed4d605ceead0c00ba5ddc3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rpc_server.rs</strong><dd><code>Refactor subscription method names and calls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/rpc/rpc_server.rs

<li>Renamed subscription methods for consistency<br> <li> Updated method calls to match new names<br> <li> Improved code formatting for better readability<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1733/files#diff-835ba255c9a5c1fe0e13285bc39e058e1c74422e5e03ebba483c9d8a15c45405">+12/-3</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rpc_subscriptions.rs</strong><dd><code>Implement client-specific subscription metrics</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/rpc/rpc_subscriptions.rs

<li>Introduced client-specific metrics for subscriptions<br> <li> Added new <code>sub_metrics</code> module for handling subscription metrics<br> <li> Updated subscription methods to use new metrics<br> <li> Refactored metric update logic for better organization<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1733/files#diff-a07ba1157cec6586a0520b8dfb11e9d073359af24471ac286ff5eaa2669d355c">+50/-13</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>metrics_definitions.rs</strong><dd><code>Add client parameter to subscription metric</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/infra/metrics/metrics_definitions.rs

<li>Added <code>client</code> parameter to <code>rpc_subscriptions_active</code> gauge metric<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1733/files#diff-2ca1adc579301e6de5f9e1d69eb1ed2f70aeee0f3b54fe113346040b4eab652b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information