### PR TITLE
enha: identify clients in errors

### DIFF
--- a/src/eth/follower/consensus.rs
+++ b/src/eth/follower/consensus.rs
@@ -32,7 +32,7 @@ pub trait Consensus: Send + Sync {
     }
 
     /// Forwards a transaction to leader.
-    async fn forward_to_leader(&self, tx_hash: Hash, tx_data: Bytes, rpc_client: RpcClientApp) -> Result<Hash, StratusError> {
+    async fn forward_to_leader(&self, tx_hash: Hash, tx_data: Bytes, rpc_client: &RpcClientApp) -> Result<Hash, StratusError> {
         #[cfg(feature = "metrics")]
         let start = metrics::now();
 

--- a/src/eth/rpc/rpc_method_wrapper.rs
+++ b/src/eth/rpc/rpc_method_wrapper.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use cfg_if::cfg_if;
 use jsonrpsee::types::Params;
 use jsonrpsee::Extensions;
 
@@ -8,15 +9,28 @@ use super::RpcContext;
 use crate::eth::primitives::StratusError;
 use crate::infra::metrics::inc_executor_transaction_error_types;
 
-pub fn call_error_metrics_wrapper<F, T>(function: F) -> impl Fn(Params<'_>, Arc<RpcContext>, Extensions) -> Result<T, StratusError> + Clone
-where
-    F: Fn(Params<'_>, Arc<RpcContext>, &Extensions) -> Result<T, StratusError> + Clone,
-{
-    move |params, ctx, extensions| {
-        function(params, ctx, &extensions).inspect_err(|e| {
-            let error_type = <&'static str>::from(e);
-            let client = extensions.rpc_client();
-            inc_executor_transaction_error_types(error_type, client);
-        })
+cfg_if! {
+    if #[cfg(feature = "metrics")] {
+        pub fn call_error_metrics_wrapper<F, T>(function: F) -> impl Fn(Params<'_>, Arc<RpcContext>, Extensions) -> Result<T, StratusError> + Clone
+        where
+            F: Fn(Params<'_>, Arc<RpcContext>, &Extensions) -> Result<T, StratusError> + Clone,
+        {
+            move |params, ctx, extensions| {
+                function(params, ctx, &extensions).inspect_err(|e| {
+                    let error_type = <&'static str>::from(e);
+                    let client = extensions.rpc_client();
+                    inc_executor_transaction_error_types(error_type, client);
+                })
+            }
+        }
+    } else {
+        pub fn call_error_metrics_wrapper<F, T>(function: F) -> impl Fn(Params<'_>, Arc<RpcContext>, Extensions) -> Result<T, StratusError> + Clone
+        where
+            F: Fn(Params<'_>, Arc<RpcContext>, &Extensions) -> Result<T, StratusError> + Clone,
+        {
+            move |params, ctx, extensions| {
+                function(params, ctx, &extensions)
+            }
+        }
     }
 }

--- a/src/eth/rpc/rpc_method_wrapper.rs
+++ b/src/eth/rpc/rpc_method_wrapper.rs
@@ -3,17 +3,20 @@ use std::sync::Arc;
 use jsonrpsee::types::Params;
 use jsonrpsee::Extensions;
 
+use super::rpc_parser::RpcExtensionsExt;
 use super::RpcContext;
 use crate::eth::primitives::StratusError;
 use crate::infra::metrics::inc_executor_transaction_error_types;
 
 pub fn call_error_metrics_wrapper<F, T>(function: F) -> impl Fn(Params<'_>, Arc<RpcContext>, Extensions) -> Result<T, StratusError> + Clone
 where
-    F: Fn(Params<'_>, Arc<RpcContext>, Extensions) -> Result<T, StratusError> + Clone,
+    F: Fn(Params<'_>, Arc<RpcContext>, &Extensions) -> Result<T, StratusError> + Clone,
 {
     move |params, ctx, extensions| {
-        function(params, ctx, extensions).inspect_err(|e| {
-            inc_executor_transaction_error_types(<&'static str>::from(e));
+        function(params, ctx, &extensions).inspect_err(|e| {
+            let error_type = <&'static str>::from(e);
+            let client = extensions.rpc_client();
+            inc_executor_transaction_error_types(error_type, client);
         })
     }
 }

--- a/src/eth/rpc/rpc_parser.rs
+++ b/src/eth/rpc/rpc_parser.rs
@@ -12,15 +12,15 @@ use crate::ext::type_basename;
 /// Extensions for jsonrpsee Extensions.
 pub trait RpcExtensionsExt {
     /// Returns the client performing the JSON-RPC request.
-    fn rpc_client(&self) -> RpcClientApp;
+    fn rpc_client(&self) -> &RpcClientApp;
 
     /// Enters RpcMiddleware request span if present.
     fn enter_middleware_span(&self) -> Option<tracing::span::Entered<'_>>;
 }
 
 impl RpcExtensionsExt for Extensions {
-    fn rpc_client(&self) -> RpcClientApp {
-        self.get::<RpcClientApp>().cloned().unwrap_or(RpcClientApp::Unknown)
+    fn rpc_client(&self) -> &RpcClientApp {
+        self.get::<RpcClientApp>().unwrap_or(&RpcClientApp::Unknown)
     }
 
     fn enter_middleware_span(&self) -> Option<tracing::span::Entered<'_>> {

--- a/src/eth/rpc/rpc_server.rs
+++ b/src/eth/rpc/rpc_server.rs
@@ -1137,7 +1137,7 @@ fn eth_get_storage_at(params: Params<'_>, ctx: Arc<RpcContext>, ext: Extensions)
 // -----------------------------------------------------------------------------
 
 /// Returns an error JSON-RPC response if the client is not allowed to perform the current operation.
-fn reject_unknown_client(client: RpcClientApp) -> Result<(), StratusError> {
+fn reject_unknown_client(client: &RpcClientApp) -> Result<(), StratusError> {
     if client.is_unknown() && not(GlobalState::is_unknown_client_enabled()) {
         return Err(StratusError::RpcClientMissing);
     }

--- a/src/eth/rpc/rpc_server.rs
+++ b/src/eth/rpc/rpc_server.rs
@@ -1054,7 +1054,7 @@ async fn eth_subscribe(params: Params<'_>, pending: PendingSubscriptionSink, ctx
     };
 
     // check subscription limits
-    if let Err(e) = ctx.subs.check_client_subscriptions(ctx.rpc_server.rpc_max_subscriptions, &client).await {
+    if let Err(e) = ctx.subs.check_client_subscriptions(ctx.rpc_server.rpc_max_subscriptions, client).await {
         drop(method_enter);
         pending.reject(e).instrument(method_span).await;
         return Ok(());

--- a/src/eth/rpc/rpc_server.rs
+++ b/src/eth/rpc/rpc_server.rs
@@ -800,7 +800,7 @@ fn eth_estimate_gas(params: Params<'_>, ctx: Arc<RpcContext>, ext: Extensions) -
     }
 }
 
-fn eth_call(params: Params<'_>, ctx: Arc<RpcContext>, ext: Extensions) -> Result<String, StratusError> {
+fn eth_call(params: Params<'_>, ctx: Arc<RpcContext>, ext: &Extensions) -> Result<String, StratusError> {
     // enter span
     let _middleware_enter = ext.enter_middleware_span();
     let _method_enter = info_span!("rpc::eth_call", tx_from = field::Empty, tx_to = field::Empty, filter = field::Empty).entered();
@@ -843,7 +843,7 @@ fn eth_call(params: Params<'_>, ctx: Arc<RpcContext>, ext: Extensions) -> Result
     }
 }
 
-fn eth_send_raw_transaction(params: Params<'_>, ctx: Arc<RpcContext>, ext: Extensions) -> Result<String, StratusError> {
+fn eth_send_raw_transaction(params: Params<'_>, ctx: Arc<RpcContext>, ext: &Extensions) -> Result<String, StratusError> {
     // enter span
     let _middleware_enter = ext.enter_middleware_span();
     let _method_enter = info_span!(

--- a/src/eth/rpc/rpc_subscriptions.rs
+++ b/src/eth/rpc/rpc_subscriptions.rs
@@ -373,28 +373,28 @@ impl RpcSubscriptionsConnected {
     }
 
     /// Adds a new subscriber to `newPendingTransactions` event.
-    pub async fn add_new_pending_txs_subscription(&self, rpc_client: RpcClientApp, sink: SubscriptionSink) {
+    pub async fn add_new_pending_txs_subscription(&self, rpc_client: &RpcClientApp, sink: SubscriptionSink) {
         tracing::info!(
             id = sink.subscription_id().to_string_ext(),
             %rpc_client,
             "subscribing to newPendingTransactions event"
         );
         let mut subs = self.pending_txs.write().await;
-        subs.insert(sink.connection_id(), Subscription::new(rpc_client, sink.into()));
+        subs.insert(sink.connection_id(), Subscription::new(rpc_client.clone(), sink.into()));
 
         #[cfg(feature = "metrics")]
         sub_metrics::update_new_pending_txs_subscription_metrics(&subs);
     }
 
     /// Adds a new subscriber to `newHeads` event.
-    pub async fn add_new_heads_subscription(&self, rpc_client: RpcClientApp, sink: SubscriptionSink) {
+    pub async fn add_new_heads_subscription(&self, rpc_client: &RpcClientApp, sink: SubscriptionSink) {
         tracing::info!(
             id = sink.subscription_id().to_string_ext(),
             %rpc_client,
             "subscribing to newHeads event"
         );
         let mut subs = self.new_heads.write().await;
-        subs.insert(sink.connection_id(), Subscription::new(rpc_client, sink.into()));
+        subs.insert(sink.connection_id(), Subscription::new(rpc_client.clone(), sink.into()));
 
         #[cfg(feature = "metrics")]
         sub_metrics::update_new_heads_subscription_metrics(&subs);
@@ -404,7 +404,7 @@ impl RpcSubscriptionsConnected {
     ///
     /// If the same connection is asking to subscribe with the same filter (which is redundant),
     /// the new subscription will overwrite the newest one.
-    pub async fn add_logs_subscription(&self, rpc_client: RpcClientApp, filter: LogFilter, sink: SubscriptionSink) {
+    pub async fn add_logs_subscription(&self, rpc_client: &RpcClientApp, filter: LogFilter, sink: SubscriptionSink) {
         tracing::info!(
             id = sink.subscription_id().to_string_ext(), ?filter,
             %rpc_client,
@@ -415,7 +415,7 @@ impl RpcSubscriptionsConnected {
 
         // Insert the new subscription, if it already existed with the provided filter, overwrite
         // the previous sink with the newest
-        let inner = Subscription::new(rpc_client, sink.into());
+        let inner = Subscription::new(rpc_client.clone(), sink.into());
         filter_to_subscription_map.insert(filter.clone(), SubscriptionWithFilter::new(inner, filter));
 
         #[cfg(feature = "metrics")]

--- a/src/infra/blockchain_client/blockchain_client.rs
+++ b/src/infra/blockchain_client/blockchain_client.rs
@@ -203,7 +203,7 @@ impl BlockchainClient {
     // -------------------------------------------------------------------------
 
     /// Forwards a transaction to leader.
-    pub async fn send_raw_transaction_to_leader(&self, tx: EthersBytes, rpc_client: RpcClientApp) -> Result<Hash, StratusError> {
+    pub async fn send_raw_transaction_to_leader(&self, tx: EthersBytes, rpc_client: &RpcClientApp) -> Result<Hash, StratusError> {
         tracing::debug!("sending raw transaction to leader");
 
         let tx = to_json_value(tx);

--- a/src/infra/metrics/metrics_definitions.rs
+++ b/src/infra/metrics/metrics_definitions.rs
@@ -133,7 +133,7 @@ metrics! {
     histogram_counter executor_local_call_gas{contract, function},
 
     "Count types of errors when executing a transaction."
-    counter executor_transaction_error_types{error_type}
+    counter executor_transaction_error_types{error_type, client}
 }
 
 metrics! {


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Improved efficiency by changing multiple methods to accept references instead of values, reducing unnecessary cloning.
- Enhanced error metrics by including client information, allowing for better tracking and analysis of errors per client.
- Optimized client handling in RPC middleware and subscriptions, improving performance and reducing memory usage.
- Updated `RpcExtensionsExt` trait to return a reference to `RpcClientApp`, further reducing cloning operations.
- Refactored several RPC methods and blockchain client methods to align with the new reference-based approach.
- Modified metrics definitions to include client information in transaction error types.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>consensus.rs</strong><dd><code>Modify forward_to_leader method signature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/follower/consensus.rs

<li>Changed <code>forward_to_leader</code> method to take <code>rpc_client</code> as a reference <br>instead of by value.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1751/files#diff-d16e08176a325dc1f8ffd7aa8d0bc88f4741e605d930e60ad2b6358e097e2fec">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rpc_method_wrapper.rs</strong><dd><code>Enhance error metrics with client information</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/rpc/rpc_method_wrapper.rs

<li>Updated <code>call_error_metrics_wrapper</code> to pass <code>extensions</code> as a reference.<br> <li> Modified error handling to include client information in metrics.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1751/files#diff-0bbd6e729eb4e018401d1475a5dd64871ecb654be7b3d125c48c204fbddc9545">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rpc_middleware.rs</strong><dd><code>Optimize client handling in RPC middleware</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/rpc/rpc_middleware.rs

<li>Refactored client extraction logic to avoid unnecessary cloning.<br> <li> Improved handling of transaction client information.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1751/files#diff-31b7182aec4416845e60ec9ec16720ae97d31260e1a9c50d601d542dee8776f5">+8/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rpc_parser.rs</strong><dd><code>Modify RpcExtensionsExt trait for efficiency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/rpc/rpc_parser.rs

<li>Changed <code>rpc_client</code> method to return a reference instead of cloning.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1751/files#diff-2756485347ebcee6b3104300efc1ebc605d7ba6ede30878111e2a7d4dbe46b40">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rpc_server.rs</strong><dd><code>Refactor RPC methods to use references</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/rpc/rpc_server.rs

<li>Updated several RPC methods to take <code>ext</code> as a reference.<br> <li> Modified <code>reject_unknown_client</code> to accept a reference to <code>RpcClientApp</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1751/files#diff-835ba255c9a5c1fe0e13285bc39e058e1c74422e5e03ebba483c9d8a15c45405">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rpc_subscriptions.rs</strong><dd><code>Optimize RPC subscription handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/rpc/rpc_subscriptions.rs

<li>Modified subscription methods to take <code>rpc_client</code> as a reference.<br> <li> Updated subscription creation to clone <code>rpc_client</code> only when necessary.<br> <br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1751/files#diff-a07ba1157cec6586a0520b8dfb11e9d073359af24471ac286ff5eaa2669d355c">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>blockchain_client.rs</strong><dd><code>Update blockchain client method signature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/infra/blockchain_client/blockchain_client.rs

<li>Changed <code>send_raw_transaction_to_leader</code> method to take <code>rpc_client</code> as a <br>reference.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1751/files#diff-05af32e93a38a2ab966d4c4c633284d19cada2fa11c1962fabf9c981ff7fd3e6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>metrics_definitions.rs</strong><dd><code>Enhance transaction error metrics with client info</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/infra/metrics/metrics_definitions.rs

- Added `client` field to `executor_transaction_error_types` metric.



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1751/files#diff-2ca1adc579301e6de5f9e1d69eb1ed2f70aeee0f3b54fe113346040b4eab652b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information