### PR TITLE
enha: add flag for scaling rocksdb cache

### DIFF
--- a/src/eth/storage/permanent_storage.rs
+++ b/src/eth/storage/permanent_storage.rs
@@ -95,6 +95,10 @@ pub struct PermanentStorageConfig {
     /// The maximum time to wait for the RocksDB `wait_for_compaction` shutdown call.
     #[arg(long = "rocks-shutdown-timeout", env = "ROCKS_SHUTDOWN_TIMEOUT", value_parser=parse_duration, default_value = "4m")]
     pub rocks_shutdown_timeout: Duration,
+
+    /// Augments or decreases the size of Column Family caches based on a multiplier.
+    #[arg(long = "rocks-cache-size-multiplier", env = "ROCKS_CACHE_SIZE_MULTIPLIER")]
+    pub rocks_cache_size_multiplier: Option<f32>,
 }
 
 #[derive(DebugAsJson, Clone, serde::Serialize)]
@@ -124,11 +128,11 @@ impl PermanentStorageConfig {
                 Box::new(RedisPermanentStorage::new(url)?)
             }
 
-            PermanentStorageKind::Rocks => {
-                let prefix = self.rocks_path_prefix.clone();
-                let shutdown_timeout = self.rocks_shutdown_timeout;
-                Box::new(RocksPermanentStorage::new(prefix, shutdown_timeout)?)
-            }
+            PermanentStorageKind::Rocks => Box::new(RocksPermanentStorage::new(
+                self.rocks_path_prefix.clone(),
+                self.rocks_shutdown_timeout,
+                self.rocks_cache_size_multiplier,
+            )?),
         };
         Ok(perm)
     }

--- a/src/eth/storage/rocks/rocks_permanent.rs
+++ b/src/eth/storage/rocks/rocks_permanent.rs
@@ -27,7 +27,7 @@ pub struct RocksPermanentStorage {
 }
 
 impl RocksPermanentStorage {
-    pub fn new(db_path_prefix: Option<String>, shutdown_timeout: Duration) -> anyhow::Result<Self> {
+    pub fn new(db_path_prefix: Option<String>, shutdown_timeout: Duration, cache_size_multiplier: Option<f32>) -> anyhow::Result<Self> {
         tracing::info!("setting up rocksdb storage");
 
         let path = if let Some(prefix) = db_path_prefix {
@@ -48,7 +48,7 @@ impl RocksPermanentStorage {
             "data/rocksdb".to_string()
         };
 
-        let state = RocksStorageState::new(path, shutdown_timeout)?;
+        let state = RocksStorageState::new(path, shutdown_timeout, cache_size_multiplier)?;
         let block_number = state.preload_block_number()?;
 
         Ok(Self { state, block_number })

--- a/src/eth/storage/rocks/rocks_permanent.rs
+++ b/src/eth/storage/rocks/rocks_permanent.rs
@@ -27,10 +27,10 @@ pub struct RocksPermanentStorage {
 }
 
 impl RocksPermanentStorage {
-    pub fn new(rocks_path_prefix: Option<String>, shutdown_timeout: Duration) -> anyhow::Result<Self> {
+    pub fn new(db_path_prefix: Option<String>, shutdown_timeout: Duration) -> anyhow::Result<Self> {
         tracing::info!("setting up rocksdb storage");
 
-        let path = if let Some(prefix) = rocks_path_prefix {
+        let path = if let Some(prefix) = db_path_prefix {
             // run some checks on the given prefix
             if prefix.is_empty() {
                 bail!("given prefix for RocksDB is empty, try not providing the flag");


### PR DESCRIPTION
this will allow us to make experiments, as well as run Stratus or Importer-Offline on smaller VMs if necessary

(I currently need this for importer-offline)