### PR TITLE
chore: add docs for common `--initial-accounts`

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -234,6 +234,10 @@ pub struct RpcDownloaderConfig {
     pub paralellism: usize,
 
     /// Accounts to retrieve initial balance information.
+    ///
+    /// For Cloudwalk networks, provide these addresses for BRLC:
+    /// - Mainnet: 0xF56A88A4afF45cdb5ED7Fe63a8b71aEAaFF24FA6
+    /// - Testnet: 0xE45b176cAd7090A5CF70B69a73b6DEF9296ba6A2
     #[arg(long = "initial-accounts", env = "INITIAL_ACCOUNTS", value_delimiter = ',')]
     pub initial_accounts: Vec<Address>,
 


### PR DESCRIPTION
### **PR Type**
Documentation, Enhancement


___

### **Description**
- Enhanced the documentation for the `initial_accounts` field in the `RpcDownloaderConfig` struct
- Added specific information for Cloudwalk networks:
  - Provided BRLC addresses for Mainnet and Testnet
- Improved clarity for users configuring initial accounts in different network environments



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.rs</strong><dd><code>Add documentation for initial accounts in Cloudwalk networks</code></dd></summary>
<hr>

src/config.rs

<li>Added documentation for the <code>initial_accounts</code> field in the <br><code>RpcDownloaderConfig</code> struct<br> <li> Provided specific addresses for BRLC on Cloudwalk networks (Mainnet <br>and Testnet)<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1781/files#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecd">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information