### PR TITLE
fix: wrong label order in rpc_subscriptions_active

### DIFF
--- a/src/eth/rpc/rpc_subscriptions.rs
+++ b/src/eth/rpc/rpc_subscriptions.rs
@@ -134,13 +134,13 @@ impl RpcSubscriptions {
                     // Set cleaned subscriptions gauges to zero, which might be the wrong value
                     // they'll be set back to the correct values in the lines below
                     for client in pending_txs_subs_cleaned {
-                        metrics::set_rpc_subscriptions_active(0, client.to_string(), label::PENDING_TXS);
+                        metrics::set_rpc_subscriptions_active(0, label::PENDING_TXS, client.to_string());
                     }
                     for client in new_heads_subs_cleaned {
-                        metrics::set_rpc_subscriptions_active(0, client.to_string(), label::NEW_HEADS);
+                        metrics::set_rpc_subscriptions_active(0, label::NEW_HEADS, client.to_string());
                     }
                     for client in logs_subs_cleaned.into_iter().map(|(client, _)| client) {
-                        metrics::set_rpc_subscriptions_active(0, client.to_string(), label::LOGS);
+                        metrics::set_rpc_subscriptions_active(0, label::LOGS, client.to_string());
                     }
 
                     sub_metrics::update_new_pending_txs_subscription_metrics(&(*subs.pending_txs.read().await));
@@ -458,7 +458,7 @@ mod sub_metrics {
         let client_counts: HashMap<&RpcClientApp, usize> = sub_client_app_iter.map(|sub| &sub.client).counts();
 
         for (client, count) in client_counts {
-            metrics::set_rpc_subscriptions_active(count as u64, client.to_string(), sub_label);
+            metrics::set_rpc_subscriptions_active(count as u64, sub_label, client.to_string());
         }
     }
 }


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed a bug in the RPC subscriptions metrics reporting
- Corrected the order of arguments in `metrics::set_rpc_subscriptions_active` function calls
- Updated all occurrences of the function call to use the correct order: (count, sub_label, client)
- This fix ensures that the RPC subscription metrics are reported correctly for different subscription types and clients



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rpc_subscriptions.rs</strong><dd><code>Correct argument order in RPC subscription metrics</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/rpc/rpc_subscriptions.rs

<li>Fixed the order of arguments in <code>metrics::set_rpc_subscriptions_active</code> <br>function calls<br> <li> Updated the order to be (count, sub_label, client) instead of (count, <br>client, sub_label)<br> <li> Applied the fix in multiple places where the function is called<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1754/files#diff-a07ba1157cec6586a0520b8dfb11e9d073359af24471ac286ff5eaa2669d355c">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information