### PR TITLE
ci(lint): format shell scripts and add check

### DIFF
--- a/.github/workflows/lint-check.yml
+++ b/.github/workflows/lint-check.yml
@@ -65,7 +65,7 @@ jobs:
   e2e_lint:
     name: E2E Lint
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
 
     concurrency:
       group: ${{ github.workflow }}-e2e-${{ github.ref || github.run_id }}
@@ -83,7 +83,18 @@ jobs:
       - name: Set up Just
         uses: extractions/setup-just@v2
 
+      - name: Set up shfmt
+        uses: mfinelli/setup-shfmt@v3.0.1
+        with:
+          version: v3.9.0
+
+      - name: Set up shellcheck
+        run: sudo apt-get update && sudo apt-get install -y shellcheck
+
       - name: Just e2e-lint
         run: |
           npm --prefix ./e2e --silent install
           just e2e-lint --check
+
+      - name: Just shell-lint
+        run: just shell-lint --diff

--- a/e2e/cloudwalk-contracts/_functions.sh
+++ b/e2e/cloudwalk-contracts/_functions.sh
@@ -1,4 +1,4 @@
 # Log a formatted message to stderr.
 log() {
-    echo -e "  -> [$(date +"%Y-%m-%d %H:%M:%S")] $@" 1>&2;
+    echo -e "  -> [$(date +"%Y-%m-%d %H:%M:%S")] $*" 1>&2
 }

--- a/e2e/cloudwalk-contracts/contracts-clone.sh
+++ b/e2e/cloudwalk-contracts/contracts-clone.sh
@@ -2,7 +2,7 @@
 #
 # Clone Git repositories containing Solidity contracts.
 #
-source $(dirname $0)/_functions.sh
+source "$(dirname "$0")/_functions.sh"
 
 # ------------------------------------------------------------------------------
 # Functions
@@ -16,23 +16,23 @@ clone() {
 
     mkdir -p repos
 
-    if [ -d $target ]; then
+    if [ -d "$target" ]; then
         log "Updating: $repo"
-        git -C $target pull
+        git -C "$target" pull
     else
         log "Cloning: $repo"
-        git clone https://github.com/cloudwalk/$repo.git $target
-        
+        git clone https://github.com/cloudwalk/"$repo".git "$target"
+
         # checkout commit if specified and it's different from HEAD
-        head_commit=$(git -C $target rev-parse --short HEAD)
+        head_commit=$(git -C "$target" rev-parse --short HEAD)
         if [ -n "$commit" ] && [ "$commit" != "$head_commit" ]; then
             log "Checking out commit: $commit"
-            git -C $target checkout $commit --quiet
+            git -C "$target" checkout "$commit" --quiet
         fi
     fi
 
     log "Installing dependencies: $repo"
-    npm --prefix $target --silent install
+    npm --prefix "$target" --silent install
 }
 
 # Clone an alternative version of a project to the projects directory.
@@ -45,23 +45,23 @@ clone_alternative() {
 
     mkdir -p repos
 
-    if [ -d $target ]; then
+    if [ -d "$target" ]; then
         log "Updating: $repo in $folder"
-        git -C $target pull
+        git -C "$target" pull
     else
         log "Cloning: $branch branch of $repo in $folder"
-        git clone --branch $branch https://github.com/cloudwalk/$repo.git $target
-        
+        git clone --branch "$branch" https://github.com/cloudwalk/"$repo".git "$target"
+
         # checkout commit if specified and it's different from HEAD
-        head_commit=$(git -C $target rev-parse --short HEAD)
+        head_commit=$(git -C "$target" rev-parse --short HEAD)
         if [ -n "$commit" ] && [ "$commit" != "$head_commit" ]; then
             log "Checking out commit: $commit"
-            git -C $target checkout $commit --quiet
+            git -C "$target" checkout "$commit" --quiet
         fi
     fi
 
     log "Installing dependencies: $folder"
-    npm --prefix $target --silent install
+    npm --prefix "$target" --silent install
 }
 
 # ------------------------------------------------------------------------------
