### PR TITLE
chore: add debug logs to save_accounts

### DIFF
--- a/src/eth/storage/rocks/rocks_batch_writer.rs
+++ b/src/eth/storage/rocks/rocks_batch_writer.rs
@@ -11,6 +11,7 @@ use serde::Serialize;
 use super::rocks_cf::RocksCfRef;
 
 pub fn write_in_batch_for_multiple_cfs_impl(db: &DB, batch: WriteBatch) -> anyhow::Result<()> {
+    tracing::debug!("writing batch");
     let batch_len = batch.len();
     let mut options = WriteOptions::default();
     // By default, each write to rocksdb is asynchronous: it returns after pushing

--- a/src/eth/storage/rocks/rocks_state.rs
+++ b/src/eth/storage/rocks/rocks_state.rs
@@ -391,6 +391,8 @@ impl RocksStorageState {
 
     pub fn save_accounts(&self, accounts: Vec<Account>) -> Result<()> {
         let mut write_batch = WriteBatch::default();
+
+        tracing::debug!(?accounts, "preparing accounts cf batch");
         self.accounts.prepare_batch_insertion(
             accounts.iter().cloned().map(|acc| {
                 let tup = <(AddressRocksdb, AccountRocksdb)>::from(acc);
@@ -398,6 +400,8 @@ impl RocksStorageState {
             }),
             &mut write_batch,
         )?;
+
+        tracing::debug!(?accounts, "preparing accounts history batch");
         self.accounts_history.prepare_batch_insertion(
             accounts.iter().cloned().map(|acc| {
                 let tup = <(AddressRocksdb, AccountRocksdb)>::from(acc);
@@ -405,6 +409,7 @@ impl RocksStorageState {
             }),
             &mut write_batch,
         )?;
+
         write_in_batch_for_multiple_cfs_impl(&self.db, write_batch)?;
         Ok(())
     }


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added debug logging to improve visibility into RocksDB operations:
  - New log message before writing a batch in `rocks_batch_writer.rs`
  - Detailed logging in `save_accounts` function in `rocks_state.rs`
- Enhanced traceability for account batch insertions:
  - Separate logs for accounts CF batch and accounts history batch
- Improved debugging capabilities for RocksDB-related operations



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rocks_batch_writer.rs</strong><dd><code>Add debug logging for batch writing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/rocks/rocks_batch_writer.rs

- Added a debug log message before writing a batch to RocksDB



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1843/files#diff-d9ef8ac39be277b072f06ff5a4399800ecc9b3082883b20ec0a0993f8fee1cfb">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rocks_state.rs</strong><dd><code>Enhance logging in account saving process</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/rocks/rocks_state.rs

<li>Added debug log messages in the <code>save_accounts</code> function<br> <li> Logs details about accounts being prepared for batch insertion<br> <li> Separate logs for accounts CF batch and accounts history batch<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1843/files#diff-f7b822022d2c4fd93ec507cd6b5302dcf1646acbf0ee0dd077a047272b686009">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information