### PR TITLE
fix: rpc downloader speed reporter

### DIFF
--- a/src/bin/rpc_downloader.rs
+++ b/src/bin/rpc_downloader.rs
@@ -223,7 +223,7 @@ fn blocks_per_minute_reporter() {
         let block_after = BLOCKS_DOWNLOADED.load(Ordering::Relaxed);
         let block_diff = block_after - block_before;
 
-        let blocks_per_minute = block_diff as f64 / interval.as_secs_f64() / 60.0;
+        let blocks_per_minute = block_diff as f64 / interval.as_secs_f64() * 60.0;
 
         tracing::info!(
             blocks_per_minute = format_args!("{blocks_per_minute:.2}"),


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed a critical bug in the `blocks_per_minute_reporter` function where the calculation of blocks per minute was incorrect.
- Changed the formula from dividing by 60.0 to multiplying by 60.0, which correctly converts the blocks per second to blocks per minute.
- This fix ensures accurate reporting of download speed in the RPC downloader.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rpc_downloader.rs</strong><dd><code>Correct blocks per minute calculation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/bin/rpc_downloader.rs

<li>Fixed calculation of blocks per minute by multiplying by 60.0 instead <br>of dividing<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1784/files#diff-34137b2d44a1c2a35b30a2515f309e99ecd04277d9b2d681ff55c5bbe30ac5c1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information