@@ -107,16 +107,47 @@ fi
 # Process arguments
 while [[ "$#" -gt 0 ]]; do
     case "$1" in
-        -h|--help) print_help; exit 0 ;;
-        -t|--token) token=1; shift ;;
-        -p|--periphery) periphery=1; shift ;;
-        -m|--multisig) multisig=1; shift ;;
-        -c|--compound) compound=1; shift ;;
-        -i|--yield) yield=1; shift ;;
-        -x|--pix) pix=1; shift ;;
-        -4|--pixv4) pixv4=1; shift ;;
-        -2|--cppv2) cppv2=1; shift ;;
-        *) echo "Unknown option: $1"; print_help; exit 1 ;;
+    -h | --help)
+        print_help
+        exit 0
+        ;;
+    -t | --token)
+        token=1
+        shift
+        ;;
+    -p | --periphery)
+        periphery=1
+        shift
+        ;;
+    -m | --multisig)
+        multisig=1
+        shift
+        ;;
+    -c | --compound)
+        compound=1
+        shift
+        ;;
+    -i | --yield)
+        yield=1
+        shift
+        ;;
+    -x | --pix)
+        pix=1
+        shift
+        ;;
+    -4 | --pixv4)
+        pixv4=1
+        shift
+        ;;
+    -2 | --cppv2)
+        cppv2=1
+        shift
+        ;;
+    *)
+        echo "Unknown option: $1"
+        print_help
+        exit 1
+        ;;
     esac
 done
 

--- a/e2e/cloudwalk-contracts/contracts-compile.sh
+++ b/e2e/cloudwalk-contracts/contracts-compile.sh
@@ -2,7 +2,7 @@
 #
 # Compiles a subset or relevant Solidity contracts.
 #
-source $(dirname $0)/_functions.sh
+source "$(dirname "$0")/_functions.sh"
 
 # ------------------------------------------------------------------------------
 # Functions
@@ -15,10 +15,10 @@ compile_contract() {
     log "Compiling: $contract ($repo)"
 
     # compile
-    solc --base-path repos/$repo/contracts --include-path repos/$repo/node_modules --hashes --optimize -o repos/$repo/target --overwrite repos/$repo/contracts/$contract.sol
+    solc --base-path repos/"$repo"/contracts --include-path repos/"$repo"/node_modules --hashes --optimize -o repos/"$repo"/target --overwrite repos/"$repo"/contracts/"$contract".sol
 
     # copy from target folder to tests
-    cp repos/$repo/target/$contract.signatures ../../static/contracts-signatures/
+    cp repos/"$repo"/target/"$contract".signatures ../../static/contracts-signatures/
 }
 
 # ------------------------------------------------------------------------------
