### PR TITLE
enha: add method name to the rpc errors metric

### DIFF
--- a/src/eth/rpc/rpc_method_wrapper.rs
+++ b/src/eth/rpc/rpc_method_wrapper.rs
@@ -10,24 +10,24 @@ use crate::eth::primitives::StratusError;
 cfg_if! {
     if #[cfg(feature = "metrics")] {
         use super::rpc_parser::RpcExtensionsExt;
-        use crate::infra::metrics::inc_executor_transaction_error_types;
+        use crate::infra::metrics::inc_rpc_error_response;
 
-        fn metrify_stratus_error(err: &StratusError, extensions: &Extensions) {
+        fn metrify_stratus_error(err: &StratusError, extensions: &Extensions, method_name: &'static str) {
             let error_type = <&'static str>::from(err);
             let client = extensions.rpc_client();
-            inc_executor_transaction_error_types(error_type, client);
+            inc_rpc_error_response(error_type, client, method_name);
         }
 
-        pub fn metrics_wrapper<F, T>(function: F) -> impl Fn(Params<'_>, Arc<RpcContext>, Extensions) -> Result<T, StratusError> + Clone
+        pub fn metrics_wrapper<F, T>(function: F, method_name: &'static str) -> impl Fn(Params<'_>, Arc<RpcContext>, Extensions) -> Result<T, StratusError> + Clone
         where
             F: Fn(Params<'_>, Arc<RpcContext>, &Extensions) -> Result<T, StratusError> + Clone,
         {
             move |params, ctx, extensions| {
-                function(params, ctx, &extensions).inspect_err(|e| metrify_stratus_error(e, &extensions))
+                function(params, ctx, &extensions).inspect_err(|e| metrify_stratus_error(e, &extensions, method_name))
             }
         }
     } else {
-        pub fn metrics_wrapper<F, T>(function: F) -> impl Fn(Params<'_>, Arc<RpcContext>, Extensions) -> Result<T, StratusError> + Clone
+        pub fn metrics_wrapper<F, T>(function: F, _method_name: &'static str) -> impl Fn(Params<'_>, Arc<RpcContext>, Extensions) -> Result<T, StratusError> + Clone
         where
             F: Fn(Params<'_>, Arc<RpcContext>, &Extensions) -> Result<T, StratusError> + Clone,
         {

--- a/src/infra/metrics/metrics_definitions.rs
+++ b/src/infra/metrics/metrics_definitions.rs
@@ -14,7 +14,10 @@ metrics! {
     histogram_duration rpc_requests_finished{client, method, contract, function, result, result_code, success},
 
     "Number of JSON-RPC subscriptions active right now."
-    gauge rpc_subscriptions_active{subscription, client}
+    gauge rpc_subscriptions_active{subscription, client},
+
+    "Number of times we respons a client with an error."
+    counter rpc_error_response{error_type, client, method}
 }
 
 // Storage reads.
@@ -130,10 +133,7 @@ metrics! {
     histogram_counter executor_local_call_slot_reads{contract, function},
 
     "Gas spent executing a local call."
-    histogram_counter executor_local_call_gas{contract, function},
-
-    "Count types of errors when executing a transaction."
-    counter executor_transaction_error_types{error_type, client}
+    histogram_counter executor_local_call_gas{contract, function}
 }
 
 metrics! {


### PR DESCRIPTION
### **User description**
also rename metric from `executor_transaction_error_types` to `rpc_error_response`


___

### **PR Type**
Enhancement


___

### **Description**
- Added method name to RPC error metrics for better error tracking and analysis
- Refactored RPC method registration process to include method name in metrics wrapper
- Renamed `executor_transaction_error_types` metric to `rpc_error_response`
- Updated `rpc_error_response` metric to include `method` label alongside `error_type` and `client`
- Introduced a new helper function `register_blocking_method` to streamline method registration with metrics wrapper
- Updated all relevant RPC method registrations to use the new helper function



___



PRDescriptionHeader.CHANGES_WALKTHROUGH
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rpc_method_wrapper.rs</strong><dd><code>Add method name to RPC error metrics</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/rpc/rpc_method_wrapper.rs

<li>Renamed metric from <code>executor_transaction_error_types</code> to <br><code>rpc_error_response</code><br> <li> Added <code>method_name</code> parameter to <code>metrify_stratus_error</code> and <br><code>metrics_wrapper</code> functions<br> <li> Updated <code>inc_executor_transaction_error_types</code> to <code>inc_rpc_error_response</code> <br>with additional <code>method_name</code> parameter<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1826/files#diff-0bbd6e729eb4e018401d1475a5dd64871ecb654be7b3d125c48c204fbddc9545">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rpc_server.rs</strong><dd><code>Refactor RPC method registration with metrics wrapper</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/rpc/rpc_server.rs

<li>Introduced new <code>register_blocking_method</code> helper function<br> <li> Updated all <code>register_blocking_method</code> calls to use the new helper <br>function<br> <li> Added <code>method_name</code> parameter to <code>metrics_wrapper</code> calls<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1826/files#diff-835ba255c9a5c1fe0e13285bc39e058e1c74422e5e03ebba483c9d8a15c45405">+28/-13</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>metrics_definitions.rs</strong><dd><code>Update metrics definitions for RPC errors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/infra/metrics/metrics_definitions.rs

<li>Removed <code>executor_transaction_error_types</code> metric<br> <li> Added new <code>rpc_error_response</code> metric with <code>error_type</code>, <code>client</code>, and <br><code>method</code> labels<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1826/files#diff-2ca1adc579301e6de5f9e1d69eb1ed2f70aeee0f3b54fe113346040b4eab652b">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information