### PR TITLE
fix: span across yield point in `eth_subscribe`

### DIFF
--- a/src/eth/rpc/rpc_parser.rs
+++ b/src/eth/rpc/rpc_parser.rs
@@ -8,6 +8,7 @@ use tracing::Span;
 use crate::eth::primitives::StratusError;
 use crate::eth::rpc::rpc_client_app::RpcClientApp;
 use crate::ext::type_basename;
+use crate::infra::tracing::EnteredWrap;
 
 /// Extensions for jsonrpsee Extensions.
 pub trait RpcExtensionsExt {
@@ -15,7 +16,7 @@ pub trait RpcExtensionsExt {
     fn rpc_client(&self) -> &RpcClientApp;
 
     /// Enters RpcMiddleware request span if present.
-    fn enter_middleware_span(&self) -> Option<tracing::span::Entered<'_>>;
+    fn enter_middleware_span(&self) -> Option<EnteredWrap<'_>>;
 }
 
 impl RpcExtensionsExt for Extensions {
@@ -23,8 +24,8 @@ impl RpcExtensionsExt for Extensions {
         self.get::<RpcClientApp>().unwrap_or(&RpcClientApp::Unknown)
     }
 
-    fn enter_middleware_span(&self) -> Option<tracing::span::Entered<'_>> {
-        self.get::<Span>().map(|s| s.enter())
+    fn enter_middleware_span(&self) -> Option<EnteredWrap<'_>> {
+        self.get::<Span>().map(|s| s.enter()).map(EnteredWrap::new)
     }
 }
 

--- a/src/infra/tracing/mod.rs
+++ b/src/infra/tracing/mod.rs
@@ -1,9 +1,11 @@
 mod tracing_config;
+mod tracing_entered_wrap;
 mod tracing_services;
 
 pub use tracing_config::TracingConfig;
 pub use tracing_config::TracingLogFormat;
 pub use tracing_config::TracingProtocol;
+pub use tracing_entered_wrap::EnteredWrap;
 pub use tracing_services::info_task_spawn;
 pub use tracing_services::new_cid;
 pub use tracing_services::warn_task_cancellation;

--- a/src/infra/tracing/tracing_entered_wrap.rs
+++ b/src/infra/tracing/tracing_entered_wrap.rs
@@ -1,0 +1,25 @@
+use std::marker::PhantomData;
+
+use tracing::span::Entered;
+
+/// A wrapper around `tracing::span::Entered` that is not `Send`.
+///
+/// This is useful for ensuring that a span is not sent to another thread,
+/// specially to prevent most cases of spans being helf accross await points.
+pub struct EnteredWrap<'a> {
+    // we only care about its destructor
+    _entered: Entered<'a>,
+    _not_send: NotSendMarker,
+}
+
+impl<'a> EnteredWrap<'a> {
+    pub fn new(entered: Entered<'a>) -> Self {
+        Self {
+            _entered: entered,
+            _not_send: PhantomData,
+        }
+    }
+}
+
+// workaround for making a type !Send while negative trait bounds is an unstable feature
+type NotSendMarker = PhantomData<*mut ()>;


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed a bug in `eth_subscribe` where spans were held across await points, potentially causing issues with tracing
- Introduced `EnteredWrap`, a new type that wraps `tracing::span::Entered` and is not `Send`, preventing spans from being sent to another thread
- Modified `RpcExtensionsExt` trait and its implementation to use `EnteredWrap`
- Improved span handling in `eth_subscribe` by introducing a `clear_spans` function to properly drop spans before await points
- Updated the tracing module to include and export the new `EnteredWrap` type



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rpc_parser.rs</strong><dd><code>Modify middleware span handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/rpc/rpc_parser.rs

<li>Changed <code>enter_middleware_span</code> to return <code>Option<EnteredWrap<'_>></code> instead of <code>Option<tracing::span::Entered<'_>></code><br> <li> Added import for <code>EnteredWrap</code> from <code>crate::infra::tracing</code><br> <li> Modified <code>enter_middleware_span</code> implementation to wrap the <code>Entered</code> in <br><code>EnteredWrap</code><br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1810/files#diff-2756485347ebcee6b3104300efc1ebc605d7ba6ede30878111e2a7d4dbe46b40">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Add EnteredWrap to tracing module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/infra/tracing/mod.rs

<li>Added new module <code>tracing_entered_wrap</code><br> <li> Exported <code>EnteredWrap</code> from the new module<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1810/files#diff-177bb3ac35078ce299aee9ab01589bb566842c1331c17e2a8b878c6268fdc8c1">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>tracing_entered_wrap.rs</strong><dd><code>Implement EnteredWrap for safer span handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/infra/tracing/tracing_entered_wrap.rs

<li>Introduced new <code>EnteredWrap</code> struct to wrap <code>tracing::span::Entered</code><br> <li> Implemented <code>EnteredWrap</code> to prevent sending spans across threads<br> <li> Added <code>NotSendMarker</code> type as a workaround for making <code>EnteredWrap</code> not <br><code>Send</code><br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1810/files#diff-dab7deafcbf16ade9980faaf817f11ac993b541f54bb8589c6645030bc0d193d">+25/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rpc_server.rs</strong><dd><code>Improve span handling in eth_subscribe</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/rpc/rpc_server.rs

<li>Introduced <code>clear_spans</code> function to drop spans before await points<br> <li> Modified <code>eth_subscribe</code> function to use <code>clear_spans</code> at appropriate <br>locations<br> <li> Removed individual <code>drop(method_enter)</code> calls<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1810/files#diff-835ba255c9a5c1fe0e13285bc39e058e1c74422e5e03ebba483c9d8a15c45405">+6/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information