### PR TITLE
chore: remove unused write operations (insert, delete, batch_delete)

### DIFF
--- a/src/eth/storage/rocks/rocks_batch_writer.rs
+++ b/src/eth/storage/rocks/rocks_batch_writer.rs
@@ -51,19 +51,6 @@ impl BufferedBatchWriter {
         Ok(())
     }
 
-    pub fn delete<K, V>(&mut self, cf_ref: &RocksCfRef<K, V>, key: K) -> anyhow::Result<()>
-    where
-        K: Serialize + for<'de> Deserialize<'de> + Debug + std::hash::Hash + Eq,
-        V: Serialize + for<'de> Deserialize<'de> + Debug + Clone,
-    {
-        self.len += 1;
-        cf_ref.prepare_batch_deletion([key], &mut self.batch)?;
-        if self.len >= self.capacity {
-            self.flush(cf_ref.db())?;
-        }
-        Ok(())
-    }
-
     pub fn flush(&mut self, db: &DB) -> anyhow::Result<()> {
         if self.len == 0 {
             return Ok(());

--- a/src/eth/storage/rocks/rocks_cf.rs
+++ b/src/eth/storage/rocks/rocks_cf.rs
@@ -152,37 +152,6 @@ where
             .collect()
     }
 
-    /// Insert pair (key, value) to the Column Family.
-    pub fn insert(&self, key: K, value: V) -> Result<()> {
-        self.insert_impl(key, value)
-            .with_context(|| format!("when trying to insert value in CF: '{}'", self.column_family))
-    }
-
-    #[inline]
-    fn insert_impl(&self, key: K, value: V) -> Result<()> {
-        let cf = self.handle();
-
-        let serialized_key = self.serialize_key_with_context(&key)?;
-        let serialized_value = self.serialize_value_with_context(&value)?;
-
-        self.db.put_cf(&cf, serialized_key, serialized_value).map_err(Into::into)
-    }
-
-    /// Deletes an entry from the database by key
-    #[allow(dead_code)]
-    pub fn delete(&self, key: &K) -> Result<()> {
-        self.delete_impl(key)
-            .with_context(|| format!("when trying to delete value from CF: '{}'", self.column_family))
-    }
-
-    #[inline]
-    fn delete_impl(&self, key: &K) -> Result<()> {
-        let serialized_key = self.serialize_key_with_context(key)?;
-        let cf = self.handle();
-
-        self.db.delete_cf(&cf, serialized_key).map_err(Into::into)
-    }
-
     pub fn apply_batch_with_context(&self, batch: WriteBatch) -> Result<()> {
         self.db
             .write(batch)
@@ -211,39 +180,6 @@ where
             batch.put_cf(&cf, serialized_key, serialized_value);
         }
         Ok(())
-    }
-
-    pub fn prepare_batch_deletion<I>(&self, deletions: I, batch: &mut WriteBatch) -> Result<()>
-    where
-        I: IntoIterator<Item = K>,
-    {
-        let cf = self.handle();
-
-        for key in deletions {
-            let serialized_key = self
-                .serialize_key_with_context(&key)
-                .with_context(|| format!("failed to prepare batch delete for CF: '{}'", self.column_family))?;
-            // add the delete operation to the batch
-            batch.delete_cf(&cf, serialized_key);
-        }
-        Ok(())
-    }
-
-    // Custom method that combines entry and or_insert_with from a HashMap
-    pub fn get_or_insert_with<F>(&self, key: K, default: F) -> Result<V>
-    where
-        F: FnOnce() -> V,
-    {
-        let value = self.get(&key)?;
-
-        Ok(match value {
-            Some(value) => value,
-            None => {
-                let new_value = default();
-                self.insert(key, new_value.clone())?;
-                new_value
-            }
-        })
     }
 
     #[allow(dead_code)]


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Removed unused write operations (`insert`, `delete`, `batch_delete`) from the RocksDB wrapper
- Simplified `BufferedBatchWriter` by removing the `delete` method
- Eliminated `insert_impl`, `delete_impl`, `prepare_batch_deletion`, and `get_or_insert_with` methods from `RocksCf`
- Improved code maintainability by removing dead code and unused functionality
- No new features added; purely a code cleanup operation



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Code cleanup</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rocks_batch_writer.rs</strong><dd><code>Remove unused delete operation from BufferedBatchWriter</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/rocks/rocks_batch_writer.rs

<li>Removed the <code>delete</code> method from the <code>BufferedBatchWriter</code> struct<br> <li> Simplified the implementation by removing unused write operations<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1769/files#diff-d9ef8ac39be277b072f06ff5a4399800ecc9b3082883b20ec0a0993f8fee1cfb">+0/-13</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rocks_cf.rs</strong><dd><code>Remove unused write operations from RocksCf</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/rocks/rocks_cf.rs

<li>Removed <code>insert</code>, <code>delete</code>, <code>prepare_batch_deletion</code>, and <code>get_or_insert_with</code> <br>methods<br> <li> Eliminated unused write operations and their associated helper <br>functions<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1769/files#diff-0eaed53baca4bd2355e2a54a150b305569904a45c93547da288208c6373d1df2">+0/-64</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information