### PR TITLE
fix: rpc downloader shutdown

### DIFF
--- a/src/eth/follower/importer/importer.rs
+++ b/src/eth/follower/importer/importer.rs
@@ -150,6 +150,8 @@ impl Importer {
     // Executor
     // -----------------------------------------------------------------------------
 
+    pub const TASKS_COUNT: usize = 3;
+
     // Executes external blocks and persist them to storage.
     async fn start_block_executor(
         executor: Arc<Executor>,


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Improved RPC downloader shutdown mechanism:
  - Implemented graceful shutdown using `GlobalState::is_shutdown_warn`
  - Enhanced error handling for download tasks
- Refactored importer-related code:
  - Introduced `TASKS_COUNT` constant in `Importer` struct
  - Updated global variables to use the new constant
- Enhanced code organization and maintainability:
  - Added `TASK_NAME` constant in RPC downloader
  - Replaced hard-coded values with constants
- Minor improvements:
  - Updated import statements
  - Simplified stream processing in RPC downloader



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rpc_downloader.rs</strong><dd><code>Improve RPC downloader robustness and shutdown behavior</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/bin/rpc_downloader.rs

<li>Replaced <code>TryStreamExt</code> with <code>stream</code> from futures crate<br> <li> Introduced <code>TASK_NAME</code> constant for better code organization<br> <li> Implemented graceful shutdown mechanism using <br><code>GlobalState::is_shutdown_warn</code><br> <li> Changed error handling approach for download tasks<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1762/files#diff-34137b2d44a1c2a35b30a2515f309e99ecd04277d9b2d681ff55c5bbe30ac5c1">+15/-10</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>importer.rs</strong><dd><code>Add constant for importer tasks count</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/follower/importer/importer.rs

- Added `TASKS_COUNT` constant with a value of 3



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1762/files#diff-bd50f502f039aff8f75753bc780d281ae7d7936fadc9d53482084c647aec94ca">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>globals.rs</strong><dd><code>Refactor importer-related global variables</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/globals.rs

<li>Imported <code>Importer</code> from the <code>eth::follower::importer</code> module<br> <li> Updated <code>IMPORTER_ONLINE_TASKS_SEMAPHORE</code> to use <code>Importer::TASKS_COUNT</code><br> <li> Modified <code>wait_for_importer_to_finish</code> to use <code>Importer::TASKS_COUNT</code><br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1762/files#diff-48d6fbc3a4ed67100952dcccfada858623c931e73d6de32984d4d1457e68d3a9">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information