@@ -29,16 +29,16 @@ compile_contract() {
 asdf local solidity 0.8.24 || echo "asdf, solidity plugin or solidity version not found"
 
 # execute
-compile_contract brlc-token          BRLCToken
+compile_contract brlc-token BRLCToken
 
-compile_contract brlc-pix-cashier    PixCashier
+compile_contract brlc-pix-cashier PixCashier
 
-compile_contract brlc-periphery      CashbackDistributor
-compile_contract brlc-periphery      CardPaymentProcessor
+compile_contract brlc-periphery CashbackDistributor
+compile_contract brlc-periphery CardPaymentProcessor
 
-compile_contract compound-periphery  CompoundAgent
+compile_contract compound-periphery CompoundAgent
 
-compile_contract brlc-multisig       MultiSigWallet
+compile_contract brlc-multisig MultiSigWallet
 
 compile_contract brlc-yield-streamer BalanceTracker
 compile_contract brlc-yield-streamer YieldStreamer

--- a/e2e/cloudwalk-contracts/contracts-coverage.sh
+++ b/e2e/cloudwalk-contracts/contracts-coverage.sh
@@ -2,7 +2,7 @@
 #
 # Generate coverage info for the Solidity contracts.
 #
-source $(dirname $0)/_functions.sh
+source "$(dirname "$0")/_functions.sh"
 
 # ------------------------------------------------------------------------------
 # Functions
@@ -12,7 +12,7 @@ source $(dirname $0)/_functions.sh
 coverage() {
     repo=$1
 
-    if [ -d repos/$repo/coverage/ ]; then
+    if [ -d repos/"$repo"/coverage/ ]; then
         log "Already generated coverage for $repo"
         return
     fi
@@ -20,14 +20,17 @@ coverage() {
     log "Generating coverage: $repo"
 
     # Enter the repository folder
-    if [ ! -d repos/$repo ]; then
+    if [ ! -d repos/"$repo" ]; then
         log "Repository not found: $repo. Is it cloned?"
         return
     fi
-    cd repos/$repo
-    
+
+    # shellcheck disable=SC2164
+    # reason: the existence of the repository is checked above
+    cd repos/"$repo"
+
     npx hardhat coverage
-    
+
     # Leave the repository folder
     cd ../../
 }
@@ -40,8 +43,8 @@ coverage() {
 asdf local solidity 0.8.16 || echo "asdf, solidity plugin or solidity version not found"
 
 # execute
-coverage brlc-token     
-coverage brlc-periphery    
+coverage brlc-token
+coverage brlc-periphery
 coverage brlc-pix-cashier
 coverage brlc-yield-streamer
 coverage brlc-multisig

--- a/e2e/cloudwalk-contracts/contracts-flatten.sh
+++ b/e2e/cloudwalk-contracts/contracts-flatten.sh
@@ -21,17 +21,17 @@ flatten() {
     log "Flattenning: $contract ($repo)"
 
     # Enter the repository folder
-    cd repos/"$repo" || log "$repo folder does not exist" && exit 1
+    cd repos/"$repo" || (log "$repo folder does not exist" && exit 1)
     cp ../../../hardhat.config.ts .
 
     # Flatten
-    npx hardhat flatten contracts/"$contract".sol > ../../integration/contracts/"$contract".flattened.sol
+    npx hardhat flatten contracts/"$contract".sol >../../integration/contracts/"$contract".flattened.sol
 
     # Leave the repository folder
     cd ../../
 
     # Install ts-node if not installed
-    command -v ts-node > /dev/null || npm install --save-dev ts-node
+    command -v ts-node >/dev/null || npm install --save-dev ts-node
 
     # Lint the flattened contract
     log "Linting the flattened $contract ($repo)"

--- a/e2e/cloudwalk-contracts/contracts-flatten.sh
+++ b/e2e/cloudwalk-contracts/contracts-flatten.sh
@@ -2,7 +2,7 @@
 #
 # Flattens a subset or relevant Solidity contracts.
 #
-source $(dirname $0)/_functions.sh
+source "$(dirname "$0")/_functions.sh"
 
 # ------------------------------------------------------------------------------
 # Functions
@@ -13,7 +13,7 @@ flatten() {
     repo=$1
     contract=$2
 
-    if [ -f integration/contracts/$contract.flattened.sol ]; then
+    if [ -f integration/contracts/"$contract".flattened.sol ]; then
         echo "Skipping flattening of $contract ($repo)"
         return
     fi
@@ -21,22 +21,22 @@ flatten() {
     log "Flattenning: $contract ($repo)"
 
     # Enter the repository folder
-    cd repos/$repo
+    cd repos/"$repo" || log "$repo folder does not exist" && exit 1
     cp ../../../hardhat.config.ts .
-    
+
     # Flatten
-    npx hardhat flatten contracts/$contract.sol > ../../integration/contracts/$contract.flattened.sol
-    
+    npx hardhat flatten contracts/"$contract".sol > ../../integration/contracts/"$contract".flattened.sol
+
     # Leave the repository folder
     cd ../../
 
     # Install ts-node if not installed
     command -v ts-node > /dev/null || npm install --save-dev ts-node
-    
+
     # Lint the flattened contract
     log "Linting the flattened $contract ($repo)"
-    npx ts-node integration/test/helpers/lint-flattened.ts integration/contracts/$contract.flattened.sol
-    
+    npx ts-node integration/test/helpers/lint-flattened.ts integration/contracts/"$contract".flattened.sol
+
 }
 
 # ------------------------------------------------------------------------------
@@ -76,14 +76,39 @@ fi
 # Process arguments
 while [[ "$#" -gt 0 ]]; do
     case "$1" in
-        -h|--help) print_help; exit 0 ;;
-        -t|--token) token=1; shift ;;
-        -p|--periphery) periphery=1; shift ;;
-        -m|--multisig) multisig=1; shift ;;
-        -c|--compound) compound=1; shift ;;
-        -i|--yield) yield=1; shift ;;
-        -x|--pix) pix=1; shift ;;
-        *) echo "Unknown option: $1"; print_help; exit 1 ;;
+    -h | --help)
+        print_help
+        exit 0
+        ;;
+    -t | --token)
+        token=1
+        shift
+        ;;
+    -p | --periphery)
+        periphery=1
+        shift
+        ;;
+    -m | --multisig)
+        multisig=1
+        shift
+        ;;
+    -c | --compound)
+        compound=1
+        shift
+        ;;
+    -i | --yield)
+        yield=1
+        shift
+        ;;
+    -x | --pix)
+        pix=1
+        shift
+        ;;
+    *)
+        echo "Unknown option: $1"
+        print_help
+        exit 1
+        ;;
     esac
 done
 # configure tools
