### PR TITLE
refac: remove unused or unnecessary StratusError variants

### DIFF
--- a/src/eth/primitives/stratus_error.rs
+++ b/src/eth/primitives/stratus_error.rs
@@ -123,10 +123,6 @@ pub enum StratusError {
     // -------------------------------------------------------------------------
     // Miner
     // -------------------------------------------------------------------------
-    #[error("Miner mode change to ({miner_mode}) is unsupported.")]
-    #[strum(props(kind = "internal"))]
-    MinerModeChangeUnsupported { miner_mode: &'static str },
-
     #[error("Miner mode param is invalid.")]
     #[strum(props(kind = "internal"))]
     MinerModeParamInvalid,

--- a/src/eth/primitives/stratus_error.rs
+++ b/src/eth/primitives/stratus_error.rs
@@ -123,10 +123,6 @@ pub enum StratusError {
     // -------------------------------------------------------------------------
     // Miner
     // -------------------------------------------------------------------------
-    #[error("Requested miner mode conflicts with current miner mode.")]
-    #[strum(props(kind = "internal"))]
-    MinerModeConflict,
-
     #[error("Miner mode change to ({miner_mode}) is unsupported.")]
     #[strum(props(kind = "internal"))]
     MinerModeChangeUnsupported { miner_mode: &'static str },

--- a/src/eth/rpc/rpc_server.rs
+++ b/src/eth/rpc/rpc_server.rs
@@ -518,8 +518,7 @@ async fn change_miner_mode(new_mode: MinerMode, ctx: &RpcContext) -> Result<Json
             ctx.miner.start_interval_mining(duration).await;
         }
         MinerMode::Automine => {
-            tracing::error!("automine mode is not supported");
-            return Err(StratusError::MinerModeChangeUnsupported { miner_mode: "automine" });
+            return log_and_err!("Miner mode change to 'automine' is unsupported.").map_err(Into::into);
         }
     }
 


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Removed unused `MinerModeConflict` and `MinerModeChangeUnsupported` error variants from `StratusError` enum in `stratus_error.rs`
- Refactored error handling for unsupported miner mode (automine) in `rpc_server.rs`:
  - Replaced `StratusError::MinerModeChangeUnsupported` with a custom error message using `log_and_err!` macro
- These changes simplify the error handling and remove unnecessary code, improving maintainability



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>stratus_error.rs</strong><dd><code>Remove unused StratusError variants</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/stratus_error.rs

<li>Removed <code>MinerModeConflict</code> error variant<br> <li> Removed <code>MinerModeChangeUnsupported</code> error variant<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1839/files#diff-301cded01d772388e3e5c08ede093b91c3e4478c08e11a48f70e3d44351385fb">+0/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rpc_server.rs</strong><dd><code>Refactor error handling for unsupported miner mode</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/rpc/rpc_server.rs

<li>Replaced <code>StratusError::MinerModeChangeUnsupported</code> with a custom error <br>message using <code>log_and_err!</code> macro<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1839/files#diff-835ba255c9a5c1fe0e13285bc39e058e1c74422e5e03ebba483c9d8a15c45405">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information