### PR TITLE
chore: add 0 to left of months, days and hours with only 1 digit

### DIFF
--- a/src/bin/historic_events_processor.rs
+++ b/src/bin/historic_events_processor.rs
@@ -124,11 +124,11 @@ fn main() -> Result<(), anyhow::Error> {
 
             hours_since_0 = timestamp.0 / 3600;
             if !event_batch.is_empty() {
-                let folder_path = format!("events/{}/{}/{}", date.year(), date.month(), date.day());
+                let folder_path = format!("events/{}/{:02}/{:02}", date.year(), date.month(), date.day());
                 if !std::path::Path::new(&folder_path).exists() {
                     std::fs::create_dir_all(&folder_path)?;
                 }
-                std::fs::write(format!("{}/{}", folder_path, date.hour()), event_batch.join("\n"))?;
+                std::fs::write(format!("{}/{:02}", folder_path, date.hour()), event_batch.join("\n"))?;
             }
             std::fs::write("last_processed_block", number.to_string())?;
             event_batch.clear();


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Enhanced the formatting of date and time components in file paths and names
- Added leading zeros to months, days, and hours that have only one digit
- Ensures consistent file naming and folder structure for better organization and sorting
- Affects the `historic_events_processor.rs` file in the `src/bin` directory



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>historic_events_processor.rs</strong><dd><code>Add leading zeros to date and time components</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/bin/historic_events_processor.rs

<li>Modified the folder path formatting to include leading zeros for month <br>and day<br> <li> Updated the file name formatting to include leading zeros for hour<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1849/files#diff-783a0df733dbcaeda4ed1c0f489555965746b725684709eab41c3c5992832f79">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information