### PR TITLE
feat: send_buffered function to send events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4999,6 +4999,7 @@ dependencies = [
  "fake",
  "fancy-duration",
  "futures",
+ "futures-channel",
  "futures-timer",
  "futures-util",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ crossbeam-channel = "=0.5.13"
 futures = "=0.3.30"
 futures-timer = "=3.0.3"
 futures-util = "=0.3.31"
+futures-channel = "=0.3.31"
 
 # ethereum / rpc
 ethabi = "=18.0.0"

--- a/src/infra/kafka/kafka.rs
+++ b/src/infra/kafka/kafka.rs
@@ -2,8 +2,11 @@ use anyhow::Result;
 use clap::Parser;
 use clap::ValueEnum;
 use display_json::DebugAsJson;
+use futures::Stream;
+use futures::StreamExt;
 use rdkafka::message::Header;
 use rdkafka::message::OwnedHeaders;
+use rdkafka::producer::future_producer::OwnedDeliveryResult;
 use rdkafka::producer::DeliveryFuture;
 use rdkafka::producer::FutureProducer;
 use rdkafka::producer::FutureRecord;
@@ -162,13 +165,23 @@ impl KafkaConnector {
 
     pub async fn send_event<T: Event>(&self, event: T) -> Result<()> {
         match self.queue_event(event) {
-            Ok(fut) =>
+            Ok(fut) => {
                 if let Err(e) = fut.await {
                     log_and_err!(reason = e, "failed to publish kafka event")
                 } else {
                     Ok(())
-                },
+                }
+            }
             Err(e) => Err(e),
         }
+    }
+
+    pub async fn send_buffered<T: Event>(
+        &self,
+        events: Vec<T>,
+        buffer_size: usize,
+    ) -> Result<impl Stream<Item = Result<OwnedDeliveryResult, futures_channel::oneshot::Canceled>>> {
+        let futures: Vec<DeliveryFuture> = events.into_iter().map(|event| self.queue_event(event)).collect::<Result<Vec<_>, _>>()?;
+        Ok(futures::stream::iter(futures).buffered(buffer_size))
     }
 }

--- a/src/infra/kafka/kafka.rs
+++ b/src/infra/kafka/kafka.rs
@@ -165,18 +165,17 @@ impl KafkaConnector {
 
     pub async fn send_event<T: Event>(&self, event: T) -> Result<()> {
         match self.queue_event(event) {
-            Ok(fut) => {
+            Ok(fut) =>
                 if let Err(e) = fut.await {
                     log_and_err!(reason = e, "failed to publish kafka event")
                 } else {
                     Ok(())
-                }
-            }
+                },
             Err(e) => Err(e),
         }
     }
 
-    pub async fn send_buffered<T: Event>(
+    pub fn send_buffered<T: Event>(
         &self,
         events: Vec<T>,
         buffer_size: usize,

--- a/src/infra/kafka/kafka.rs
+++ b/src/infra/kafka/kafka.rs
@@ -164,10 +164,7 @@ impl KafkaConnector {
     }
 
     pub async fn send_event<T: Event>(&self, event: T) -> Result<()> {
-        match self.queue_event(event) {
-            Ok(fut) => handle_delivery_result(fut.await),
-            Err(e) => Err(e),
-        }
+        handle_delivery_result(self.queue_event(event)?.await)
     }
 
     pub fn send_buffered<T: Event>(&self, events: Vec<T>, buffer_size: usize) -> Result<impl Stream<Item = Result<()>>> {

--- a/src/infra/kafka/kafka.rs
+++ b/src/infra/kafka/kafka.rs
@@ -172,7 +172,7 @@ impl KafkaConnector {
 
     pub fn send_buffered<T: Event>(&self, events: Vec<T>, buffer_size: usize) -> Result<impl Stream<Item = Result<()>>> {
         let futures: Vec<DeliveryFuture> = events.into_iter().map(|event| self.queue_event(event)).collect::<Result<Vec<_>, _>>()?; // This could fail because the queue is full
-        Ok(futures::stream::iter(futures).buffered(buffer_size).map(|res| handle_delivery_result(res)))
+        Ok(futures::stream::iter(futures).buffered(buffer_size).map(handle_delivery_result))
     }
 }
 

--- a/src/infra/kafka/kafka.rs
+++ b/src/infra/kafka/kafka.rs
@@ -171,7 +171,7 @@ impl KafkaConnector {
     }
 
     pub fn send_buffered<T: Event>(&self, events: Vec<T>, buffer_size: usize) -> Result<impl Stream<Item = Result<()>>> {
-        let futures: Vec<DeliveryFuture> = events.into_iter().map(|event| self.queue_event(event)).collect::<Result<Vec<_>, _>>()?;
+        let futures: Vec<DeliveryFuture> = events.into_iter().map(|event| self.queue_event(event)).collect::<Result<Vec<_>, _>>()?; // This could fail because the queue is full
         Ok(futures::stream::iter(futures).buffered(buffer_size).map(|res| handle_delivery_result(res)))
     }
 }

--- a/src/infra/kafka/kafka.rs
+++ b/src/infra/kafka/kafka.rs
@@ -165,12 +165,11 @@ impl KafkaConnector {
 
     pub async fn send_event<T: Event>(&self, event: T) -> Result<()> {
         match self.queue_event(event) {
-            Ok(fut) =>
-                if let Err(e) = fut.await {
-                    log_and_err!(reason = e, "failed to publish kafka event")
-                } else {
-                    Ok(())
-                },
+            Ok(fut) => match fut.await {
+                Err(e) => log_and_err!(reason = e, "failed to publish kafka event"),
+                Ok(Err((e, _))) => log_and_err!(reason = e, "failed to publish kafka event"),
+                Ok(_) => Ok(()),
+            },
             Err(e) => Err(e),
         }
     }


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Implemented a new `send_buffered` function in the `KafkaConnector` struct to allow sending multiple events efficiently
- The `send_buffered` function takes a vector of events and a buffer size, returning a `Stream` of delivery results
- Modified the `send_event` function for improved error handling and readability
- Added necessary imports from `futures` and `rdkafka` crates to support the new functionality
- Included `futures-channel` dependency in Cargo.toml to enable the use of `futures_channel::oneshot::Canceled`



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>kafka.rs</strong><dd><code>Implement buffered event sending for Kafka</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/infra/kafka/kafka.rs

<li>Added new imports from <code>futures</code> and <code>rdkafka</code> crates<br> <li> Implemented new <code>send_buffered</code> function for sending multiple events<br> <li> Modified <code>send_event</code> function for better error handling<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1829/files#diff-516e87c7aa8eb8e7908ce3727257a1f4ee49127c5e0e7dcd60fac65c3afcafef">+15/-2</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Add futures-channel dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Cargo.toml

- Added `futures-channel` dependency with version "=0.3.31"



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1829/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information