@@ -92,11 +117,11 @@ asdf local solidity 0.8.16 || echo "asdf, solidity plugin or solidity version no
 log "Flattening repositories"
 
 if [ "$token" == 1 ]; then
-    flatten brlc-token          BRLCToken
+    flatten brlc-token BRLCToken
 fi
 
 if [ "$pix" == 1 ]; then
-    flatten brlc-pix-cashier    PixCashier
+    flatten brlc-pix-cashier PixCashier
 fi
 
 if [ "$yield" == 1 ]; then
@@ -105,14 +130,14 @@ if [ "$yield" == 1 ]; then
 fi
 
 if [ "$periphery" == 1 ]; then
-    flatten brlc-periphery      CardPaymentProcessor
-    flatten brlc-periphery      CashbackDistributor
+    flatten brlc-periphery CardPaymentProcessor
+    flatten brlc-periphery CashbackDistributor
 fi
 
 if [ "$multisig" == 1 ]; then
-    flatten brlc-multisig       MultiSigWallet
+    flatten brlc-multisig MultiSigWallet
 fi
 
 if [ "$compound" == 1 ]; then
-    flatten compound-periphery  CompoundAgent
+    flatten compound-periphery CompoundAgent
 fi

--- a/e2e/cloudwalk-contracts/contracts-remove.sh
+++ b/e2e/cloudwalk-contracts/contracts-remove.sh
@@ -2,7 +2,7 @@
 #
 # Clone Git repositories containing Solidity contracts.
 #
-source $(dirname $0)/_functions.sh
+source "$(dirname "$0")/_functions.sh"
 
 # ------------------------------------------------------------------------------
 # Functions
