### PR TITLE
fix: just outdated command by bumping cargo to 1.81

### DIFF
--- a/.github/workflows/_setup-e2e.yml
+++ b/.github/workflows/_setup-e2e.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Rust
-        run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.79
+        run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.81
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Rust
-        run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.79
+        run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.81
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -14,6 +14,7 @@ on:
       - 'src/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
+      - 'rust-toolchain.toml'
       - 'tests/fixtures/**'
       - 'static/**'
       - '.sqlx/**'

--- a/.github/workflows/check-features.yml
+++ b/.github/workflows/check-features.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Rust
-        run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.79
+        run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.81
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/comment-tag-report.yml
+++ b/.github/workflows/comment-tag-report.yml
@@ -18,7 +18,7 @@ jobs:
               uses: actions/checkout@v4
 
             - name: Set up Rust
-              run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.79
+              run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.81
 
             - name: Setup Ruby
               uses: ruby/setup-ruby@v1

--- a/.github/workflows/doc-test.yml
+++ b/.github/workflows/doc-test.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Rust
-        run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.79
+        run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.81
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/e2e-contracts-rocks.yml
+++ b/.github/workflows/e2e-contracts-rocks.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Rust
-        run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.79
+        run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.81
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/e2e-contracts.yml
+++ b/.github/workflows/e2e-contracts.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Rust
-        run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.79
+        run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.81
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/e2e-leader-follower.yml
+++ b/.github/workflows/e2e-leader-follower.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Rust
-        run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.79
+        run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.81
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
@@ -72,7 +72,7 @@ jobs:
         run: |
           cargo install killport || true
           cargo install wait-service || true
-      
+
       - name: Install Python 3.12
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/int-test.yml
+++ b/.github/workflows/int-test.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Rust
-        run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.79
+        run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.81
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/outdated.yml
+++ b/.github/workflows/outdated.yml
@@ -18,7 +18,7 @@ jobs:
               uses: actions/checkout@v4
 
             - name: Set up Rust
-              run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.79
+              run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.81
 
             - name: Set up Just
               uses: extractions/setup-just@v2

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Rust
-        run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.79
+        run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.81
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.80"
+channel = "1.81"
 targets = []
 profile = "default"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.79"
+channel = "1.80"
 targets = []
 profile = "default"


### PR DESCRIPTION
### **User description**
running CI to see if this fixes it


___

### **PR Type**
Enhancement


___

### **Description**
- Upgraded the Rust toolchain version from 1.79 to 1.80 in `rust-toolchain.toml`
- This update ensures the project is using the latest stable version of Rust
- May include performance improvements, bug fixes, and new language features introduced in Rust 1.80


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rust-toolchain.toml</strong><dd><code>Upgrade Rust toolchain version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rust-toolchain.toml

- Updated Rust toolchain channel from 1.79 to 1.80



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1744/files#diff-2b1bde2cf3a858b7bf7424cb8bcbf01f35b94dc80b925d9432cbab3319ca9b4e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information