### PR TITLE
fix: rename transaction_datetime to block_datetime

### DIFF
--- a/src/ledger/events.rs
+++ b/src/ledger/events.rs
@@ -148,10 +148,10 @@ impl Serialize for AccountTransfers {
         state.serialize_field("idempotency_key", &self.idempotency_key())?;
         state.serialize_field("account_address", &self.account_address)?;
         state.serialize_field("transaction_hash", &self.transaction_hash)?;
-        state.serialize_field("transaction_datetime", &self.block_datetime.to_rfc3339())?;
         state.serialize_field("contract_address", &self.contract_address)?;
         state.serialize_field("function_id", &const_hex::encode_prefixed(self.function_id))?;
         state.serialize_field("block_number", &self.block_number.as_u64())?;
+        state.serialize_field("block_datetime", &self.block_datetime.to_rfc3339())?;
         state.serialize_field("transfers", &self.transfers)?;
         state.end()
     }
@@ -234,8 +234,8 @@ pub fn transaction_to_events(block_timestamp: UnixTime, tx: TransactionMined) ->
                 tracing::error!("bug: transaction emitting transfers must have the 4-byte signature");
                 [0; 4]
             }),
-            block_datetime: block_timestamp.into(),
             block_number: tx.block_number,
+            block_datetime: block_timestamp.into(),
             transfers: vec![],
         };
 
@@ -303,10 +303,10 @@ mod tests {
                 "idempotency_key": "0x0000000000000000000000000000000000000000000000000000000000000000::0x0000000000000000000000000000000000000000",
                 "account_address": "0x0000000000000000000000000000000000000000",
                 "transaction_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
-                "transaction_datetime": "2024-10-16T19:47:50+00:00",
                 "contract_address":"0x0000000000000000000000000000000000000000",
                 "function_id": "0x00000000",
                 "block_number": 0,
+                "block_datetime": "2024-10-16T19:47:50+00:00",
                 "transfers": [{
                     "token_address": "0x0000000000000000000000000000000000000000",
                     "debit_party_address": "0x0000000000000000000000000000000000000000",


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Renamed 'transaction_datetime' to 'block_datetime' in the AccountTransfers struct serialization for better clarity and consistency
- Reordered fields in the AccountTransfers struct and its serialization to group related fields together
- Updated the test case JSON to reflect the new field name and order
- This change improves code readability and maintains consistency in terminology across the codebase



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>events.rs</strong><dd><code>Rename and reorder datetime field in AccountTransfers</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/ledger/events.rs

<li>Renamed 'transaction_datetime' field to 'block_datetime' in <br>AccountTransfers serialization<br> <li> Updated field order in AccountTransfers struct and serialization<br> <li> Adjusted test case JSON to reflect the field name change<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1790/files#diff-3c32fd4a5d4c71b18e0d1b10b6f00f18c4dca2d3acd63d314343f7be6a219515">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information