@@ -13,9 +13,9 @@ remove() {
     repo=$1
     target=repos/$repo
 
-    if [ -d $target ]; then
+    if [ -d "$target" ]; then
         log "Removing: $repo"
-        rm -rf $target
+        rm -rf "$target"
     else
         log "Already removed: $repo"
         log "Nothing to do, leaving"
@@ -59,14 +59,39 @@ fi
 # Process arguments
 while [[ "$#" -gt 0 ]]; do
     case "$1" in
-        -h|--help) print_help; exit 0 ;;
-        -t|--token) token=1; shift ;;
-        -p|--periphery) periphery=1; shift ;;
-        -m|--multisig) multisig=1; shift ;;
-        -c|--compound) compound=1; shift ;;
-        -i|--yield) yield=1; shift ;;
-        -x|--pix) pix=1; shift ;;
-        *) echo "Unknown option: $1"; print_help; exit 1 ;;
+    -h | --help)
+        print_help
+        exit 0
+        ;;
+    -t | --token)
+        token=1
+        shift
+        ;;
+    -p | --periphery)
+        periphery=1
+        shift
+        ;;
+    -m | --multisig)
+        multisig=1
+        shift
+        ;;
+    -c | --compound)
+        compound=1
+        shift
+        ;;
+    -i | --yield)
+        yield=1
+        shift
+        ;;
+    -x | --pix)
+        pix=1
+        shift
+        ;;
+    *)
+        echo "Unknown option: $1"
+        print_help
+        exit 1
+        ;;
     esac
 done
 

--- a/e2e/cloudwalk-contracts/contracts-test.sh
+++ b/e2e/cloudwalk-contracts/contracts-test.sh
@@ -14,7 +14,7 @@ test() {
     log "Testing: $file ($repo)"
 
     # configure hardhat env
-    cd repos/"$repo" || log "Error: $repo not found" && exit 1
+    cd repos/"$repo" || (log "Error: $repo not found" && exit 1)
     git restore .
     cp ../../../hardhat.config.ts .
     rm -rf .openzeppelin/

--- a/e2e/cloudwalk-contracts/contracts-test.sh
+++ b/e2e/cloudwalk-contracts/contracts-test.sh
@@ -2,7 +2,7 @@
 #
 # Runs tests for Solidity contracts.
 #
-source $(dirname $0)/_functions.sh
+source "$(dirname "$0")/_functions.sh"
 
 # ------------------------------------------------------------------------------
 # Functions
@@ -14,25 +14,25 @@ test() {
     log "Testing: $file ($repo)"
 
     # configure hardhat env
-    cd repos/$repo
+    cd repos/"$repo" || log "Error: $repo not found" && exit 1
     git restore .
     cp ../../../hardhat.config.ts .
     rm -rf .openzeppelin/
 
     # apply git patch
     patch_file="../../patches/$repo.patch"
-    if [ -e $patch_file ]; then
+    if [ -e "$patch_file" ]; then
         log "Applying Git patch: $patch_file"
-        git apply $patch_file || true
+        git apply "$patch_file" || true
     fi
 
     # test
     if [ -z "$test" ]; then
         log "Executing all tests"
-        npx hardhat test --bail --network stratus test/$file.test.ts
+        npx hardhat test --bail --network stratus test/"$file".test.ts
     else
         log "Executing filtered tests: $test"
-        npx hardhat test --bail --network stratus test/$file.test.ts --grep $test
+        npx hardhat test --bail --network stratus test/"$file".test.ts --grep "$test"
     fi
     result_code=$?
 
@@ -40,6 +40,8 @@ test() {
     git restore .
 
     # go back to previous directory
+    # shellcheck disable=SC2164
+    # reason: This cd should not fail
     cd -
 
     # exit with same return code as the test if an error ocurred
@@ -94,16 +96,47 @@ fi
 # Process arguments
 if [[ "$#" -gt 0 ]]; then
     case "$1" in
-        -h|--help) print_help; exit 0 ;;
-        -t|--token) token=1; shift ;;
-        -p|--periphery) periphery=1; shift ;;
-        -m|--multisig) multisig=1; shift ;;
-        -c|--compound) compound=1; shift ;;
-        -i|--yield) yield=1; shift ;;
-        -x|--pix) pix=1; shift ;;
-        -4|--pixv4) pixv4=1; shift ;;
-        -2|--cppv2) cppv2=1; shift ;;
-        *) echo "Unknown option: $1"; print_help; exit 1 ;;
+    -h | --help)
+        print_help
+        exit 0
+        ;;
+    -t | --token)
+        token=1
+        shift
+        ;;
+    -p | --periphery)
+        periphery=1
+        shift
+        ;;
+    -m | --multisig)
+        multisig=1
+        shift
+        ;;
+    -c | --compound)
+        compound=1
+        shift
+        ;;
+    -i | --yield)
+        yield=1
+        shift
+        ;;
+    -x | --pix)
+        pix=1
+        shift
+        ;;
+    -4 | --pixv4)
+        pixv4=1
+        shift
+        ;;
+    -2 | --cppv2)
+        cppv2=1
+        shift
+        ;;
+    *)
+        echo "Unknown option: $1"
+        print_help
+        exit 1
+        ;;
     esac
 fi
 

