### PR TITLE
tweak: change rpc-downloader speed reporter from bps to bpm

### DIFF
--- a/src/bin/rpc_downloader.rs
+++ b/src/bin/rpc_downloader.rs
@@ -223,11 +223,11 @@ fn blocks_per_minute_reporter() {
         let block_after = BLOCKS_DOWNLOADED.load(Ordering::Relaxed);
         let block_diff = block_after - block_before;
 
-        let blocks_per_second = block_diff as f64 / interval.as_secs_f64();
+        let blocks_per_minute = block_diff as f64 / interval.as_secs_f64() / 60.0;
 
         tracing::info!(
-            blocks_per_second = format_args!("{blocks_per_second:.2}"),
-            blocks_per_day = (blocks_per_second * 60.0 * 60.0 * 24.0) as u32,
+            blocks_per_minute = format_args!("{blocks_per_minute:.2}"),
+            blocks_per_day = (blocks_per_minute * 60.0 * 24.0) as u32,
             sample_interval = ?interval,
             "speed report",
         );


### PR DESCRIPTION
### **User description**
to help in comparing with the importer-offline reports


___

### **PR Type**
Enhancement


___

### **Description**
- Changed the speed reporting metric in the RPC downloader from blocks per second (bps) to blocks per minute (bpm)
- Updated the `blocks_per_minute_reporter` function to calculate and log blocks per minute instead of blocks per second
- Adjusted the calculation for blocks per day to use the new blocks per minute metric
- Modified the log output to display `blocks_per_minute` instead of `blocks_per_second`
- This change aligns the reporting with the importer-offline reports for easier comparison



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rpc_downloader.rs</strong><dd><code>Update speed reporting to blocks per minute</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/bin/rpc_downloader.rs

<li>Changed speed reporting from blocks per second to blocks per minute<br> <li> Updated variable names and calculations accordingly<br> <li> Adjusted log output to reflect the new metric<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1783/files#diff-34137b2d44a1c2a35b30a2515f309e99ecd04277d9b2d681ff55c5bbe30ac5c1">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information