### PR TITLE
chore: remove outdated comments

### DIFF
--- a/src/eth/rpc/rpc_subscriptions.rs
+++ b/src/eth/rpc/rpc_subscriptions.rs
@@ -247,8 +247,7 @@ impl RpcSubscriptions {
         let msg = match msg.try_into() {
             Ok(msg) => msg,
             Err(e) => {
-                // TODO: remove format!() after rust analyzer bug is fixed
-                tracing::error!(parent: None, reason = format!("{e:?}"), "failed to convert message into subscription message");
+                tracing::error!(parent: None, reason = ?e, "failed to convert message into subscription message");
                 return;
             }
         };

--- a/src/eth/storage/rocks/rocks_state.rs
+++ b/src/eth/storage/rocks/rocks_state.rs
@@ -283,7 +283,6 @@ impl RocksStorageState {
 
     pub fn read_slot(&self, address: &Address, index: &SlotIndex, point_in_time: &StoragePointInTime) -> Result<Option<Slot>> {
         if address.is_coinbase() {
-            //XXX temporary, we will reload the database later without it
             return Ok(None);
         }
 
@@ -323,7 +322,6 @@ impl RocksStorageState {
 
     pub fn read_account(&self, address: &Address, point_in_time: &StoragePointInTime) -> Result<Option<Account>> {
         if address.is_coinbase() || address.is_zero() {
-            //XXX temporary, we will reload the database later without it
             return Ok(None);
         }
 

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -162,8 +162,7 @@ pub trait MutexExt<T> {
 impl<T> MutexExt<T> for Mutex<T> {
     fn lock_or_clear<'a>(&'a self, error_message: &str) -> MutexGuard<'a, T> {
         self.lock().unwrap_or_else(|poison_err| {
-            // TODO: remove this format!() after Rust-Analyzer bug is fixed
-            tracing::error!("Fatal: failed to lock mutex, {error_message}");
+            tracing::error!(error_context, "fatal: failed to lock mutex");
             self.clear_poison();
             poison_err.into_inner()
         })

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -156,11 +156,11 @@ impl<T> MutexResultExt<T> for Result<T, std::sync::PoisonError<T>> {
 }
 
 pub trait MutexExt<T> {
-    fn lock_or_clear<'a>(&'a self, error_message: &str) -> MutexGuard<'a, T>;
+    fn lock_or_clear<'a>(&'a self, error_context: &str) -> MutexGuard<'a, T>;
 }
 
 impl<T> MutexExt<T> for Mutex<T> {
-    fn lock_or_clear<'a>(&'a self, error_message: &str) -> MutexGuard<'a, T> {
+    fn lock_or_clear<'a>(&'a self, error_context: &str) -> MutexGuard<'a, T> {
         self.lock().unwrap_or_else(|poison_err| {
             tracing::error!(error_context, "fatal: failed to lock mutex");
             self.clear_poison();

--- a/src/infra/tracing/tracing_services.rs
+++ b/src/infra/tracing/tracing_services.rs
@@ -352,7 +352,7 @@ pub fn warn_task_cancellation(task: &str) -> String {
 /// Returns the formatted tracing message.
 #[track_caller]
 pub fn warn_task_tx_closed(task: &str) -> String {
-    let message = format!("exiting {} because the tx channel on the other side was closed", task);
+    let message = format!("exiting {} because the tx channel on the receiver side was closed", task);
     tracing::warn!(%message);
     message
 }
@@ -362,7 +362,7 @@ pub fn warn_task_tx_closed(task: &str) -> String {
 /// Returns the formatted tracing message.
 #[track_caller]
 pub fn warn_task_rx_closed(task: &str) -> String {
-    let message = format!("exiting {} because the rx channel on the other side was closed", task);
+    let message = format!("exiting {} because the rx channel on the sender side was closed", task);
     tracing::warn!(%message);
     message
 }


### PR DESCRIPTION
### **User description**
and update a couple error messages


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Optimized error logging by removing unnecessary `format!()` calls in multiple files, improving performance.
- Removed outdated comments in `RocksStorageState`, enhancing code clarity.
- Improved `MutexExt` trait in `src/ext.rs`:
  - Renamed `error_message` parameter to `error_context` for better clarity.
  - Updated error message to be more concise.
- Fixed inaccurate error messages in `tracing_services.rs`:
  - Clarified "tx channel" and "rx channel" closure messages to specify "receiver side" and "sender side" respectively.
- Overall, these changes improve code quality, performance, and error message accuracy across multiple components.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rpc_subscriptions.rs</strong><dd><code>Optimize error logging in RpcSubscriptions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/rpc/rpc_subscriptions.rs

<li>Removed <code>format!()</code> call in error logging, using <code>?e</code> instead for better <br>performance<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1765/files#diff-a07ba1157cec6586a0520b8dfb11e9d073359af24471ac286ff5eaa2669d355c">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ext.rs</strong><dd><code>Improve MutexExt trait and error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/ext.rs

<li>Renamed parameter <code>error_message</code> to <code>error_context</code> for clarity<br> <li> Removed <code>format!()</code> call in error logging for better performance<br> <li> Updated error message to be more concise<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1765/files#diff-4ff673578dd06edb71da19750f05cb48bbbd3c78ded3dbeda59409354c35cef6">+3/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rocks_state.rs</strong><dd><code>Remove outdated comments in RocksStorageState</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/rocks/rocks_state.rs

<li>Removed outdated comments about temporary code and database reloading<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1765/files#diff-f7b822022d2c4fd93ec507cd6b5302dcf1646acbf0ee0dd077a047272b686009">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tracing_services.rs</strong><dd><code>Clarify error messages in tracing services</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/infra/tracing/tracing_services.rs

<li>Updated error messages in <code>warn_task_tx_closed</code> and <code>warn_task_rx_closed</code> <br>functions for accuracy<br> <li> Changed "other side" to "receiver side" and "sender side" respectively<br> <br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1765/files#diff-21c16d06019b3283856236ea996d455c4170d7bc0dcd40cfcc498842adde69c4">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information