### PR TITLE
enha: add node mode to metric tags

### DIFF
--- a/src/infra/metrics/metrics_macros.rs
+++ b/src/infra/metrics/metrics_macros.rs
@@ -49,6 +49,7 @@ macro_rules! metrics_impl_fn_inc {
                 let labels = super::into_labels(
                     vec![
                         ("group", stringify!($group).into()),
+                        ("node_mode", $crate::globals::GlobalState::get_node_mode().to_string().into()),
                         $(
                             (stringify!($label), $label.into()),
                         )*
@@ -66,6 +67,7 @@ macro_rules! metrics_impl_fn_inc {
                 let labels = super::into_labels(
                     vec![
                         ("group", stringify!($group).into()),
+                        ("node_mode", $crate::globals::GlobalState::get_node_mode().to_string().into()),
                         $(
                             (stringify!($label), $label.into()),
                         )*
@@ -84,6 +86,7 @@ macro_rules! metrics_impl_fn_inc {
                 let labels = super::into_labels(
                     vec![
                         ("group", stringify!($group).into()),
+                        ("node_mode", $crate::globals::GlobalState::get_node_mode().to_string().into()),
                         $(
                             (stringify!($label), $label.into()),
                         )*
@@ -102,6 +105,7 @@ macro_rules! metrics_impl_fn_inc {
                 let labels = super::into_labels(
                     vec![
                         ("group", stringify!($group).into()),
+                        ("node_mode", $crate::globals::GlobalState::get_node_mode().to_string().into()),
                         $(
                             (stringify!($label), $label.into()),
                         )*
@@ -120,6 +124,7 @@ macro_rules! metrics_impl_fn_inc {
                 let labels = super::into_labels(
                     vec![
                         ("group", stringify!($group).into()),
+                        ("node_mode", $crate::globals::GlobalState::get_node_mode().to_string().into()),
                         $(
                             (stringify!($label), $label.into()),
                         )*

--- a/src/infra/metrics/metrics_macros.rs
+++ b/src/infra/metrics/metrics_macros.rs
@@ -49,7 +49,7 @@ macro_rules! metrics_impl_fn_inc {
                 let labels = super::into_labels(
                     vec![
                         ("group", stringify!($group).into()),
-                        ("node_mode", $crate::globals::GlobalState::get_node_mode().to_string().into()),
+                        ("node_mode", stringify!($crate::globals::GlobalState::get_node_mode()).into()),
                         $(
                             (stringify!($label), $label.into()),
                         )*
@@ -67,7 +67,7 @@ macro_rules! metrics_impl_fn_inc {
                 let labels = super::into_labels(
                     vec![
                         ("group", stringify!($group).into()),
-                        ("node_mode", $crate::globals::GlobalState::get_node_mode().to_string().into()),
+                        ("node_mode", stringify!($crate::globals::GlobalState::get_node_mode()).into()),
                         $(
                             (stringify!($label), $label.into()),
                         )*
@@ -86,7 +86,7 @@ macro_rules! metrics_impl_fn_inc {
                 let labels = super::into_labels(
                     vec![
                         ("group", stringify!($group).into()),
-                        ("node_mode", $crate::globals::GlobalState::get_node_mode().to_string().into()),
+                        ("node_mode", stringify!($crate::globals::GlobalState::get_node_mode()).into()),
                         $(
                             (stringify!($label), $label.into()),
                         )*
@@ -105,7 +105,7 @@ macro_rules! metrics_impl_fn_inc {
                 let labels = super::into_labels(
                     vec![
                         ("group", stringify!($group).into()),
-                        ("node_mode", $crate::globals::GlobalState::get_node_mode().to_string().into()),
+                        ("node_mode", stringify!($crate::globals::GlobalState::get_node_mode()).into()),
                         $(
                             (stringify!($label), $label.into()),
                         )*
@@ -124,7 +124,7 @@ macro_rules! metrics_impl_fn_inc {
                 let labels = super::into_labels(
                     vec![
                         ("group", stringify!($group).into()),
-                        ("node_mode", $crate::globals::GlobalState::get_node_mode().to_string().into()),
+                        ("node_mode", stringify!($crate::globals::GlobalState::get_node_mode()).into()),
                         $(
                             (stringify!($label), $label.into()),
                         )*


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added a new "node_mode" label to all metric types (counter, histogram, gauge) in the metrics macro implementations.
- The node mode is dynamically obtained from `GlobalState::get_node_mode()` for each metric call.
- This enhancement allows for better categorization and analysis of metrics based on the current node mode.
- The change is consistently applied across different metric macro implementations, ensuring uniform behavior.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>metrics_macros.rs</strong><dd><code>Add node mode label to all metrics</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/infra/metrics/metrics_macros.rs

<li>Added "node_mode" label to all metric types (counter, histogram, <br>gauge)<br> <li> The node mode is obtained from <code>GlobalState::get_node_mode()</code><br> <li> Applied changes consistently across different metric macro <br>implementations<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1807/files#diff-f6d65111492e2c296e7d7a8333142d2dfbcdbb4a09967415ca0eaae3c7c8828e">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information