### PR TITLE
test(contracts): always run on latest commits

### DIFF
--- a/e2e/cloudwalk-contracts/contracts-clone.sh
+++ b/e2e/cloudwalk-contracts/contracts-clone.sh
@@ -38,9 +38,9 @@ clone() {
 # Clone an alternative version of a project to the projects directory.
 clone_alternative() {
     repo=$1
-    commit=$2
-    branch=$3
-    folder=$4
+    branch=$2
+    folder=$3
+    commit=$4
     target=repos/$folder
 
     mkdir -p repos
@@ -123,35 +123,35 @@ done
 log "Cloning or updating repositories"
 
 if [ "$token" == 1 ]; then
-    clone brlc-token ddb70af
+    clone brlc-token
 fi
 
 if [ "$pix" == 1 ]; then
-    clone brlc-pix-cashier fe9343c
+    clone brlc-pix-cashier
 fi
 
 if [ "$yield" == 1 ]; then
-    clone brlc-yield-streamer da8d9ce
+    clone brlc-yield-streamer
 fi
 
 if [ "$periphery" == 1 ]; then
-    clone brlc-periphery 1e3de39
+    clone brlc-periphery
 fi
 
 if [ "$multisig" == 1 ]; then
-    clone brlc-multisig f70ec64
+    clone brlc-multisig
 fi
 
 if [ "$compound" == 1 ]; then
-    clone compound-periphery c3ca5df
+    clone compound-periphery
 fi
 
 # Alternative versions
 
 if [ "$pixv4" == 1 ]; then
-    clone_alternative brlc-pix-cashier b5e9cbf pix-cashier-v4 brlc-pix-cashier-v4
+    clone_alternative brlc-pix-cashier pix-cashier-v4 brlc-pix-cashier-v4
 fi
 
 if [ "$cppv2" == 1 ]; then
-    clone_alternative brlc-periphery 7eab765 cpp2 brlc-periphery-v2
+    clone_alternative brlc-periphery cpp2 brlc-periphery-v2
 fi


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Removed hardcoded commit hashes for all repository clones, allowing the script to always use the latest commits
- Updated the `clone_alternative` function to prioritize branch over commit, improving flexibility
- Adjusted all function calls to match the new parameter order
- This change ensures that the E2E tests always run on the most recent code, improving test coverage and relevance



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>contracts-clone.sh</strong><dd><code>Update repository cloning process to use latest commits</code>&nbsp; &nbsp; </dd></summary>
<hr>

e2e/cloudwalk-contracts/contracts-clone.sh

<li>Removed hardcoded commit hashes for cloning repositories<br> <li> Updated <code>clone_alternative</code> function to accept branch as second <br>parameter instead of commit<br> <li> Adjusted function calls to match new parameter order<br> <li> Removed commit parameter from all <code>clone</code> function calls<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1755/files#diff-5b521c8f3ba50a86c4afd8303eab5079009a0e12e43f0ab45bc37b459dddab64">+11/-11</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information