--- a/justfile
+++ b/justfile
@@ -242,6 +242,12 @@ e2e-lint mode="--write":
     fi
     node_modules/.bin/prettier . {{ mode }} --ignore-unknown
 
+# E2E: Lint and format shell scripts for cloudwalk contracts
+shell-lint mode="--write":
+    @command -v shfmt > /dev/null 2>&1 && command -v shellcheck > /dev/null 2>&1 || echo "Please, install shfmt and shellcheck" && exit 0
+    @shfmt {{ mode }} --indent 4 --space-redirects e2e/cloudwalk-contracts/*.sh
+    @shellcheck e2e/cloudwalk-contracts/*.sh --severity=warning --shell=bash
+
 # E2E: profiles RPC sync and generates a flamegraph
 e2e-flamegraph:
     #!/bin/bash
@@ -292,26 +298,26 @@ e2e-leader-follower-up test="brlc":
         just _log "Running deploy script"
         cd utils/deploy
         poetry install --no-root
-    
+
         for i in {1..5}; do
             poetry run python3 ./deploy.py --current-leader 0.0.0.0:3000 --current-follower 0.0.0.0:3001 --auto-approve
             if [ $? -ne 0 ]; then
                 just _log "Deploy script failed"
                 exit 1
             fi
-    
+
             just _log "Switching back roles..."
             sleep 5
-    
+
             poetry run python3 ./deploy.py --current-leader 0.0.0.0:3001 --current-follower 0.0.0.0:3000 --auto-approve
             if [ $? -ne 0 ]; then
                 just _log "Deploy script failed"
                 exit 1
             fi
-    
+
             sleep 5
         done
-    
+
         just _log "Deploy script ran successfully"
         exit 0
     elif [ -d e2e/cloudwalk-contracts ]; then

--- a/justfile
+++ b/justfile
@@ -245,7 +245,7 @@ e2e-lint mode="--write":
 # E2E: Lint and format shell scripts for cloudwalk contracts
 shell-lint mode="--write":
     @command -v shfmt > /dev/null 2>&1 && command -v shellcheck > /dev/null 2>&1 || echo "Please, install shfmt and shellcheck" && exit 0
-    @shfmt {{ mode }} --indent 4 --space-redirects e2e/cloudwalk-contracts/*.sh
+    @shfmt {{ mode }} --indent 4 e2e/cloudwalk-contracts/*.sh
     @shellcheck e2e/cloudwalk-contracts/*.sh --severity=warning --shell=bash
 
 # E2E: profiles RPC sync and generates a flamegraph


### PR DESCRIPTION
### **User description**
All shell scripts inside cloudwalk-contracts are now formatted and linted with `shfmt` and `shellcheck`. 
Their configurations are totally compatible with Zed's Basher extension out of the box. 
Without Zed, use `just shell-lint` locally to format and lint them if you make a change.
The check was added to CI's Lint action


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Enhanced shell script robustness and safety across multiple files by adding quotes around variables and improving error handling.
- Improved script formatting and readability, including better indentation and case statement formatting.
- Fixed various shellcheck warnings throughout the shell scripts.
- Added a new shell linting step to the CI workflow using the `just shell-lint` command.
- Introduced a new `shell-lint` recipe in the justfile to lint and format shell scripts using `shfmt` and `shellcheck`.
- Minor bug fixes, including correcting the use of `$*` instead of `$@` in the log function.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>_functions.sh</strong><dd><code>Fix shellcheck warning in log function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

e2e/cloudwalk-contracts/_functions.sh

<li>Fixed shellcheck warning by using <code>$*</code> instead of <code>$@</code> in the <code>log</code> function<br> <br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1757/files#diff-5036735dd530ca789baaf5d774e5f04c57dea86e787a7ee7f0e63453dc48b0e6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>contracts-clone.sh</strong><dd><code>Improve shell script robustness and formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

e2e/cloudwalk-contracts/contracts-clone.sh

<li>Added quotes around variables to prevent word splitting<br> <li> Improved formatting and indentation<br> <li> Fixed shellcheck warnings<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1757/files#diff-5b521c8f3ba50a86c4afd8303eab5079009a0e12e43f0ab45bc37b459dddab64">+57/-26</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>contracts-compile.sh</strong><dd><code>Enhance script safety and readability</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

e2e/cloudwalk-contracts/contracts-compile.sh

<li>Added quotes around variables to prevent word splitting<br> <li> Improved formatting<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1757/files#diff-a82863d36c28eb1a3da8c1d37812d55fcf2c245c24fc81612f93789444655c12">+9/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>contracts-coverage.sh</strong><dd><code>Improve script robustness and documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

e2e/cloudwalk-contracts/contracts-coverage.sh

<li>Added quotes around variables<br> <li> Improved error handling and comments<br> <li> Fixed shellcheck warnings<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1757/files#diff-21618402f641706222cda11f5267e0aea92d7f3c337f41c394f77b0641e8d9e1">+12/-9</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>contracts-flatten.sh</strong><dd><code>Enhance script safety and readability</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

e2e/cloudwalk-contracts/contracts-flatten.sh

<li>Added quotes around variables<br> <li> Improved error handling<br> <li> Enhanced case statement formatting<br> <li> Fixed shellcheck warnings<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1757/files#diff-2c8107794f81af077b0559efb09c62629fe6353e69a09eca927c323aaf7963d5">+49/-24</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>contracts-remove.sh</strong><dd><code>Improve script robustness and formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

e2e/cloudwalk-contracts/contracts-remove.sh

<li>Added quotes around variables<br> <li> Improved case statement formatting<br> <li> Fixed shellcheck warnings<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1757/files#diff-d90c58ee8f3707cd2e12178cd9db784f66d7d26a9dcbbcd9e7c4d03c7c10abde">+37/-12</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>contracts-test.sh</strong><dd><code>Enhance script safety and readability</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

e2e/cloudwalk-contracts/contracts-test.sh

<li>Added quotes around variables<br> <li> Improved error handling<br> <li> Enhanced case statement formatting<br> <li> Fixed shellcheck warnings<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1757/files#diff-0661dd68b35d7b4108c0e7cb30304b44749b0cc259d7a1216c35aac6809f29df">+50/-17</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>lint-check.yml</strong><dd><code>Add shell linting to CI workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/lint-check.yml

<li>Added a new step to run shell linting using the <code>just shell-lint</code> <br>command<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1757/files#diff-dda267615bb53af994fa659ec8de11a5c4855ee18b1922370924f65759d8cae1">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>justfile</strong><dd><code>Add shell linting recipe to justfile</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

justfile

- Added a new `shell-lint` recipe to lint and format shell scripts



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1757/files#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1">+11/-5</a>&nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information