### PR TITLE
enha: add function to queue events to allow for sending in batches

### DIFF
--- a/src/eth/follower/importer/importer.rs
+++ b/src/eth/follower/importer/importer.rs
@@ -234,7 +234,7 @@ impl Importer {
                     let events = transaction_to_events(mined_block.header.timestamp, Cow::Borrowed(tx));
                     for event in events {
                         if let Err(e) = kafka_conn.send_event(event).await {
-                            tracing::error!(reason = ?e, block_number = %mined_block.number(), "failed to send block to kafka");
+                            tracing::error!(reason = ?e, block_number = %mined_block.number(), tx_hash = ?tx.input.hash, "failed to send transfer event to kafka");
                         }
                     }
                 }


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added a new `queue_event` function in the `KafkaConnector` to allow for batched event sending
- Modified `send_event` to use the new `queue_event` function, improving efficiency
- Enhanced error logging in the importer, now including transaction hash for failed Kafka event sending
- Improved error handling and logging for Kafka event publishing process
- These changes allow for more efficient event handling and better debugging capabilities



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>importer.rs</strong><dd><code>Enhanced error logging for Kafka event sending</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/follower/importer/importer.rs

<li>Improved error logging for failed Kafka event sending, now including <br>transaction hash<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1828/files#diff-bd50f502f039aff8f75753bc780d281ae7d7936fadc9d53482084c647aec94ca">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>kafka.rs</strong><dd><code>Implemented event queueing for Kafka publishing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/infra/kafka/kafka.rs

<li>Added <code>queue_event</code> function to allow for batched event sending<br> <li> Modified <code>send_event</code> to use the new <code>queue_event</code> function<br> <li> Improved error handling and logging for Kafka event publishing<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1828/files#diff-516e87c7aa8eb8e7908ce3727257a1f4ee49127c5e0e7dcd60fac65c3afcafef">+17/-4</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information