### PR TITLE
refactor: document and rename topics method

### DIFF
--- a/src/eth/primitives/execution.rs
+++ b/src/eth/primitives/execution.rs
@@ -131,18 +131,18 @@ impl EvmExecution {
         // compare logs pairs
         for (log_index, (execution_log, receipt_log)) in self.logs.iter().zip(&receipt.logs).enumerate() {
             // compare log topics length
-            if execution_log.topics().len() != receipt_log.topics.len() {
+            if execution_log.topics_non_empty().len() != receipt_log.topics.len() {
                 return log_and_err!(format!(
                     "log topics length mismatch | hash={} log_index={} execution={} receipt={}",
                     receipt.hash(),
                     log_index,
-                    execution_log.topics().len(),
+                    execution_log.topics_non_empty().len(),
                     receipt_log.topics.len(),
                 ));
             }
 
             // compare log topics content
-            for (topic_index, (execution_log_topic, receipt_log_topic)) in execution_log.topics().iter().zip(&receipt_log.topics).enumerate() {
+            for (topic_index, (execution_log_topic, receipt_log_topic)) in execution_log.topics_non_empty().iter().zip(&receipt_log.topics).enumerate() {
                 if execution_log_topic.as_ref() != receipt_log_topic.as_ref() {
                     return log_and_err!(format!(
                         "log topic content mismatch | hash={} log_index={} topic_index={} execution={} receipt={:#x}",

--- a/src/eth/primitives/log.rs
+++ b/src/eth/primitives/log.rs
@@ -23,12 +23,14 @@ pub struct Log {
 }
 
 impl Log {
-    pub fn topics(&self) -> Vec<LogTopic> {
-        self.topics_array().into_iter().flatten().collect()
+    /// Returns all topics in the log.
+    pub fn topics(&self) -> [Option<LogTopic>; 4] {
+        [self.topic0, self.topic1, self.topic2, self.topic3]
     }
 
-    pub fn topics_array(&self) -> [Option<LogTopic>; 4] {
-        [self.topic0, self.topic1, self.topic2, self.topic3]
+    /// Returns all non-empty topics in the log.
+    pub fn topics_non_empty(&self) -> Vec<LogTopic> {
+        self.topics().into_iter().flatten().collect()
     }
 }
 

--- a/src/eth/primitives/log_filter.rs
+++ b/src/eth/primitives/log_filter.rs
@@ -37,7 +37,7 @@ impl LogFilter {
         }
 
         let filter_topics = &self.original_input.topics;
-        let log_topics = log.log.topics_array();
+        let log_topics = log.log.topics();
 
         // (https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getlogs)
         // Matching rules for filtering topics in `eth_getLogs`:

--- a/src/eth/primitives/log_mined.rs
+++ b/src/eth/primitives/log_mined.rs
@@ -40,9 +40,9 @@ impl LogMined {
         &self.log.address
     }
 
-    /// Returns the topics emitted in the log.
-    pub fn topics(&self) -> Vec<LogTopic> {
-        self.log.topics()
+    /// Returns all non-empty topics in the log.
+    pub fn topics_non_empty(&self) -> Vec<LogTopic> {
+        self.log.topics_non_empty()
     }
 
     /// Serializes itself to JSON-RPC log format.
@@ -77,7 +77,7 @@ impl From<LogMined> for EthersLog {
         Self {
             // log
             address: value.log.address.into(),
-            topics: value.topics().into_iter().map_into().collect_vec(),
+            topics: value.topics_non_empty().into_iter().map_into().collect_vec(),
             data: value.log.data.into(),
             log_index: Some(value.log_index.into()),
             removed: Some(false),

--- a/src/eth/primitives/logs_bloom.rs
+++ b/src/eth/primitives/logs_bloom.rs
@@ -21,7 +21,7 @@ impl LogsBloom {
 
     pub fn accrue_log(&mut self, log: &Log) {
         self.accrue(ethereum_types::BloomInput::Raw(log.address.as_ref()));
-        for topic in log.topics() {
+        for topic in log.topics_non_empty() {
             self.accrue(ethereum_types::BloomInput::Raw(topic.as_ref()));
         }
     }


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Refactored log topic retrieval methods across multiple files:
  - Introduced `topics_non_empty()` method to return only non-empty topics
  - Renamed existing `topics()` method to `topics_non_empty()`
  - Added new `topics()` method to return all topics, including empty ones
- Updated method calls and documentation in related files to reflect these changes
- Improved consistency and clarity in handling log topics throughout the codebase
- Enhanced error messages to provide more accurate information about log topic mismatches


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>execution.rs</strong><dd><code>Update log topic comparison logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/execution.rs

<li>Replaced <code>topics()</code> method calls with <code>topics_non_empty()</code> for log <br>comparison<br> <li> Updated error messages to reflect the new method name<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1735/files#diff-cd13932ed3cbc97c18547275105d872a204eda4ad4bf0c2811b18553b48e9038">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>log.rs</strong><dd><code>Refactor log topic retrieval methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/log.rs

<li>Renamed <code>topics()</code> method to <code>topics_non_empty()</code><br> <li> Added new <code>topics()</code> method returning all topics including empty ones<br> <li> Updated documentation for both methods<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1735/files#diff-c886f14c171107da82c777d17266657e495a804d331b3e4f0ce2f5ddafdb0a69">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>log_filter.rs</strong><dd><code>Update log filter to use new topics method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/log_filter.rs

- Updated `topics_array()` method call to `topics()`



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1735/files#diff-8a77d8af3c5d907f1763771a0823aa4cab0b90e55eb6b7b173943381b7388ff8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>log_mined.rs</strong><dd><code>Refactor mined log topic retrieval</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/log_mined.rs

<li>Renamed <code>topics()</code> method to <code>topics_non_empty()</code><br> <li> Updated method documentation<br> <li> Modified <code>to_json_rpc_log()</code> to use <code>topics_non_empty()</code><br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1735/files#diff-0ce210a69394a14d9a6424cf5ddf8b84c10a535b9ecae1dd34c0dbcff4beaf07">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>logs_bloom.rs</strong><dd><code>Update logs bloom to use new topic method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/logs_bloom.rs

- Updated `accrue_log()` method to use `topics_non_empty()`



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1735/files#diff-c3458b9b7aff3b34de5ff8012c35ed703eba05a6ff9b4fe049ac8a9968d2eb2a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information