### PR TITLE
chore: remove `MinerMode::Automine` support

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -27,26 +27,6 @@ on:
       - "rust-toolchain.toml"
 
 jobs:
-  e2e-automine-stratus:
-    name: E2E Automine Stratus in-memory
-    uses: ./.github/workflows/_setup-e2e.yml
-    with:
-      justfile_recipe: "e2e-stratus automine"
-
-    concurrency:
-      group: ${{ github.workflow }}-automine-inmemory-${{ github.ref || github.run_id }}
-      cancel-in-progress: true
-
-  e2e-automine-stratus-rocks:
-    name: E2E Automine Stratus Rocks
-    uses: ./.github/workflows/_setup-e2e.yml
-    with:
-      justfile_recipe: "e2e-stratus-rocks automine"
-
-    concurrency:
-      group: ${{ github.workflow }}-automine-rocks-${{ github.ref || github.run_id }}
-      cancel-in-progress: true
-
   e2e-external-stratus:
     name: E2E External Stratus in-memory
     uses: ./.github/workflows/_setup-e2e.yml

--- a/e2e/cloudwalk-contracts/integration/test/leader-follower-miner.test.ts
+++ b/e2e/cloudwalk-contracts/integration/test/leader-follower-miner.test.ts
@@ -120,13 +120,6 @@ describe("Miner mode change integration test", function () {
         expect(response.data.result).to.equal(false);
     });
 
