### PR TITLE
refac: simplify unknown client rejection

### DIFF
--- a/src/eth/rpc/mod.rs
+++ b/src/eth/rpc/mod.rs
@@ -18,5 +18,6 @@ use rpc_middleware::RpcMiddleware;
 use rpc_parser::next_rpc_param;
 use rpc_parser::next_rpc_param_or_default;
 use rpc_parser::parse_rpc_rlp;
+use rpc_server::reject_unknown_client;
 pub use rpc_server::serve_rpc;
 pub use rpc_subscriptions::RpcSubscriptions;

--- a/src/eth/rpc/rpc_server.rs
+++ b/src/eth/rpc/rpc_server.rs
@@ -671,7 +671,6 @@ fn eth_get_block_by_selector<const KIND: char>(params: Params<'_>, ctx: Arc<RpcC
     };
 
     // parse params
-    reject_unknown_client(ext.rpc_client())?;
     let (params, filter) = next_rpc_param::<BlockFilter>(params.sequence())?;
     let (_, full_transactions) = next_rpc_param::<bool>(params)?;
 
@@ -717,7 +716,6 @@ fn eth_get_transaction_by_hash(params: Params<'_>, ctx: Arc<RpcContext>, ext: &E
     let _method_enter = info_span!("rpc::eth_getTransactionByHash", tx_hash = field::Empty, found = field::Empty).entered();
 
     // parse params
-    reject_unknown_client(ext.rpc_client())?;
     let (_, tx_hash) = next_rpc_param::<Hash>(params.sequence())?;
 
     // track
@@ -748,7 +746,6 @@ fn eth_get_transaction_receipt(params: Params<'_>, ctx: Arc<RpcContext>, ext: &E
     let _method_enter = info_span!("rpc::eth_getTransactionReceipt", tx_hash = field::Empty, found = field::Empty).entered();
 
     // parse params
-    reject_unknown_client(ext.rpc_client())?;
     let (_, tx_hash) = next_rpc_param::<Hash>(params.sequence())?;
 
     // track
@@ -779,7 +776,6 @@ fn eth_estimate_gas(params: Params<'_>, ctx: Arc<RpcContext>, ext: &Extensions) 
     let _method_enter = info_span!("rpc::eth_estimateGas", tx_from = field::Empty, tx_to = field::Empty).entered();
 
     // parse params
-    reject_unknown_client(ext.rpc_client())?;
     let (_, call) = next_rpc_param::<CallInput>(params.sequence())?;
 
     // track
@@ -820,7 +816,6 @@ fn eth_call(params: Params<'_>, ctx: Arc<RpcContext>, ext: &Extensions) -> Resul
     let _method_enter = info_span!("rpc::eth_call", tx_from = field::Empty, tx_to = field::Empty, filter = field::Empty).entered();
 
     // parse params
-    reject_unknown_client(ext.rpc_client())?;
     let (params, call) = next_rpc_param::<CallInput>(params.sequence())?;
     let (_, filter) = next_rpc_param_or_default::<BlockFilter>(params)?;
 
@@ -870,7 +865,6 @@ fn eth_send_raw_transaction(params: Params<'_>, ctx: Arc<RpcContext>, ext: &Exte
     .entered();
 
     // parse params
-    reject_unknown_client(ext.rpc_client())?;
     let (_, tx_data) = next_rpc_param::<Bytes>(params.sequence())?;
     let tx = parse_rpc_rlp::<TransactionInput>(&tx_data)?;
     let tx_hash = tx.hash;
@@ -932,7 +926,6 @@ fn eth_get_logs(params: Params<'_>, ctx: Arc<RpcContext>, ext: &Extensions) -> R
     .entered();
 
     // parse params
-    reject_unknown_client(ext.rpc_client())?;
     let (_, filter_input) = next_rpc_param_or_default::<LogFilterInput>(params.sequence())?;
     let mut filter = filter_input.parse(&ctx.storage)?;
 
@@ -983,7 +976,6 @@ fn eth_get_transaction_count(params: Params<'_>, ctx: Arc<RpcContext>, ext: &Ext
     let _method_enter = info_span!("rpc::eth_getTransactionCount", address = field::Empty, filter = field::Empty).entered();
 
     // pare params
-    reject_unknown_client(ext.rpc_client())?;
     let (params, address) = next_rpc_param::<Address>(params.sequence())?;
     let (_, filter) = next_rpc_param_or_default::<BlockFilter>(params)?;
 
@@ -1005,7 +997,6 @@ fn eth_get_balance(params: Params<'_>, ctx: Arc<RpcContext>, ext: &Extensions) -
     let _method_enter = info_span!("rpc::eth_getBalance", address = field::Empty, filter = field::Empty).entered();
 
     // parse params
-    reject_unknown_client(ext.rpc_client())?;
     let (params, address) = next_rpc_param::<Address>(params.sequence())?;
     let (_, filter) = next_rpc_param_or_default::<BlockFilter>(params)?;
 
@@ -1028,7 +1019,6 @@ fn eth_get_code(params: Params<'_>, ctx: Arc<RpcContext>, ext: &Extensions) -> R
     let _method_enter = info_span!("rpc::eth_getCode", address = field::Empty, filter = field::Empty).entered();
 
     // parse params
-    reject_unknown_client(ext.rpc_client())?;
     let (params, address) = next_rpc_param::<Address>(params.sequence())?;
     let (_, filter) = next_rpc_param_or_default::<BlockFilter>(params)?;
 
@@ -1058,8 +1048,8 @@ async fn eth_subscribe(params: Params<'_>, pending: PendingSubscriptionSink, ctx
     // it's necessary to clear the span before an await point
     let clear_spans = || drop((middleware_enter, method_enter));
 
-    // parse params
     reject_unknown_client(ext.rpc_client())?;
+    // parse params
     let client = ext.rpc_client();
     let (params, event) = match next_rpc_param::<String>(params.sequence()) {
         Ok((params, event)) => (params, event),
@@ -1127,7 +1117,6 @@ fn eth_get_storage_at(params: Params<'_>, ctx: Arc<RpcContext>, ext: &Extensions
     let _method_enter = info_span!("rpc::eth_getStorageAt", address = field::Empty, index = field::Empty).entered();
 
     // parse params
-    reject_unknown_client(ext.rpc_client())?;
     let (params, address) = next_rpc_param::<Address>(params.sequence())?;
     let (params, index) = next_rpc_param::<SlotIndex>(params)?;
     let (_, block_filter) = next_rpc_param_or_default::<BlockFilter>(params)?;
@@ -1150,7 +1139,7 @@ fn eth_get_storage_at(params: Params<'_>, ctx: Arc<RpcContext>, ext: &Extensions
 // -----------------------------------------------------------------------------
 
 /// Returns an error JSON-RPC response if the client is not allowed to perform the current operation.
-fn reject_unknown_client(client: &RpcClientApp) -> Result<(), StratusError> {
+pub(super) fn reject_unknown_client(client: &RpcClientApp) -> Result<(), StratusError> {
     if client.is_unknown() && not(GlobalState::is_unknown_client_enabled()) {
         return Err(StratusError::RpcClientMissing);
     }


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Centralized the `reject_unknown_client` check in the `metrics_wrapper` function, removing redundant checks from individual RPC methods.
- Improved span handling in the `eth_subscribe` function for better performance and clarity.
- Updated imports and function visibility for better code organization.
- This refactoring simplifies the code, reduces duplication, and improves maintainability without changing the overall functionality.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Add import for reject_unknown_client</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/rpc/mod.rs

- Added import for `reject_unknown_client` function



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1840/files#diff-0a0c2af8f16ac3beb803893d128781f7a3a203e12dcd6738e7ac439cd78493cd">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rpc_method_wrapper.rs</strong><dd><code>Centralize reject_unknown_client check in metrics_wrapper</code></dd></summary>
<hr>

src/eth/rpc/rpc_method_wrapper.rs

<li>Moved <code>reject_unknown_client</code> check to the <code>metrics_wrapper</code> function<br> <li> Updated imports to use more specific paths<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1840/files#diff-0bbd6e729eb4e018401d1475a5dd64871ecb654be7b3d125c48c204fbddc9545">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rpc_server.rs</strong><dd><code>Simplify RPC methods by removing redundant checks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/rpc/rpc_server.rs

<li>Removed individual <code>reject_unknown_client</code> checks from various RPC <br>methods<br> <li> Updated <code>eth_subscribe</code> function to handle span clearing more <br>efficiently<br> <li> Changed visibility of <code>reject_unknown_client</code> function to <code>pub(super)</code><br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1840/files#diff-835ba255c9a5c1fe0e13285bc39e058e1c74422e5e03ebba483c9d8a15c45405">+5/-17</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information