### PR TITLE
chore: make error message descriptive

### DIFF
--- a/e2e/cloudwalk-contracts/integration/test/leader-follower-change.test.ts
+++ b/e2e/cloudwalk-contracts/integration/test/leader-follower-change.test.ts
@@ -42,7 +42,7 @@ describe("Leader & Follower change integration test", function () {
             "100ms",
         ]);
         expect(response.data.error.code).to.equal(-32009);
-        expect(response.data.error.message).to.equal("Transaction processing is enabled.");
+        expect(response.data.error.message).to.equal("Can't change miner mode while transactions are enabled.");
     });
 
     it("Change Leader to Follower with miner enabled should fail ", async function () {
@@ -96,7 +96,7 @@ describe("Leader & Follower change integration test", function () {
         updateProviderUrl("stratus-follower");
         const response = await sendAndGetFullResponse("stratus_changeToLeader", []);
         expect(response.data.error.code).to.equal(-32009);
-        expect(response.data.error.message).to.equal("Transaction processing is enabled.");
+        expect(response.data.error.message).to.equal("Can't change miner mode while transactions are enabled.");
     });
 
     it("Change Follower to Leader should succeed", async function () {

--- a/e2e/cloudwalk-contracts/integration/test/leader-follower-miner.test.ts
+++ b/e2e/cloudwalk-contracts/integration/test/leader-follower-miner.test.ts
@@ -36,14 +36,14 @@ describe("Miner mode change integration test", function () {
         updateProviderUrl("stratus");
         const response = await sendAndGetFullResponse("stratus_changeMinerMode", ["external"]);
         expect(response.data.error.code).eq(-32009);
-        expect(response.data.error.message).eq("Transaction processing is enabled.");
+        expect(response.data.error.message).eq("Can't change miner mode while transactions are enabled.");
     });
 
     it("Miner change to Interval on Follower should fail because transactions are enabled", async function () {
         updateProviderUrl("stratus-follower");
         const response = await sendAndGetFullResponse("stratus_changeMinerMode", ["1s"]);
         expect(response.data.error.code).eq(-32009);
-        expect(response.data.error.message).eq("Transaction processing is enabled.");
+        expect(response.data.error.message).eq("Can't change miner mode while transactions are enabled.");
     });
 
     it("Disable transactions on Leader", async function () {

--- a/src/eth/primitives/stratus_error.rs
+++ b/src/eth/primitives/stratus_error.rs
@@ -58,7 +58,7 @@ pub enum StratusError {
     #[strum(props(kind = "server_state"))]
     RpcTransactionDisabled,
 
-    #[error("Transaction processing is enabled.")]
+    #[error("Can't change miner mode while transactions are enabled.")]
     #[strum(props(kind = "server_state"))]
     RpcTransactionEnabled,
 


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Enhanced the error message for `RpcTransactionEnabled` in `stratus_error.rs` to be more descriptive and specific
- Updated corresponding test files to expect the new error message:
  - `leader-follower-change.test.ts`: Updated two test cases
  - `leader-follower-miner.test.ts`: Updated two test cases
- The new error message provides clearer information about why the operation cannot be performed



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>stratus_error.rs</strong><dd><code>Update RpcTransactionEnabled error message</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/stratus_error.rs

<li>Updated error message for <code>RpcTransactionEnabled</code> to be more descriptive<br> <br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1838/files#diff-301cded01d772388e3e5c08ede093b91c3e4478c08e11a48f70e3d44351385fb">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>leader-follower-change.test.ts</strong><dd><code>Update error message expectations in leader-follower tests</code></dd></summary>
<hr>

e2e/cloudwalk-contracts/integration/test/leader-follower-change.test.ts

<li>Updated expected error message in two test cases to match the new <br>error message<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1838/files#diff-7236d4b676b75ced96eb321337290326efe4e91a261edc4e83b688c4da09dd7c">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>leader-follower-miner.test.ts</strong><dd><code>Update error message expectations in miner mode tests</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

e2e/cloudwalk-contracts/integration/test/leader-follower-miner.test.ts

<li>Updated expected error message in two test cases to match the new <br>error message<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1838/files#diff-4b1c5fc9f33c8088178dffe2234e70df03667bf90fa3a5663fd17c3dabfe13a5">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information