### PR TITLE
chore: remove unnecessary check

### DIFF
--- a/src/eth/rpc/rpc_server.rs
+++ b/src/eth/rpc/rpc_server.rs
@@ -375,11 +375,6 @@ async fn stratus_change_to_follower(params: Params<'_>, ctx: Arc<RpcContext>, ex
         });
     }
 
-    if not(ctx.miner.is_paused()) {
-        tracing::error!("miner is currently not paused, cannot change node mode");
-        return Err(StratusError::MinerEnabled);
-    }
-
     let change_miner_mode_result = change_miner_mode(MinerMode::External, &ctx).await;
     if let Err(e) = change_miner_mode_result {
         tracing::error!(reason = ?e, "failed to change miner mode");


### PR DESCRIPTION
### **User description**
This check is already done in the change_miner_mode function that is called below


___

### **PR Type**
Enhancement


___

### **Description**
- Removed unnecessary check for miner pause status in `stratus_change_to_follower` function
- Simplified the logic for changing to follower mode by relying on the existing checks in `change_miner_mode` function
- Improved code efficiency and reduced redundancy
- Maintains the same functionality while streamlining the process


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rpc_server.rs</strong><dd><code>Streamline follower mode transition logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/rpc/rpc_server.rs

<li>Removed redundant check for miner pause status before changing to <br>follower mode<br> <li> Simplified error handling logic in <code>stratus_change_to_follower</code> function<br> <br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1737/files#diff-835ba255c9a5c1fe0e13285bc39e058e1c74422e5e03ebba483c9d8a15c45405">+0/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information