### PR TITLE
enha: metrify errors for all eth methods

### DIFF
--- a/src/eth/executor/executor.rs
+++ b/src/eth/executor/executor.rs
@@ -35,6 +35,7 @@ use crate::eth::storage::StratusStorage;
 use crate::ext::spawn_thread;
 use crate::ext::to_json_string;
 use crate::ext::MutexExt;
+#[cfg(feature = "metrics")]
 use crate::ext::OptionExt;
 #[cfg(feature = "metrics")]
 use crate::infra::metrics;

--- a/src/eth/rpc/rpc_method_wrapper.rs
+++ b/src/eth/rpc/rpc_method_wrapper.rs
@@ -11,7 +11,7 @@ use crate::infra::metrics::inc_executor_transaction_error_types;
 
 cfg_if! {
     if #[cfg(feature = "metrics")] {
-        pub fn call_error_metrics_wrapper<F, T>(function: F) -> impl Fn(Params<'_>, Arc<RpcContext>, Extensions) -> Result<T, StratusError> + Clone
+        pub fn metrics_wrapper<F, T>(function: F) -> impl Fn(Params<'_>, Arc<RpcContext>, Extensions) -> Result<T, StratusError> + Clone
         where
             F: Fn(Params<'_>, Arc<RpcContext>, &Extensions) -> Result<T, StratusError> + Clone,
         {
@@ -24,7 +24,7 @@ cfg_if! {
             }
         }
     } else {
-        pub fn call_error_metrics_wrapper<F, T>(function: F) -> impl Fn(Params<'_>, Arc<RpcContext>, Extensions) -> Result<T, StratusError> + Clone
+        pub fn metrics_wrapper<F, T>(function: F) -> impl Fn(Params<'_>, Arc<RpcContext>, Extensions) -> Result<T, StratusError> + Clone
         where
             F: Fn(Params<'_>, Arc<RpcContext>, &Extensions) -> Result<T, StratusError> + Clone,
         {

--- a/src/eth/rpc/rpc_middleware.rs
+++ b/src/eth/rpc/rpc_middleware.rs
@@ -8,6 +8,7 @@ use futures::future::BoxFuture;
 use jsonrpsee::server::middleware::rpc::layer::ResponseFuture;
 use jsonrpsee::server::middleware::rpc::RpcService;
 use jsonrpsee::server::middleware::rpc::RpcServiceT;
+#[cfg(feature = "metrics")]
 use jsonrpsee::server::ConnectionGuard;
 use jsonrpsee::types::error::INTERNAL_ERROR_CODE;
 use jsonrpsee::types::Params;
@@ -182,6 +183,7 @@ impl<'a> Future for RpcResponse<'a> {
             let response_success = response.is_success();
             let response_result: JsonValue = from_json_str(response.as_result());
 
+            #[cfg_attr(not(feature = "metrics"), allow(unused_variables))]
             let (level, error_code) = match response_result
                 .get("error")
                 .and_then(|v| v.get("code"))

--- a/src/eth/rpc/rpc_server.rs
+++ b/src/eth/rpc/rpc_server.rs
@@ -33,7 +33,7 @@ use tracing::info_span;
 use tracing::Instrument;
 use tracing::Span;
 
-use super::rpc_method_wrapper::call_error_metrics_wrapper;
+use super::rpc_method_wrapper::metrics_wrapper;
 use crate::alias::JsonValue;
 use crate::eth::executor::Executor;
 use crate::eth::follower::consensus::Consensus;
@@ -206,29 +206,29 @@ fn register_methods(mut module: RpcModule<RpcContext>) -> anyhow::Result<RpcModu
     module.register_method("eth_gasPrice", eth_gas_price)?;
 
     // block
-    module.register_blocking_method("eth_blockNumber", eth_block_number)?;
-    module.register_blocking_method("eth_getBlockByNumber", eth_get_block_by_number)?;
-    module.register_blocking_method("eth_getBlockByHash", eth_get_block_by_hash)?;
+    module.register_blocking_method("eth_blockNumber", metrics_wrapper(eth_block_number))?;
+    module.register_blocking_method("eth_getBlockByNumber", metrics_wrapper(eth_get_block_by_number))?;
+    module.register_blocking_method("eth_getBlockByHash", metrics_wrapper(eth_get_block_by_hash))?;
     module.register_method("eth_getUncleByBlockHashAndIndex", eth_get_uncle_by_block_hash_and_index)?;
 
     // transactions
-    module.register_blocking_method("eth_getTransactionByHash", eth_get_transaction_by_hash)?;
-    module.register_blocking_method("eth_getTransactionReceipt", eth_get_transaction_receipt)?;
-    module.register_blocking_method("eth_estimateGas", eth_estimate_gas)?;
-    module.register_blocking_method("eth_call", call_error_metrics_wrapper(eth_call))?;
-    module.register_blocking_method("eth_sendRawTransaction", call_error_metrics_wrapper(eth_send_raw_transaction))?;
+    module.register_blocking_method("eth_getTransactionByHash", metrics_wrapper(eth_get_transaction_by_hash))?;
+    module.register_blocking_method("eth_getTransactionReceipt", metrics_wrapper(eth_get_transaction_receipt))?;
+    module.register_blocking_method("eth_estimateGas", metrics_wrapper(eth_estimate_gas))?;
+    module.register_blocking_method("eth_call", metrics_wrapper(eth_call))?;
+    module.register_blocking_method("eth_sendRawTransaction", metrics_wrapper(eth_send_raw_transaction))?;
 
     // logs
-    module.register_blocking_method("eth_getLogs", eth_get_logs)?;
+    module.register_blocking_method("eth_getLogs", metrics_wrapper(eth_get_logs))?;
 
     // account
     module.register_method("eth_accounts", eth_accounts)?;
-    module.register_blocking_method("eth_getTransactionCount", eth_get_transaction_count)?;
-    module.register_blocking_method("eth_getBalance", eth_get_balance)?;
-    module.register_blocking_method("eth_getCode", eth_get_code)?;
+    module.register_blocking_method("eth_getTransactionCount", metrics_wrapper(eth_get_transaction_count))?;
+    module.register_blocking_method("eth_getBalance", metrics_wrapper(eth_get_balance))?;
+    module.register_blocking_method("eth_getCode", metrics_wrapper(eth_get_code))?;
 
     // storage
-    module.register_blocking_method("eth_getStorageAt", eth_get_storage_at)?;
+    module.register_blocking_method("eth_getStorageAt", metrics_wrapper(eth_get_storage_at))?;
 
     // subscriptions
     module.register_subscription("eth_subscribe", "eth_subscription", "eth_unsubscribe", eth_subscribe)?;
@@ -625,7 +625,7 @@ fn eth_gas_price(_: Params<'_>, _: &RpcContext, _: &Extensions) -> String {
 // Block
 // -----------------------------------------------------------------------------
 
-fn eth_block_number(_params: Params<'_>, ctx: Arc<RpcContext>, ext: Extensions) -> Result<JsonValue, StratusError> {
+fn eth_block_number(_params: Params<'_>, ctx: Arc<RpcContext>, ext: &Extensions) -> Result<JsonValue, StratusError> {
     // enter span
     let _middleware_enter = ext.enter_middleware_span();
     let _method_enter = info_span!("rpc::eth_blockNumber", block_number = field::Empty).entered();
@@ -637,16 +637,16 @@ fn eth_block_number(_params: Params<'_>, ctx: Arc<RpcContext>, ext: Extensions) 
     Ok(to_json_value(block_number))
 }
 
-fn eth_get_block_by_hash(params: Params<'_>, ctx: Arc<RpcContext>, ext: Extensions) -> Result<JsonValue, StratusError> {
+fn eth_get_block_by_hash(params: Params<'_>, ctx: Arc<RpcContext>, ext: &Extensions) -> Result<JsonValue, StratusError> {
     eth_get_block_by_selector::<'h'>(params, ctx, ext)
 }
 
-fn eth_get_block_by_number(params: Params<'_>, ctx: Arc<RpcContext>, ext: Extensions) -> Result<JsonValue, StratusError> {
+fn eth_get_block_by_number(params: Params<'_>, ctx: Arc<RpcContext>, ext: &Extensions) -> Result<JsonValue, StratusError> {
     eth_get_block_by_selector::<'n'>(params, ctx, ext)
 }
 
 #[inline(always)]
-fn eth_get_block_by_selector<const KIND: char>(params: Params<'_>, ctx: Arc<RpcContext>, ext: Extensions) -> Result<JsonValue, StratusError> {
+fn eth_get_block_by_selector<const KIND: char>(params: Params<'_>, ctx: Arc<RpcContext>, ext: &Extensions) -> Result<JsonValue, StratusError> {
     // enter span
     let _middleware_enter = ext.enter_middleware_span();
     let _method_enter = if KIND == 'h' {
@@ -708,7 +708,7 @@ fn eth_get_uncle_by_block_hash_and_index(_: Params<'_>, _: &RpcContext, _: &Exte
 // Transaction
 // -----------------------------------------------------------------------------
 
-fn eth_get_transaction_by_hash(params: Params<'_>, ctx: Arc<RpcContext>, ext: Extensions) -> Result<JsonValue, StratusError> {
+fn eth_get_transaction_by_hash(params: Params<'_>, ctx: Arc<RpcContext>, ext: &Extensions) -> Result<JsonValue, StratusError> {
     // enter span
     let _middleware_enter = ext.enter_middleware_span();
     let _method_enter = info_span!("rpc::eth_getTransactionByHash", tx_hash = field::Empty, found = field::Empty).entered();
@@ -739,7 +739,7 @@ fn eth_get_transaction_by_hash(params: Params<'_>, ctx: Arc<RpcContext>, ext: Ex
     }
 }
 
-fn eth_get_transaction_receipt(params: Params<'_>, ctx: Arc<RpcContext>, ext: Extensions) -> Result<JsonValue, StratusError> {
+fn eth_get_transaction_receipt(params: Params<'_>, ctx: Arc<RpcContext>, ext: &Extensions) -> Result<JsonValue, StratusError> {
     // enter span
     let _middleware_enter = ext.enter_middleware_span();
     let _method_enter = info_span!("rpc::eth_getTransactionReceipt", tx_hash = field::Empty, found = field::Empty).entered();
@@ -770,7 +770,7 @@ fn eth_get_transaction_receipt(params: Params<'_>, ctx: Arc<RpcContext>, ext: Ex
     }
 }
 
-fn eth_estimate_gas(params: Params<'_>, ctx: Arc<RpcContext>, ext: Extensions) -> Result<String, StratusError> {
+fn eth_estimate_gas(params: Params<'_>, ctx: Arc<RpcContext>, ext: &Extensions) -> Result<String, StratusError> {
     // enter span
     let _middleware_enter = ext.enter_middleware_span();
     let _method_enter = info_span!("rpc::eth_estimateGas", tx_from = field::Empty, tx_to = field::Empty).entered();
@@ -974,7 +974,7 @@ fn eth_accounts(_: Params<'_>, _ctx: &RpcContext, _: &Extensions) -> Result<Json
     Ok(json!([]))
 }
 
-fn eth_get_transaction_count(params: Params<'_>, ctx: Arc<RpcContext>, ext: Extensions) -> Result<String, StratusError> {
+fn eth_get_transaction_count(params: Params<'_>, ctx: Arc<RpcContext>, ext: &Extensions) -> Result<String, StratusError> {
     // enter span
     let _middleware_enter = ext.enter_middleware_span();
     let _method_enter = info_span!("rpc::eth_getTransactionCount", address = field::Empty, filter = field::Empty).entered();
@@ -996,7 +996,7 @@ fn eth_get_transaction_count(params: Params<'_>, ctx: Arc<RpcContext>, ext: Exte
     Ok(hex_num(account.nonce))
 }
 
-fn eth_get_balance(params: Params<'_>, ctx: Arc<RpcContext>, ext: Extensions) -> Result<String, StratusError> {
+fn eth_get_balance(params: Params<'_>, ctx: Arc<RpcContext>, ext: &Extensions) -> Result<String, StratusError> {
     // enter span
     let _middleware_enter = ext.enter_middleware_span();
     let _method_enter = info_span!("rpc::eth_getBalance", address = field::Empty, filter = field::Empty).entered();
@@ -1019,7 +1019,7 @@ fn eth_get_balance(params: Params<'_>, ctx: Arc<RpcContext>, ext: Extensions) ->
     Ok(hex_num(account.balance))
 }
 
-fn eth_get_code(params: Params<'_>, ctx: Arc<RpcContext>, ext: Extensions) -> Result<String, StratusError> {
+fn eth_get_code(params: Params<'_>, ctx: Arc<RpcContext>, ext: &Extensions) -> Result<String, StratusError> {
     // enter span
     let _middleware_enter = ext.enter_middleware_span();
     let _method_enter = info_span!("rpc::eth_getCode", address = field::Empty, filter = field::Empty).entered();
@@ -1119,7 +1119,7 @@ async fn eth_subscribe(params: Params<'_>, pending: PendingSubscriptionSink, ctx
 // Storage
 // -----------------------------------------------------------------------------
 
-fn eth_get_storage_at(params: Params<'_>, ctx: Arc<RpcContext>, ext: Extensions) -> Result<String, StratusError> {
+fn eth_get_storage_at(params: Params<'_>, ctx: Arc<RpcContext>, ext: &Extensions) -> Result<String, StratusError> {
     // enter span
     let _middleware_enter = ext.enter_middleware_span();
     let _method_enter = info_span!("rpc::eth_getStorageAt", address = field::Empty, index = field::Empty).entered();

--- a/src/eth/storage/rocks/rocks_state.rs
+++ b/src/eth/storage/rocks/rocks_state.rs
@@ -51,6 +51,7 @@ use crate::eth::primitives::SlotIndex;
 use crate::eth::primitives::TransactionMined;
 use crate::eth::storage::rocks::types::SlotValueRocksdb;
 use crate::eth::storage::StoragePointInTime;
+#[cfg(feature = "metrics")]
 use crate::ext::MutexExt;
 use crate::ext::OptionExt;
 use crate::log_and_err;


### PR DESCRIPTION
### **User description**
now all sync eth methods used in production report errors to the same metric


___

### **PR Type**
Enhancement


___

### **Description**
- Refactored the metrics wrapper in `rpc_method_wrapper.rs`:
  - Renamed `call_error_metrics_wrapper` to `metrics_wrapper` for clarity
  - Introduced `metrify_stratus_error` function to centralize error handling logic
  - Simplified the wrapper implementation
- Updated `rpc_server.rs` to use the new `metrics_wrapper`:
  - Applied `metrics_wrapper` to all relevant RPC methods
  - Modified function signatures to use `&Extensions` instead of `Extensions`
  - Removed unnecessary `Arc` wrapping for `RpcContext` in some function calls
- These changes improve code consistency, error handling, and metrics collection across all Ethereum RPC methods



___



PRDescriptionHeader.CHANGES_WALKTHROUGH
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rpc_method_wrapper.rs</strong><dd><code>Refactor metrics wrapper for improved error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/rpc/rpc_method_wrapper.rs

<li>Renamed <code>call_error_metrics_wrapper</code> to <code>metrics_wrapper</code><br> <li> Simplified error handling logic by introducing <code>metrify_stratus_error</code> <br>function<br> <li> Updated conditional compilation for metrics feature<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1825/files#diff-0bbd6e729eb4e018401d1475a5dd64871ecb654be7b3d125c48c204fbddc9545">+9/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rpc_server.rs</strong><dd><code>Apply metrics wrapper to RPC methods and refactor signatures</code></dd></summary>
<hr>

src/eth/rpc/rpc_server.rs

<li>Applied <code>metrics_wrapper</code> to all relevant RPC methods<br> <li> Updated function signatures to use <code>&Extensions</code> instead of <code>Extensions</code><br> <li> Removed unnecessary <code>Arc</code> wrapping for <code>RpcContext</code> in some function calls<br> <br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1825/files#diff-835ba255c9a5c1fe0e13285bc39e058e1c74422e5e03ebba483c9d8a15c45405">+25/-25</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information