### PR TITLE
enha: standardize behavior when rwlock is poisoned

### DIFF
--- a/src/eth/follower/importer/importer_config.rs
+++ b/src/eth/follower/importer/importer_config.rs
@@ -94,9 +94,9 @@ impl ImporterConfig {
                 ctx.set_consensus(Some(consensus));
             }
             None => {
-                tracing::error!("failed to update consensus: consensus is None");
+                tracing::error!("failed to update consensus: Consensus is not set.");
                 GlobalState::set_importer_shutdown(true);
-                return Err(StratusError::ConsensusUpdateError);
+                return Err(StratusError::ConsensusNotSet);
             }
         }
 

--- a/src/eth/follower/importer/importer_config.rs
+++ b/src/eth/follower/importer/importer_config.rs
@@ -89,25 +89,14 @@ impl ImporterConfig {
             }
         };
 
-        {
-            let mut consensus_lock = match ctx.consensus.write() {
-                Ok(consensus_lock) => consensus_lock,
-                Err(poisoned) => {
-                    tracing::error!("consensus write lock was poisoned");
-                    ctx.consensus.clear_poison();
-                    poisoned.into_inner()
-                }
-            };
-
-            match consensus {
-                Some(consensus) => {
-                    *consensus_lock = Some(consensus);
-                }
-                None => {
-                    tracing::error!("failed to update consensus: consensus is None");
-                    GlobalState::set_importer_shutdown(true);
-                    return Err(StratusError::ConsensusUpdateError);
-                }
+        match consensus {
+            Some(consensus) => {
+                ctx.set_consensus(Some(consensus));
+            }
+            None => {
+                tracing::error!("failed to update consensus: consensus is None");
+                GlobalState::set_importer_shutdown(true);
+                return Err(StratusError::ConsensusUpdateError);
             }
         }
 

--- a/src/eth/follower/importer/importer_config.rs
+++ b/src/eth/follower/importer/importer_config.rs
@@ -94,6 +94,7 @@ impl ImporterConfig {
                 Ok(lock) => lock,
                 Err(poisoned) => {
                     tracing::error!("consensus write lock was poisoned");
+                    ctx.consensus.clear_poison();
                     poisoned.into_inner()
                 }
             };

--- a/src/eth/follower/importer/importer_config.rs
+++ b/src/eth/follower/importer/importer_config.rs
@@ -91,7 +91,7 @@ impl ImporterConfig {
 
         {
             let mut consensus_lock = match ctx.consensus.write() {
-                Ok(lock) => lock,
+                Ok(consensus_lock) => consensus_lock,
                 Err(poisoned) => {
                     tracing::error!("consensus write lock was poisoned");
                     ctx.consensus.clear_poison();

--- a/src/eth/primitives/stratus_error.rs
+++ b/src/eth/primitives/stratus_error.rs
@@ -169,9 +169,9 @@ pub enum StratusError {
     #[strum(props(kind = "internal"))]
     ConsensusSet,
 
-    #[error("Failed to update consensus.")]
+    #[error("Failed to update consensus: Consensus is not set.")]
     #[strum(props(kind = "internal"))]
-    ConsensusUpdateError,
+    ConsensusNotSet,
 
     // -------------------------------------------------------------------------
     // Unexpected

--- a/src/eth/primitives/stratus_error.rs
+++ b/src/eth/primitives/stratus_error.rs
@@ -127,10 +127,6 @@ pub enum StratusError {
     #[strum(props(kind = "internal"))]
     MinerModeConflict,
 
-    #[error("Failed to acquire lock on miner mode.")]
-    #[strum(props(kind = "internal"))]
-    MinerModeLockFailed,
-
     #[error("Miner mode change to ({miner_mode}) is unsupported.")]
     #[strum(props(kind = "internal"))]
     MinerModeChangeUnsupported { miner_mode: &'static str },
@@ -176,10 +172,6 @@ pub enum StratusError {
     #[error("Failed to update consensus.")]
     #[strum(props(kind = "internal"))]
     ConsensusUpdateError,
-
-    #[error("Failed to acquire lock on consensus.")]
-    #[strum(props(kind = "internal"))]
-    ConsensusLockFailed,
 
     // -------------------------------------------------------------------------
     // Unexpected

--- a/src/eth/rpc/rpc_server.rs
+++ b/src/eth/rpc/rpc_server.rs
@@ -272,7 +272,7 @@ async fn stratus_health(_: Params<'_>, context: Arc<RpcContext>, _: Extensions) 
     let should_serve = match GlobalState::get_node_mode() {
         NodeMode::Leader => true,
         NodeMode::Follower => match context.consensus() {
-            Some(consensus) => tokio::task::block_in_place(|| Handle::current().block_on(consensus.should_serve())),
+            Some(consensus) => consensus.should_serve().await,
             None => false,
         },
     };

--- a/src/eth/rpc/rpc_server.rs
+++ b/src/eth/rpc/rpc_server.rs
@@ -278,7 +278,7 @@ async fn stratus_health(_: Params<'_>, context: Arc<RpcContext>, _: Extensions) 
                     tracing::error!("consensus read lock was poisoned");
                     context.consensus.clear_poison();
                     poisoned.into_inner()
-                },
+                }
             };
             match consensus_lock.as_ref() {
                 Some(consensus) => tokio::task::block_in_place(|| Handle::current().block_on(consensus.should_serve())),
@@ -456,7 +456,7 @@ fn stratus_shutdown_importer(_: Params<'_>, ctx: &RpcContext, _: &Extensions) ->
                 tracing::error!("consensus read lock was poisoned");
                 ctx.consensus.clear_poison();
                 poisoned.into_inner()
-            },
+            }
         };
         if consensus_lock.is_none() {
             tracing::error!("importer is already shut down");
@@ -471,7 +471,7 @@ fn stratus_shutdown_importer(_: Params<'_>, ctx: &RpcContext, _: &Extensions) ->
                 tracing::error!("consensus write lock was poisoned");
                 ctx.consensus.clear_poison();
                 poisoned.into_inner()
-            },
+            }
         };
         *consensus_lock = None;
     }
@@ -537,7 +537,7 @@ async fn change_miner_mode(new_mode: MinerMode, ctx: &RpcContext) -> Result<Json
                         tracing::error!("consensus read lock was poisoned");
                         ctx.consensus.clear_poison();
                         poisoned.into_inner()
-                    },
+                    }
                 };
                 if consensus_lock.is_some() {
                     tracing::error!("cannot change miner mode to Interval with consensus set");
@@ -938,7 +938,7 @@ fn eth_send_raw_transaction(params: Params<'_>, ctx: Arc<RpcContext>, ext: Exten
                     tracing::error!("consensus read lock was poisoned");
                     ctx.consensus.clear_poison();
                     poisoned.into_inner()
-                },
+                }
             };
             match consensus_lock.as_ref() {
                 Some(consensus) => match Handle::current().block_on(consensus.forward_to_leader(tx_hash, tx_data, ext.rpc_client())) {

--- a/src/eth/rpc/rpc_server.rs
+++ b/src/eth/rpc/rpc_server.rs
@@ -273,7 +273,7 @@ async fn stratus_health(_: Params<'_>, context: Arc<RpcContext>, _: Extensions) 
         NodeMode::Leader => true,
         NodeMode::Follower => {
             let consensus_lock = match context.consensus.read() {
-                Ok(lock) => lock,
+                Ok(consensus_lock) => consensus_lock,
                 Err(poisoned) => {
                     tracing::error!("consensus read lock was poisoned");
                     context.consensus.clear_poison();
@@ -451,7 +451,7 @@ fn stratus_shutdown_importer(_: Params<'_>, ctx: &RpcContext, _: &Extensions) ->
 
     if GlobalState::is_importer_shutdown() {
         let consensus_lock = match ctx.consensus.read() {
-            Ok(lock) => lock,
+            Ok(consensus_lock) => consensus_lock,
             Err(poisoned) => {
                 tracing::error!("consensus read lock was poisoned");
                 ctx.consensus.clear_poison();
@@ -466,7 +466,7 @@ fn stratus_shutdown_importer(_: Params<'_>, ctx: &RpcContext, _: &Extensions) ->
 
     {
         let mut consensus_lock = match ctx.consensus.write() {
-            Ok(lock) => lock,
+            Ok(consensus_lock) => consensus_lock,
             Err(poisoned) => {
                 tracing::error!("consensus write lock was poisoned");
                 ctx.consensus.clear_poison();
@@ -532,7 +532,7 @@ async fn change_miner_mode(new_mode: MinerMode, ctx: &RpcContext) -> Result<Json
 
             {
                 let consensus_lock = match ctx.consensus.read() {
-                    Ok(lock) => lock,
+                    Ok(consensus_lock) => consensus_lock,
                     Err(poisoned) => {
                         tracing::error!("consensus read lock was poisoned");
                         ctx.consensus.clear_poison();
@@ -933,7 +933,7 @@ fn eth_send_raw_transaction(params: Params<'_>, ctx: Arc<RpcContext>, ext: Exten
         },
         NodeMode::Follower => {
             let consensus_lock = match ctx.consensus.read() {
-                Ok(lock) => lock,
+                Ok(consensus_lock) => consensus_lock,
                 Err(poisoned) => {
                     tracing::error!("consensus read lock was poisoned");
                     ctx.consensus.clear_poison();

--- a/src/eth/rpc/rpc_server.rs
+++ b/src/eth/rpc/rpc_server.rs
@@ -276,6 +276,7 @@ async fn stratus_health(_: Params<'_>, context: Arc<RpcContext>, _: Extensions) 
                 Ok(lock) => lock,
                 Err(poisoned) => {
                     tracing::error!("consensus read lock was poisoned");
+                    context.consensus.clear_poison();
                     poisoned.into_inner()
                 },
             };
@@ -453,6 +454,7 @@ fn stratus_shutdown_importer(_: Params<'_>, ctx: &RpcContext, _: &Extensions) ->
             Ok(lock) => lock,
             Err(poisoned) => {
                 tracing::error!("consensus read lock was poisoned");
+                ctx.consensus.clear_poison();
                 poisoned.into_inner()
             },
         };

--- a/src/eth/rpc/rpc_server.rs
+++ b/src/eth/rpc/rpc_server.rs
@@ -271,20 +271,10 @@ async fn stratus_health(_: Params<'_>, context: Arc<RpcContext>, _: Extensions) 
 
     let should_serve = match GlobalState::get_node_mode() {
         NodeMode::Leader => true,
-        NodeMode::Follower => {
-            let consensus_lock = match context.consensus.read() {
-                Ok(consensus_lock) => consensus_lock,
-                Err(poisoned) => {
-                    tracing::error!("consensus read lock was poisoned");
-                    context.consensus.clear_poison();
-                    poisoned.into_inner()
-                }
-            };
-            match consensus_lock.as_ref() {
-                Some(consensus) => tokio::task::block_in_place(|| Handle::current().block_on(consensus.should_serve())),
-                None => false,
-            }
-        }
+        NodeMode::Follower => match context.consensus() {
+            Some(consensus) => tokio::task::block_in_place(|| Handle::current().block_on(consensus.should_serve())),
+            None => false,
+        },
     };
 
     if not(should_serve) {
@@ -449,32 +439,12 @@ fn stratus_shutdown_importer(_: Params<'_>, ctx: &RpcContext, _: &Extensions) ->
         return Err(StratusError::StratusNotFollower);
     }
 
-    if GlobalState::is_importer_shutdown() {
-        let consensus_lock = match ctx.consensus.read() {
-            Ok(consensus_lock) => consensus_lock,
-            Err(poisoned) => {
-                tracing::error!("consensus read lock was poisoned");
-                ctx.consensus.clear_poison();
-                poisoned.into_inner()
-            }
-        };
-        if consensus_lock.is_none() {
-            tracing::error!("importer is already shut down");
-            return Err(StratusError::ImporterAlreadyShutdown);
-        }
+    if GlobalState::is_importer_shutdown() && ctx.consensus().is_none() {
+        tracing::error!("importer is already shut down");
+        return Err(StratusError::ImporterAlreadyShutdown);
     }
 
-    {
-        let mut consensus_lock = match ctx.consensus.write() {
-            Ok(consensus_lock) => consensus_lock,
-            Err(poisoned) => {
-                tracing::error!("consensus write lock was poisoned");
-                ctx.consensus.clear_poison();
-                poisoned.into_inner()
-            }
-        };
-        *consensus_lock = None;
-    }
+    ctx.set_consensus(None);
 
     const TASK_NAME: &str = "rpc-server::importer-shutdown";
     GlobalState::shutdown_importer_from(TASK_NAME, "received importer shutdown request");
@@ -530,19 +500,9 @@ async fn change_miner_mode(new_mode: MinerMode, ctx: &RpcContext) -> Result<Json
         MinerMode::Interval(duration) => {
             tracing::info!(duration = ?duration, "changing miner mode to Interval");
 
-            {
-                let consensus_lock = match ctx.consensus.read() {
-                    Ok(consensus_lock) => consensus_lock,
-                    Err(poisoned) => {
-                        tracing::error!("consensus read lock was poisoned");
-                        ctx.consensus.clear_poison();
-                        poisoned.into_inner()
-                    }
-                };
-                if consensus_lock.is_some() {
-                    tracing::error!("cannot change miner mode to Interval with consensus set");
-                    return Err(StratusError::ConsensusSet);
-                }
+            if ctx.consensus().is_some() {
+                tracing::error!("cannot change miner mode to Interval with consensus set");
+                return Err(StratusError::ConsensusSet);
             }
 
             ctx.miner.start_interval_mining(duration).await;
@@ -931,26 +891,16 @@ fn eth_send_raw_transaction(params: Params<'_>, ctx: Arc<RpcContext>, ext: Exten
                 Err(e)
             }
         },
-        NodeMode::Follower => {
-            let consensus_lock = match ctx.consensus.read() {
-                Ok(consensus_lock) => consensus_lock,
-                Err(poisoned) => {
-                    tracing::error!("consensus read lock was poisoned");
-                    ctx.consensus.clear_poison();
-                    poisoned.into_inner()
-                }
-            };
-            match consensus_lock.as_ref() {
-                Some(consensus) => match Handle::current().block_on(consensus.forward_to_leader(tx_hash, tx_data, ext.rpc_client())) {
-                    Ok(hash) => Ok(hex_data(hash)),
-                    Err(e) => Err(e),
-                },
-                None => {
-                    tracing::error!("unable to forward transaction because consensus is temporarily unavailable for follower node");
-                    Err(StratusError::ConsensusUnavailable)
-                }
+        NodeMode::Follower => match ctx.consensus() {
+            Some(consensus) => match Handle::current().block_on(consensus.forward_to_leader(tx_hash, tx_data, ext.rpc_client())) {
+                Ok(hash) => Ok(hex_data(hash)),
+                Err(e) => Err(e),
+            },
+            None => {
+                tracing::error!("unable to forward transaction because consensus is temporarily unavailable for follower node");
+                Err(StratusError::ConsensusUnavailable)
             }
-        }
+        },
     }
 }
 


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Standardized the behavior when RwLocks are poisoned across multiple files
- Improved error handling by replacing `map_err` with `match` statements
- Implemented recovery of data from poisoned locks using `into_inner()`
- Removed redundant error variants related to lock failures
- Enhanced code consistency and robustness in handling concurrent access errors


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>importer_config.rs</strong><dd><code>Improve RwLock error handling in ImporterConfig</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/follower/importer/importer_config.rs

<li>Modified error handling for poisoned RwLock in <code>ImporterConfig</code> <br>implementation<br> <li> Replaced <code>map_err</code> with <code>match</code> statement for better error handling<br> <li> Now uses <code>into_inner()</code> to recover data from poisoned lock<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1734/files#diff-d6208b041b3fff7e5d6e8ed530417cc9ac4d6037a7a9737370e05322418d1d34">+8/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rpc_server.rs</strong><dd><code>Standardize RwLock error handling in RPC server</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/rpc/rpc_server.rs

<li>Updated error handling for poisoned RwLocks in multiple functions<br> <li> Replaced <code>map_err</code> with <code>match</code> statements for better error handling<br> <li> Now uses <code>into_inner()</code> to recover data from poisoned locks<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1734/files#diff-835ba255c9a5c1fe0e13285bc39e058e1c74422e5e03ebba483c9d8a15c45405">+40/-25</a>&nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>stratus_error.rs</strong><dd><code>Remove redundant lock failure error variants</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/stratus_error.rs

<li>Removed <code>MinerModeLockFailed</code> and <code>ConsensusLockFailed</code> error variants<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1734/files#diff-301cded01d772388e3e5c08ede093b91c3e4478c08e11a48f70e3d44351385fb">+0/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information