### PR TITLE
enha: publish amount as U256

### DIFF
--- a/e2e/cloudwalk-contracts/integration/test/leader-follower-kafka.test.ts
+++ b/e2e/cloudwalk-contracts/integration/test/leader-follower-kafka.test.ts
@@ -56,7 +56,7 @@ describe("Leader & Follower Kafka integration test", function () {
                 expect(JSON.parse(message).transfers[0].credit_party_address.toLowerCase()).to.be.eql(
                     wallet.address.toLowerCase(),
                 );
-                expect(JSON.parse(message).transfers[0].amount).to.equal("0.00001");
+                expect(JSON.parse(message).transfers[0].amount).to.equal("10");
             });
         });
     });

--- a/src/ledger/events.rs
+++ b/src/ledger/events.rs
@@ -57,7 +57,7 @@ pub struct AccountTransfers {
     ///
     /// Used for ordering multiple events from the same user that happened in the same block.
     ///
-    /// Format: Integer in base - Range: 0 to [`u64::MAX`]
+    /// Format: Integer in base 10 - Range: 0 to [`u64::MAX`]
     pub transaction_index: u64,
 
     /// Address of the contract that originated transfers.
@@ -122,7 +122,7 @@ pub struct AccountTransfer {
 
     /// Amount transferred from debit party to credit party.
     ///
-    /// Format: Decimal in base 10 and 6 decimal places - Formatted as String to avoid losing precision - Range: 0 to [`U256::MAX`].
+    /// Format: Integer in base 10 - Formatted as String to avoid losing precision - Range: 0 to [`U256::MAX`].
     pub amount: U256,
 }
 


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Refactored the `amount` field in `AccountTransfer` struct to use `U256` instead of `Decimal`
- Removed `rust_decimal` dependency and `TOKEN_SCALE` constant, simplifying the codebase
- Updated serialization logic to directly convert `U256` to string, preserving full precision
- Modified test cases to use the new `U256` representation for amounts
- Improved documentation to reflect the changes in amount format and range



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>events.rs</strong><dd><code>Refactor amount representation to use U256</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/ledger/events.rs

<li>Removed <code>rust_decimal</code> dependency and <code>TOKEN_SCALE</code> constant<br> <li> Changed <code>amount</code> field in <code>AccountTransfer</code> struct to use <code>U256</code> instead of <br><code>Decimal</code><br> <li> Updated serialization of <code>amount</code> to use <code>U256.to_string()</code><br> <li> Adjusted test cases to reflect new <code>U256</code> representation of amounts<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1830/files#diff-3c32fd4a5d4c71b18e0d1b10b6f00f18c4dca2d3acd63d314343f7be6a219515">+5/-13</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information