### PR TITLE
tweak: use correct error variant for invalid block number

### DIFF
--- a/src/eth/executor/evm_input.rs
+++ b/src/eth/executor/evm_input.rs
@@ -98,6 +98,10 @@ impl EvmInput {
     }
 
     /// Creates from a call that was sent directly to Stratus with `eth_call` or `eth_estimateGas`.
+    ///
+    /// # Errors:
+    ///
+    /// If `point_in_time` is `MinedPast` it's required that `mined_block` is `Some`, otherwise, this function returns an error.
     pub fn from_eth_call(
         input: CallInput,
         point_in_time: StoragePointInTime,
@@ -120,7 +124,7 @@ impl EvmInput {
                 StoragePointInTime::Mined | StoragePointInTime::Pending => UnixTime::now(),
                 StoragePointInTime::MinedPast(_) => match mined_block {
                     Some(block) => block.header.timestamp,
-                    None => return log_and_err!("failed to create EvmInput because cannot determine mined block timestamp"),
+                    None => return log_and_err!("failed to create EvmInput: couldn't determine mined block timestamp"),
                 },
             },
             point_in_time,

--- a/src/eth/executor/executor.rs
+++ b/src/eth/executor/executor.rs
@@ -540,7 +540,13 @@ impl Executor {
         // retrieve block info
         let pending_header = self.storage.read_pending_block_header()?.unwrap_or_default();
         let mined_block = match point_in_time {
-            StoragePointInTime::MinedPast(number) => self.storage.read_block(&BlockFilter::Number(number))?,
+            StoragePointInTime::MinedPast(number) => {
+                let Some(block) = self.storage.read_block(&BlockFilter::Number(number))? else {
+                    let filter = BlockFilter::Number(number);
+                    return Err(StratusError::RpcBlockFilterInvalid { filter });
+                };
+                Some(block)
+            }
             _ => None,
         };
 


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Improved error handling and messaging in the Ethereum executor:
  - Enhanced `from_eth_call` function in `EvmInput` with better error documentation and messaging
  - Refined error handling for invalid block numbers in `Executor::execute_read_only_local_transaction`
- Added explicit error return using `StratusError::RpcBlockFilterInvalid` for invalid block numbers
- Updated error messages to be more descriptive and helpful for debugging



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>evm_input.rs</strong><dd><code>Enhance error handling in EvmInput creation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/executor/evm_input.rs

<li>Added error documentation for <code>from_eth_call</code> function<br> <li> Improved error message for missing mined block timestamp<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1774/files#diff-9dbdf7472d01464e439067cbd23dfe3648c7fb38a307bee0cf8642ad16a1a252">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>executor.rs</strong><dd><code>Refine error handling for invalid block numbers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/executor/executor.rs

<li>Improved error handling for invalid block number in <br><code>StoragePointInTime::MinedPast</code><br> <li> Added explicit error return using <code>StratusError::RpcBlockFilterInvalid</code><br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1774/files#diff-6b460d7dee8280c0287e8d9d9d59cf66a57ec9fed1bc003c6ede6fef60c7376b">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information