### PR TITLE
enha: rpc-downloader: report speed

### DIFF
--- a/src/bin/rpc_downloader.rs
+++ b/src/bin/rpc_downloader.rs
@@ -203,7 +203,7 @@ async fn download(
 }
 
 fn blocks_per_minute_reporter() {
-    let mut intervals_in_minutes = (1..10).into_iter().chain(iter::repeat(10));
+    let mut intervals_in_minutes = (1..10).chain(iter::repeat(10));
 
     loop {
         let interval = intervals_in_minutes.next().expect("infinite iterator");

--- a/src/bin/rpc_downloader.rs
+++ b/src/bin/rpc_downloader.rs
@@ -203,6 +203,11 @@ async fn download(
 }
 
 fn blocks_per_minute_reporter() {
+    // wait till downloading has started to start measuring
+    while BLOCKS_DOWNLOADED.load(Ordering::Relaxed) == 0 {
+        thread::sleep(Duration::from_secs(1));
+    }
+
     let mut intervals_in_minutes = (1..10).chain(iter::repeat(10));
 
     loop {

--- a/src/bin/rpc_downloader.rs
+++ b/src/bin/rpc_downloader.rs
@@ -137,7 +137,7 @@ async fn download(
         Some(number) => number.next_block_number(),
         None => start,
     };
-    tracing::info!(%start, current = %current, end = %end_inclusive, "starting download task (might skip)");
+    tracing::info!(%start, %current, end = %end_inclusive, "starting download task (might skip)");
 
     // download blocks
     while current <= end_inclusive {
@@ -208,16 +208,14 @@ fn blocks_per_minute_reporter() {
         thread::sleep(Duration::from_secs(1));
     }
 
-    let mut intervals_in_minutes = (1..10).chain(iter::repeat(10));
+    let interval = Duration::from_secs(60);
+
+    tracing::info!("detected first download, starting to measure speed...");
 
     loop {
-        let interval = intervals_in_minutes.next().expect("infinite iterator");
-        let interval = Duration::from_secs(interval * 60);
-
         let block_before = BLOCKS_DOWNLOADED.load(Ordering::Relaxed);
         thread::sleep(interval);
         let block_after = BLOCKS_DOWNLOADED.load(Ordering::Relaxed);
-
         let block_diff = block_after - block_before;
 
         let blocks_per_second = block_diff as f64 / interval.as_secs_f64();

--- a/src/bin/rpc_downloader.rs
+++ b/src/bin/rpc_downloader.rs
@@ -220,7 +220,7 @@ fn blocks_per_minute_reporter() {
 
         let block_diff = block_after - block_before;
 
-        let blocks_per_second = block_diff as f64 / interval.as_secs() as f64;
+        let blocks_per_second = block_diff as f64 / interval.as_secs_f64();
 
         tracing::info!(
             blocks_per_second = format_args!("{blocks_per_second:.2}"),

--- a/src/bin/rpc_downloader.rs
+++ b/src/bin/rpc_downloader.rs
@@ -1,5 +1,4 @@
 use std::cmp::min;
-use std::iter;
 use std::sync::atomic::AtomicU32;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added a new feature to report the download speed of blocks in the RPC downloader
- Implemented an atomic counter `BLOCKS_DOWNLOADED` to track the number of downloaded blocks
- Created a new function `blocks_per_minute_reporter` that calculates and logs the download speed
- The reporter provides information on blocks per second and estimated blocks per day
- Modified the `download` function to update the atomic counter after each successful block download
- Spawned a new thread in `download_blocks` to run the speed reporter concurrently
- Removed individual block download logging to reduce noise in the output
- The speed report adjusts its interval dynamically, starting from 1 minute and increasing up to 10 minutes



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rpc_downloader.rs</strong><dd><code>Implement download speed reporting for RPC downloader</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/bin/rpc_downloader.rs

<li>Added new imports for atomic operations, thread, and duration<br> <li> Introduced an atomic counter <code>BLOCKS_DOWNLOADED</code> to track downloaded <br>blocks<br> <li> Implemented a new function <code>blocks_per_minute_reporter</code> to report <br>download speed<br> <li> Modified the <code>download</code> function to update the atomic counter<br> <li> Spawned a new thread in <code>download_blocks</code> to run the reporter<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1763/files#diff-34137b2d44a1c2a35b30a2515f309e99ecd04277d9b2d681ff55c5bbe30ac5c1">+37/-2</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information