### PR TITLE
chore: update comment

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -235,7 +235,7 @@ pub struct RpcDownloaderConfig {
 
     /// Accounts to retrieve initial balance information.
     ///
-    /// For Cloudwalk networks, provide these addresses for BRLC:
+    /// For Cloudwalk networks, provide these addresses:
     /// - Mainnet: 0xF56A88A4afF45cdb5ED7Fe63a8b71aEAaFF24FA6
     /// - Testnet: 0xE45b176cAd7090A5CF70B69a73b6DEF9296ba6A2
     #[arg(long = "initial-accounts", env = "INITIAL_ACCOUNTS", value_delimiter = ',')]


### PR DESCRIPTION
### **PR Type**
Documentation


___

### **Description**
- Updated the comment for the `initial_accounts` field in the `RpcDownloaderConfig` struct
- Removed specific mention of BRLC token for Cloudwalk networks, making the comment more generic
- The change clarifies that the provided addresses are for Cloudwalk networks in general, not specifically for BRLC token
- This update improves documentation accuracy and flexibility for different token types on Cloudwalk networks



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.rs</strong><dd><code>Update comment for initial accounts in RpcDownloaderConfig</code></dd></summary>
<hr>

src/config.rs

<li>Updated comment for <code>initial_accounts</code> field in <code>RpcDownloaderConfig</code> <br>struct<br> <li> Removed specific mention of BRLC token for Cloudwalk networks<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1795/files#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecd">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information