### PR TITLE
tests: fix: await sendEvmMine

### DIFF
--- a/e2e/test/helpers/rpc.ts
+++ b/e2e/test/helpers/rpc.ts
@@ -330,7 +330,7 @@ export async function subscribeAndGetEventWithContract(
     shouldMine: boolean = false,
 ): Promise<any> {
     const contract = await deployTestContractBalances();
-    if (shouldMine) sendEvmMine();
+    if (shouldMine) await sendEvmMine();
     const contractAddress = await contract.getAddress();
     const socket = openWebSocketConnection();
     addOpenListener(socket, subscription, { address: contractAddress });


### PR DESCRIPTION
### **PR Type**
Bug fix, Tests


___

### **Description**
- Fixed a potential race condition in the `subscribeAndGetEventWithContract` function by properly awaiting the `sendEvmMine()` call.
- This change ensures that the EVM mining operation completes before proceeding with the rest of the function execution.
- Improves the reliability of tests that depend on this helper function, especially when dealing with contract events and blockchain state changes.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rpc.ts</strong><dd><code>Fix asynchronous behavior in EVM mining</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

e2e/test/helpers/rpc.ts

<li>Added <code>await</code> keyword to <code>sendEvmMine()</code> call inside <br><code>subscribeAndGetEventWithContract</code> function<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1816/files#diff-de92f3345fb0b828a3a1af4938646038808ddee426127f029255c9c10bdaa1bb">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information