### PR TITLE
fix: importer config requirements

### DIFF
--- a/src/eth/follower/importer/importer_config.rs
+++ b/src/eth/follower/importer/importer_config.rs
@@ -21,7 +21,7 @@ use crate::GlobalState;
 use crate::NodeMode;
 
 #[derive(Default, Parser, DebugAsJson, Clone, serde::Serialize, serde::Deserialize)]
-#[group(requires_all = ["external_rpc, follower"])]
+#[group(requires_all = ["external_rpc", "follower"])]
 pub struct ImporterConfig {
     /// External RPC HTTP endpoint to sync blocks with Stratus.
     #[arg(short = 'r', long = "external-rpc", env = "EXTERNAL_RPC", required = false)]


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed a syntax error in the `ImporterConfig` struct's `#[group]` attribute.
- Changed `#[group(requires_all = ["external_rpc, follower"])]` to `#[group(requires_all = ["external_rpc", "follower"])]`.
- This correction ensures that the `external_rpc` and `follower` fields are properly recognized as separate required fields.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>importer_config.rs</strong><dd><code>Fix syntax in ImporterConfig group attribute</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/follower/importer/importer_config.rs

<li>Fixed a syntax error in the <code>#[group]</code> attribute by changing a comma to <br>a quotation mark.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1831/files#diff-d6208b041b3fff7e5d6e8ed530417cc9ac4d6037a7a9737370e05322418d1d34">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information