### PR TITLE
enha: make rpc-downloader shutdown faster

### DIFF
--- a/src/bin/rpc_downloader.rs
+++ b/src/bin/rpc_downloader.rs
@@ -122,6 +122,8 @@ async fn download(
     start: BlockNumber,
     end_inclusive: BlockNumber,
 ) -> anyhow::Result<()> {
+    const TASK_NAME: &str = "rpc-downloader::download";
+
     // calculate current block
     let mut current = match rpc_storage.read_max_block_number_in_range(start, end_inclusive).await? {
         Some(number) => number.next_block_number(),
@@ -134,11 +136,15 @@ async fn download(
         tracing::info!(block_number = %current, "downloading");
 
         loop {
+            if GlobalState::is_shutdown_warn(TASK_NAME) {
+                break;
+            }
+
             // retrieve block
             let block_json = match chain.fetch_block(current).await {
                 Ok(json) => json,
                 Err(e) => {
-                    tracing::warn!(reason = ?e, "retrying block download");
+                    tracing::warn!(reason = ?e, "failed to fetch, retrying block download");
                     continue;
                 }
             };


### PR DESCRIPTION
### **User description**
by also checking in the block fetch loop, we can stop running earlier


___

### **PR Type**
Enhancement


___

### **Description**
- Introduced a constant `TASK_NAME` for better task identification in the download function
- Added a shutdown check within the block fetch loop to allow for faster termination of the download process
- Enhanced error logging for block fetch failures, providing more specific information
- These changes improve the overall efficiency and responsiveness of the RPC downloader, particularly during shutdown scenarios



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rpc_downloader.rs</strong><dd><code>Enhance RPC downloader shutdown and error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/bin/rpc_downloader.rs

<li>Added a constant <code>TASK_NAME</code> for the download function<br> <li> Implemented a shutdown check in the block fetch loop<br> <li> Improved error logging message for block fetch failures<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1764/files#diff-34137b2d44a1c2a35b30a2515f309e99ecd04277d9b2d681ff55c5bbe30ac5c1">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information