### PR TITLE
enha: enable WriteOptions.sync

### DIFF
--- a/src/eth/storage/rocks/rocks_batch_writer.rs
+++ b/src/eth/storage/rocks/rocks_batch_writer.rs
@@ -13,6 +13,10 @@ use super::rocks_cf::RocksCfRef;
 pub fn write_in_batch_for_multiple_cfs_impl(db: &DB, batch: WriteBatch) -> anyhow::Result<()> {
     let batch_len = batch.len();
     let mut options = WriteOptions::default();
+    // By default, each write to rocksdb is asynchronous: it returns after pushing
+    // the write from the process into the operating system (buffer cache).
+    // This option enables sync write to ensure data is persisted to disk before
+    // returning, preventing potential data loss in case of system failure.
     options.set_sync(true);
     db.write_opt(batch, &options)
         .context("failed to write in batch to (possibly) multiple column families")

--- a/src/eth/storage/rocks/rocks_batch_writer.rs
+++ b/src/eth/storage/rocks/rocks_batch_writer.rs
@@ -3,6 +3,7 @@ use std::mem;
 
 use anyhow::Context;
 use rocksdb::WriteBatch;
+use rocksdb::WriteOptions;
 use rocksdb::DB;
 use serde::Deserialize;
 use serde::Serialize;
@@ -11,7 +12,9 @@ use super::rocks_cf::RocksCfRef;
 
 pub fn write_in_batch_for_multiple_cfs_impl(db: &DB, batch: WriteBatch) -> anyhow::Result<()> {
     let batch_len = batch.len();
-    db.write(batch)
+    let mut options = WriteOptions::default();
+    options.set_sync(true);
+    db.write_opt(batch, &options)
         .context("failed to write in batch to (possibly) multiple column families")
         .inspect_err(|e| {
             tracing::error!(reason = ?e, batch_len, "failed to write batch to DB");

--- a/src/eth/storage/rocks/rocks_cf.rs
+++ b/src/eth/storage/rocks/rocks_cf.rs
@@ -84,6 +84,7 @@ where
     }
 
     // Clears the database
+    #[cfg(feature = "dev")]
     pub fn clear(&self) -> Result<()> {
         let cf = self.handle();
 
@@ -152,6 +153,7 @@ where
             .collect()
     }
 
+    #[cfg(test)]
     pub fn apply_batch_with_context(&self, batch: WriteBatch) -> Result<()> {
         self.db
             .write(batch)

--- a/src/eth/storage/rocks/rocks_cf.rs
+++ b/src/eth/storage/rocks/rocks_cf.rs
@@ -123,7 +123,7 @@ where
         self.deserialize_value_with_context(&value_bytes).map(Some)
     }
 
-    #[cfg_attr(not(test), allow(dead_code))]
+    #[allow(dead_code)]
     pub fn multi_get<I>(&self, keys: I) -> Result<Vec<(K, V)>>
     where
         I: IntoIterator<Item = K> + Clone,

--- a/src/eth/storage/rocks/rocks_cf.rs
+++ b/src/eth/storage/rocks/rocks_cf.rs
@@ -153,7 +153,7 @@ where
             .collect()
     }
 
-    #[cfg(test)]
+    #[cfg(feature = "dev")]
     pub fn apply_batch_with_context(&self, batch: WriteBatch) -> Result<()> {
         self.db
             .write(batch)

--- a/src/eth/storage/rocks/rocks_permanent.rs
+++ b/src/eth/storage/rocks/rocks_permanent.rs
@@ -57,7 +57,7 @@ impl RocksPermanentStorage {
     // -------------------------------------------------------------------------
     // State methods
     // -------------------------------------------------------------------------
-
+    #[cfg(feature = "dev")]
     pub fn clear(&self) -> anyhow::Result<()> {
         self.state.clear().inspect_err(|e| {
             tracing::error!(reason = ?e, "failed to clear RocksPermanent DB");

--- a/src/eth/storage/rocks/rocks_state.rs
+++ b/src/eth/storage/rocks/rocks_state.rs
@@ -457,7 +457,7 @@ impl RocksStorageState {
     }
 
     /// Writes slots to state (does not write to slot history)
-    #[cfg(test)]
+    #[cfg(feature = "dev")]
     pub fn write_slots(&self, slots: Vec<(Address, Slot)>) -> Result<()> {
         let slots = slots
             .into_iter()
@@ -629,6 +629,7 @@ mod tests {
     use crate::eth::primitives::ExecutionValueChange;
 
     #[test]
+    #[cfg(feature = "dev")]
     fn test_rocks_multi_get() {
         type Key = (AddressRocksdb, SlotIndexRocksdb);
         type Value = CfAccountSlotsValue;

--- a/src/eth/storage/rocks/rocks_state.rs
+++ b/src/eth/storage/rocks/rocks_state.rs
@@ -618,8 +618,6 @@ impl fmt::Debug for RocksStorageState {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashSet;
-    use std::iter;
 
     use fake::Fake;
     use fake::Faker;

--- a/src/eth/storage/rocks/rocks_state.rs
+++ b/src/eth/storage/rocks/rocks_state.rs
@@ -190,6 +190,7 @@ impl RocksStorageState {
         Ok((u64::from(block_number)).into())
     }
 
+    #[cfg(feature = "dev")]
     pub fn reset(&self) -> Result<()> {
         self.accounts.clear()?;
         self.accounts_history.clear()?;
@@ -477,7 +478,7 @@ impl RocksStorageState {
         self.accounts_history.iter_start().map(|result| Ok(result?.1.into_inner())).collect()
     }
 
-    /// Clears in-memory state.
+    #[cfg(feature = "dev")]
     pub fn clear(&self) -> Result<()> {
         self.accounts.clear().context("when clearing accounts")?;
         self.accounts_history.clear().context("when clearing accounts_history")?;


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Enabled synchronous writes in RocksDB by using `WriteOptions` with `sync` set to true in the `write_in_batch_for_multiple_cfs_impl` function.
- Added `#[cfg(feature = "dev")]` attribute to various methods across multiple files, limiting their availability to development builds only.
- Refactored method attributes and imports in test modules for better organization and clarity.
- Changed `#[cfg_attr(not(test), allow(dead_code))]` to `#[allow(dead_code)]` for the `multi_get` method in `rocks_cf.rs`.
- These changes improve data integrity by ensuring synchronous writes and better organize the codebase by clearly separating development-only features.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rocks_batch_writer.rs</strong><dd><code>Enable synchronous writes using WriteOptions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/rocks/rocks_batch_writer.rs

<li>Imported <code>WriteOptions</code> from <code>rocksdb</code><br> <li> Modified <code>write_in_batch_for_multiple_cfs_impl</code> function to use <br><code>WriteOptions</code> with <code>sync</code> set to true<br> <li> Changed <code>db.write()</code> to <code>db.write_opt()</code> with the new options<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1801/files#diff-d9ef8ac39be277b072f06ff5a4399800ecc9b3082883b20ec0a0993f8fee1cfb">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rocks_cf.rs</strong><dd><code>Refactor method attributes for development features</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/rocks/rocks_cf.rs

<li>Added <code>#[cfg(feature = "dev")]</code> to <code>clear</code> and <code>apply_batch_with_context</code> <br>methods<br> <li> Changed <code>#[cfg_attr(not(test), allow(dead_code))]</code> to <br><code>#[allow(dead_code)]</code> for <code>multi_get</code> method<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1801/files#diff-0eaed53baca4bd2355e2a54a150b305569904a45c93547da288208c6373d1df2">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rocks_permanent.rs</strong><dd><code>Add development feature flag to clear method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/rocks/rocks_permanent.rs

- Added `#[cfg(feature = "dev")]` to `clear` method



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1801/files#diff-c129c50a85915e0c5154c4e048a4577bd45ce6ae9ec98e95acbcad09ff79b3c6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rocks_state.rs</strong><dd><code>Refactor method attributes and tests for development features</code></dd></summary>
<hr>

src/eth/storage/rocks/rocks_state.rs

<li>Added <code>#[cfg(feature = "dev")]</code> to <code>reset</code>, <code>write_slots</code>, and <code>clear</code> methods<br> <li> Removed unused imports in test module<br> <li> Added <code>#[cfg(feature = "dev")]</code> to <code>test_rocks_multi_get</code> test<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1801/files#diff-f7b822022d2c4fd93ec507cd6b5302dcf1646acbf0ee0dd077a047272b686009">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information