-    it("Miner change on Leader to Automine should fail because it is not supported", async function () {
-        updateProviderUrl("stratus");
-        const response = await sendAndGetFullResponse("stratus_changeMinerMode", ["automine"]);
-        expect(response.data.error.code).eq(-32603);
-        expect(response.data.error.message).eq("Miner mode change to (automine) is unsupported.");
-    });
-
     it("Miner change on Leader to External should fail if there are pending transactions", async function () {
         // Enable Transactions back and disable Miner on Leader
         updateProviderUrl("stratus");

--- a/justfile
+++ b/justfile
@@ -139,7 +139,7 @@ test-int name="'*'":
 # ------------------------------------------------------------------------------
 
 # E2E: Execute Hardhat tests in the specified network
-e2e network="stratus" block_modes="automine" test="":
+e2e network="stratus" block_modes="external" test="":
     #!/bin/bash
     if [ -d e2e ]; then
         cd e2e
@@ -160,7 +160,7 @@ e2e network="stratus" block_modes="automine" test="":
     done
 
 # E2E: Starts and execute Hardhat tests in Stratus
-e2e-stratus block-mode="automine" test="":
+e2e-stratus block-mode="external" test="":
     #!/bin/bash
     if [ -d e2e ]; then
         cd e2e
@@ -180,7 +180,7 @@ e2e-stratus block-mode="automine" test="":
     exit $result_code
 
 # E2E: Starts and execute Hardhat tests in Stratus
-e2e-stratus-rocks block-mode="automine" test="":
+e2e-stratus-rocks block-mode="external" test="":
     #!/bin/bash
     if [ -d e2e ]; then
         cd e2e

--- a/src/eth/miner/miner_config.rs
+++ b/src/eth/miner/miner_config.rs
@@ -2,6 +2,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 
+use anyhow::anyhow;
 use clap::Parser;
 use display_json::DebugAsJson;
 
@@ -19,7 +20,7 @@ use crate::NodeMode;
 #[derive(Parser, DebugAsJson, Clone, serde::Serialize)]
 pub struct MinerConfig {
     /// Target block time.
-    #[arg(long = "block-mode", env = "BLOCK_MODE", default_value = "automine")]
+    #[arg(long = "block-mode", env = "BLOCK_MODE", default_value = "external")]
     pub block_mode: MinerMode,
 }
 
@@ -64,10 +65,6 @@ impl MinerConfig {
 /// Indicates when the miner will mine new blocks.
 #[derive(Debug, Clone, Copy, PartialEq, strum::EnumIs, serde::Serialize, serde::Deserialize)]
 pub enum MinerMode {
-    /// Mines a new block for each transaction execution.
-    #[serde(rename = "automine")]
-    Automine,
-
     /// Mines a new block at specified interval.
     #[serde(rename = "interval")]
     Interval(Duration),
@@ -77,23 +74,12 @@ pub enum MinerMode {
     External,
 }
 
-impl MinerMode {
-    /// Checks if the mode allow to mine new blocks.
-    pub fn can_mine_new_blocks(&self) -> bool {
-        match self {
-            Self::Automine => true,
-            Self::Interval(_) => true,
-            Self::External => false,
-        }
-    }
-}
-
 impl FromStr for MinerMode {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> anyhow::Result<Self, Self::Err> {
         match s {
-            "automine" => Ok(Self::Automine),
+            "automine" => Err(anyhow!("automine is not supported by stratus")),
             "external" => Ok(Self::External),
             s => {
                 let block_time = parse_duration(s)?;

--- a/src/eth/rpc/rpc_server.rs
+++ b/src/eth/rpc/rpc_server.rs
@@ -517,9 +517,6 @@ async fn change_miner_mode(new_mode: MinerMode, ctx: &RpcContext) -> Result<Json
 
             ctx.miner.start_interval_mining(duration).await;
         }
-        MinerMode::Automine => {
-            return log_and_err!("Miner mode change to 'automine' is unsupported.").map_err(Into::into);
-        }
     }
 
     Ok(json!(true))


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Removed support for `MinerMode::Automine` throughout the codebase
- Updated `MinerConfig` to use "external" as the default block mode
- Removed `Automine` variant from `MinerMode` enum and related functionality
- Updated RPC server to no longer handle Automine mode changes
- Removed Automine-related test cases and CI jobs
- Updated E2E test configurations to use "external" as the default block mode



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>miner.rs</strong><dd><code>Remove Automine support from Miner implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/miner/miner.rs

<li>Removed <code>save_execution</code> lock from <code>MinerLocks</code> struct<br> <li> Eliminated <code>is_automine</code> check and related logic in <code>save_execution</code> <br>method<br> <li> Removed <code>mine_local_and_commit</code> method<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1836/files#diff-16f448afc7dae3e8e802f676a86dbd7051e19f6c17cbbeb53eb730d726372629">+0/-25</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>miner_config.rs</strong><dd><code>Update MinerConfig to remove Automine mode</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/miner/miner_config.rs

<li>Changed default <code>block_mode</code> to "external"<br> <li> Removed <code>Automine</code> variant from <code>MinerMode</code> enum<br> <li> Updated <code>from_str</code> implementation to return an error for "automine"<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1836/files#diff-ea3a8597b909e696993f7e791ab04e5ad784da8077b87088d9c78c804e1ef69d">+3/-17</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rpc_server.rs</strong><dd><code>Remove Automine handling in RPC server</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/rpc/rpc_server.rs

<li>Removed handling of <code>MinerMode::Automine</code> in <code>change_miner_mode</code> function<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1836/files#diff-835ba255c9a5c1fe0e13285bc39e058e1c74422e5e03ebba483c9d8a15c45405">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>leader-follower-miner.test.ts</strong><dd><code>Remove Automine test case from integration tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

e2e/cloudwalk-contracts/integration/test/leader-follower-miner.test.ts

- Removed test case for changing miner mode to Automine



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1836/files#diff-4b1c5fc9f33c8088178dffe2234e70df03667bf90fa3a5663fd17c3dabfe13a5">+0/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>e2e-test.yml</strong><dd><code>Remove Automine E2E test jobs from CI workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/e2e-test.yml

<li>Removed E2E test jobs for Automine mode (both in-memory and Rocks DB)<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1836/files#diff-5cc2c864012004f60ee3f9078fa1c4a8721c6b841e386c57f12bea58b692e6e2">+0/-20</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>justfile</strong><dd><code>Update default block mode in E2E test tasks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

justfile

<li>Changed default <code>block_modes</code> from "automine" to "external" in e2e tasks<br> <br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1836/files#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information