### PR TITLE
chore: add todo

### DIFF
--- a/src/eth/primitives/stratus_error.rs
+++ b/src/eth/primitives/stratus_error.rs
@@ -83,7 +83,7 @@ pub enum StratusError {
 
     #[error("Failed to executed transaction in EVM: {0:?}.")]
     #[strum(props(kind = "execution"))]
-    TransactionEvmFailed(String), // split this in multiple errors
+    TransactionEvmFailed(String), // TODO: split this in multiple errors
 
     #[error("Failed to execute transaction in leader: {0:?}.")]
     #[strum(props(kind = "execution"))]


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added a TODO comment in the `StratusError` enum to indicate the need for splitting the `TransactionEvmFailed` error into multiple errors.
- This change suggests a future improvement in error handling granularity for EVM transaction failures.
- The modification is minor but important for tracking future enhancements in the codebase.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>stratus_error.rs</strong><dd><code>Add TODO for refining TransactionEvmFailed error</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/stratus_error.rs

<li>Added a TODO comment to split <code>TransactionEvmFailed</code> error into multiple <br>errors<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1845/files#diff-301cded01d772388e3e5c08ede093b91c3e4478c08e11a48f70e3d44351385fb">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information