### PR TITLE
chore: remove `MinerEnabled` variant from `StratusError`

### DIFF
--- a/e2e/cloudwalk-contracts/integration/test/leader-follower-change.test.ts
+++ b/e2e/cloudwalk-contracts/integration/test/leader-follower-change.test.ts
@@ -55,7 +55,7 @@ describe("Leader & Follower change integration test", function () {
             "100ms",
         ]);
         expect(response.data.error.code).to.equal(-32603);
-        expect(response.data.error.message).to.equal("Miner is enabled.");
+        expect(response.data.error.message).to.equal("Unexpected error: can't change miner mode from Interval without pausing it first.");
     });
 
     it("Change Leader to Follower should succeed", async function () {

--- a/e2e/cloudwalk-contracts/integration/test/leader-follower-change.test.ts
+++ b/e2e/cloudwalk-contracts/integration/test/leader-follower-change.test.ts
@@ -55,8 +55,8 @@ describe("Leader & Follower change integration test", function () {
             "100ms",
         ]);
         expect(response.data.error.code).to.equal(-32603);
-        expect(response.data.error.message).to.equal(
-            "Unexpected error: can't change miner mode from Interval without pausing it first.",
+        expect(response.data.error.message.split("\n")[0]).to.equal(
+            "Unexpected error: can't change miner mode from Interval without pausing it first",
         );
     });
 

--- a/e2e/cloudwalk-contracts/integration/test/leader-follower-change.test.ts
+++ b/e2e/cloudwalk-contracts/integration/test/leader-follower-change.test.ts
@@ -55,7 +55,9 @@ describe("Leader & Follower change integration test", function () {
             "100ms",
         ]);
         expect(response.data.error.code).to.equal(-32603);
-        expect(response.data.error.message).to.equal("Unexpected error: can't change miner mode from Interval without pausing it first.");
+        expect(response.data.error.message).to.equal(
+            "Unexpected error: can't change miner mode from Interval without pausing it first.",
+        );
     });
 
     it("Change Leader to Follower should succeed", async function () {

--- a/e2e/cloudwalk-contracts/integration/test/leader-follower-miner.test.ts
+++ b/e2e/cloudwalk-contracts/integration/test/leader-follower-miner.test.ts
@@ -66,7 +66,9 @@ describe("Miner mode change integration test", function () {
         updateProviderUrl("stratus");
         const response = await sendAndGetFullResponse("stratus_changeMinerMode", ["external"]);
         expect(response.data.error.code).eq(-32603);
-        expect(response.data.error.message).eq("Miner is enabled.");
+        expect(response.data.error.message).eq(
+            "Unexpected error: can't change miner mode from Interval without pausing it first.",
+        );
     });
 
     it("Miner change to Interval on Follower should fail because importer wasn't stopped", async function () {

--- a/e2e/cloudwalk-contracts/integration/test/leader-follower-miner.test.ts
+++ b/e2e/cloudwalk-contracts/integration/test/leader-follower-miner.test.ts
@@ -66,8 +66,8 @@ describe("Miner mode change integration test", function () {
         updateProviderUrl("stratus");
         const response = await sendAndGetFullResponse("stratus_changeMinerMode", ["external"]);
         expect(response.data.error.code).eq(-32603);
-        expect(response.data.error.message).eq(
-            "Unexpected error: can't change miner mode from Interval without pausing it first.",
+        expect(response.data.error.message.split("\n")[0]).to.equal(
+            "Unexpected error: can't change miner mode from Interval without pausing it first",
         );
     });
 

--- a/justfile
+++ b/justfile
@@ -277,13 +277,13 @@ e2e-leader-follower-up test="brlc":
     mkdir e2e_logs
 
     # Start Stratus with leader flag
-    RUST_LOG=info cargo run --release --bin stratus --features dev -- --leader --block-mode 1s --perm-storage=rocks --rocks-path-prefix=temp_3000 --tokio-console-address=0.0.0.0:6668 --metrics-exporter-address=0.0.0.0:9000 -a 0.0.0.0:3000 > e2e_logs/stratus.log &
+    RUST_BACKTRACE=1 RUST_LOG=info cargo run --release --bin stratus --features dev -- --leader --block-mode 1s --perm-storage=rocks --rocks-path-prefix=temp_3000 --tokio-console-address=0.0.0.0:6668 --metrics-exporter-address=0.0.0.0:9000 -a 0.0.0.0:3000 > e2e_logs/stratus.log &
 
     # Wait for Stratus with leader flag to start
     just _wait_for_stratus 3000
 
     # Start Stratus with follower flag
-    RUST_LOG=info cargo run --release --bin stratus --features dev -- --follower --perm-storage=rocks --rocks-path-prefix=temp_3001 --tokio-console-address=0.0.0.0:6669 --metrics-exporter-address=0.0.0.0:9001 -a 0.0.0.0:3001 -r http://0.0.0.0:3000/ -w ws://0.0.0.0:3000/ > e2e_logs/importer.log &
+    RUST_BACKTRACE=1 RUST_LOG=info cargo run --release --bin stratus --features dev -- --follower --perm-storage=rocks --rocks-path-prefix=temp_3001 --tokio-console-address=0.0.0.0:6669 --metrics-exporter-address=0.0.0.0:9001 -a 0.0.0.0:3001 -r http://0.0.0.0:3000/ -w ws://0.0.0.0:3000/ > e2e_logs/importer.log &
 
     # Wait for Stratus with follower flag to start
     just _wait_for_stratus 3001

--- a/src/eth/primitives/stratus_error.rs
+++ b/src/eth/primitives/stratus_error.rs
@@ -135,10 +135,6 @@ pub enum StratusError {
     #[strum(props(kind = "internal"))]
     MinerModeParamInvalid,
 
-    #[error("Miner is enabled.")]
-    #[strum(props(kind = "internal"))]
-    MinerEnabled,
-
     // -------------------------------------------------------------------------
     // Importer
     // -------------------------------------------------------------------------

--- a/src/eth/rpc/rpc_server.rs
+++ b/src/eth/rpc/rpc_server.rs
@@ -70,6 +70,7 @@ use crate::ext::SerdeResultExt;
 use crate::infra::build_info;
 use crate::infra::metrics;
 use crate::infra::tracing::SpanExt;
+use crate::log_and_err;
 use crate::GlobalState;
 use crate::NodeMode;
 // -----------------------------------------------------------------------------
@@ -479,8 +480,7 @@ async fn change_miner_mode(new_mode: MinerMode, ctx: &RpcContext) -> Result<Json
     }
 
     if not(ctx.miner.is_paused()) && previous_mode.is_interval() {
-        tracing::error!("cannot change miner mode from Interval Mode to another mode without pausing it first");
-        return Err(StratusError::MinerEnabled);
+        return log_and_err!("can't change miner mode from Interval without pausing it first").map_err(Into::into);
     }
 
     match new_mode {


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Removed the `MinerEnabled` variant from the `StratusError` enum in `stratus_error.rs`
- Updated `change_miner_mode` function in `rpc_server.rs` to use a custom error message instead of `StratusError::MinerEnabled`
- Improved error handling by using the `log_and_err!` macro for better logging and error reporting
- Simplified the codebase by removing an unused error variant


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>stratus_error.rs</strong><dd><code>Remove MinerEnabled error variant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/stratus_error.rs

- Removed the `MinerEnabled` variant from the `StratusError` enum



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1738/files#diff-301cded01d772388e3e5c08ede093b91c3e4478c08e11a48f70e3d44351385fb">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rpc_server.rs</strong><dd><code>Replace MinerEnabled error with custom logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/rpc/rpc_server.rs

<li>Replaced <code>StratusError::MinerEnabled</code> with a custom error message using <br><code>log_and_err!</code> macro<br> <li> Added import for <code>log_and_err</code> macro<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1738/files#diff-835ba255c9a5c1fe0e13285bc39e058e1c74422e5e03ebba483c9d8a15c45405">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information