### PR TITLE
feat: implement fake leader

### DIFF
--- a/src/bin/importer_offline.rs
+++ b/src/bin/importer_offline.rs
@@ -145,7 +145,6 @@ fn execute_block_importer(
 
         let before_block = Instant::now();
         for (mut block, receipts) in blocks.into_iter() {
-            let mut receipts = ExternalReceipts::from(receipts);
             if GlobalState::is_shutdown_warn(TASK_NAME) {
                 return Ok(());
             }
@@ -155,7 +154,7 @@ fn execute_block_importer(
 
             // re-execute (and import) block
             batch_tx_len += block.transactions.len();
-            executor.execute_external_block(block.clone(), &mut receipts)?;
+            executor.execute_external_block(block.clone(), ExternalReceipts::from(receipts))?;
 
             // mine and save block
             miner.mine_external_and_commit(block)?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -176,11 +176,15 @@ impl CommonConfig {
 #[derive(DebugAsJson, Clone, Parser, derive_more::Deref, serde::Serialize)]
 #[clap(group = ArgGroup::new("mode").required(true).args(&["leader", "follower"]))]
 pub struct StratusConfig {
-    #[arg(long = "leader", env = "LEADER", conflicts_with = "follower", conflicts_with = "ImporterConfig")]
+    #[arg(long = "leader", env = "LEADER", conflicts_with_all = ["follower", "fake-leader", "ImporterConfig"])]
     pub leader: bool,
 
-    #[arg(long = "follower", env = "FOLLOWER", conflicts_with = "leader", requires = "ImporterConfig")]
+    #[arg(long = "follower", env = "FOLLOWER", conflicts_with_all = ["leader", "fake-leader"], requires = "ImporterConfig")]
     pub follower: bool,
+
+    /// The fake leader imports blocks like a follower, but executes the blocks's txs locally like a leader.
+    #[arg(long = "fake-leader", env = "FAKE_LEADER", conflicts_with_all = ["leader", "follower"], requires = "ImporterConfig")]
+    pub fake_leader: bool,
 
     #[clap(flatten)]
     pub rpc_server: RpcServerConfig,

--- a/src/eth/executor/executor.rs
+++ b/src/eth/executor/executor.rs
@@ -230,7 +230,7 @@ impl Executor {
     /// Reexecutes an external block locally and imports it to the temporary storage.
     ///
     /// Returns the remaining receipts that were not consumed by the execution.
-    pub fn execute_external_block(&self, mut block: ExternalBlock, receipts: &mut ExternalReceipts) -> anyhow::Result<()> {
+    pub fn execute_external_block(&self, mut block: ExternalBlock, mut receipts: ExternalReceipts) -> anyhow::Result<()> {
         // track
         #[cfg(feature = "metrics")]
         let (start, mut block_metrics) = (metrics::now(), EvmExecutionMetrics::default());
@@ -295,7 +295,6 @@ impl Executor {
 
         // when transaction externally failed, create fake transaction instead of reexecuting
         let tx_execution = match receipt.is_success() {
-            //
             // successful external transaction, re-execute locally
             true => {
                 // re-execute transaction

--- a/src/eth/follower/importer/importer.rs
+++ b/src/eth/follower/importer/importer.rs
@@ -217,7 +217,6 @@ impl Importer {
                 );
             }
 
-            // trocar do mine_external_and_commit para mine_external e depois commit
             let mined_block = match miner.mine_external(block) {
                 Ok(mined_block) => {
                     tracing::info!("mined external block");

--- a/src/eth/follower/importer/importer.rs
+++ b/src/eth/follower/importer/importer.rs
@@ -192,12 +192,10 @@ impl Importer {
 
             #[cfg(feature = "metrics")]
             let (start, block_number, block_tx_len) = (metrics::now(), block.number(), block.transactions.len());
-
-            // execute and mine
-            let mut receipts = ExternalReceipts::from(receipts);
             #[cfg(feature = "metrics")]
             let receipts_len = receipts.len();
-            if let Err(e) = executor.execute_external_block(block.clone(), &mut receipts) {
+
+            if let Err(e) = executor.execute_external_block(block.clone(), ExternalReceipts::from(receipts)) {
                 let message = GlobalState::shutdown_from(TASK_NAME, "failed to reexecute external block");
                 return log_and_err!(reason = e, message);
             };

--- a/src/eth/follower/importer/importer_config.rs
+++ b/src/eth/follower/importer/importer_config.rs
@@ -48,7 +48,7 @@ impl ImporterConfig {
         kafka_connector: Option<KafkaConnector>,
     ) -> anyhow::Result<Option<Arc<dyn Consensus>>> {
         match GlobalState::get_node_mode() {
-            NodeMode::Follower => self.init_follower(executor, miner, storage, kafka_connector).await,
+            NodeMode::Follower | NodeMode::FakeLeader => self.init_follower(executor, miner, storage, kafka_connector).await,
             NodeMode::Leader => Ok(None),
         }
     }

--- a/src/eth/follower/importer/importer_config.rs
+++ b/src/eth/follower/importer/importer_config.rs
@@ -88,7 +88,7 @@ impl ImporterConfig {
     }
 
     pub async fn init_follower_importer(&self, ctx: Arc<RpcContext>) -> Result<serde_json::Value, StratusError> {
-        if not(GlobalState::is_follower()) {
+        if GlobalState::get_node_mode() != NodeMode::Follower {
             tracing::error!("node is currently not a follower");
             return Err(StratusError::StratusNotFollower);
         }

--- a/src/eth/miner/miner_config.rs
+++ b/src/eth/miner/miner_config.rs
@@ -35,7 +35,7 @@ impl MinerConfig {
                 }
                 MinerMode::External
             }
-            NodeMode::Leader => self.block_mode,
+            NodeMode::Leader | NodeMode::FakeLeader => self.block_mode,
         };
 
         self.init_with_mode(mode, storage).await

--- a/src/eth/primitives/stratus_error.rs
+++ b/src/eth/primitives/stratus_error.rs
@@ -15,7 +15,7 @@ use crate::eth::primitives::ExecutionConflicts;
 use crate::eth::primitives::Nonce;
 use crate::ext::to_json_value;
 
-/// Valid  error catogories are:
+/// Valid error catogories are:
 /// * client_request: request is invalid.
 /// * client_state:   request is valid, specific client rules rejects it.
 /// * server_state:   request is valid, global server rules rejects it.

--- a/src/eth/rpc/rpc_server.rs
+++ b/src/eth/rpc/rpc_server.rs
@@ -445,7 +445,7 @@ async fn stratus_init_importer(params: Params<'_>, ctx: Arc<RpcContext>, _: Exte
 }
 
 fn stratus_shutdown_importer(_: Params<'_>, ctx: &RpcContext, _: &Extensions) -> Result<JsonValue, StratusError> {
-    if not(GlobalState::is_follower()) {
+    if GlobalState::get_node_mode() != NodeMode::Follower {
         tracing::error!("node is currently not a follower");
         return Err(StratusError::StratusNotFollower);
     }

--- a/src/eth/rpc/rpc_server.rs
+++ b/src/eth/rpc/rpc_server.rs
@@ -286,7 +286,7 @@ async fn stratus_health(_: Params<'_>, context: Arc<RpcContext>, _: Extensions) 
     }
 
     let should_serve = match GlobalState::get_node_mode() {
-        NodeMode::Leader => true,
+        NodeMode::Leader | NodeMode::FakeLeader => true,
         NodeMode::Follower => match context.consensus() {
             Some(consensus) => consensus.should_serve().await,
             None => false,
@@ -885,7 +885,7 @@ fn eth_send_raw_transaction(params: Params<'_>, ctx: Arc<RpcContext>, ext: &Exte
 
     // execute locally or forward to leader
     match GlobalState::get_node_mode() {
-        NodeMode::Leader => match ctx.executor.execute_local_transaction(tx) {
+        NodeMode::Leader | NodeMode::FakeLeader => match ctx.executor.execute_local_transaction(tx) {
             Ok(_) => Ok(hex_data(tx_hash)),
             Err(e) => {
                 if e.is_internal() {

--- a/src/eth/rpc/rpc_server.rs
+++ b/src/eth/rpc/rpc_server.rs
@@ -877,7 +877,6 @@ fn eth_send_raw_transaction(params: Params<'_>, ctx: Arc<RpcContext>, ext: &Exte
         s.rec_str("tx_nonce", &tx.nonce);
     });
 
-    // check feature
     if not(GlobalState::is_transactions_enabled()) {
         tracing::warn!(%tx_hash, "failed to execute eth_sendRawTransaction because transactions are disabled");
         return Err(StratusError::RpcTransactionDisabled);

--- a/src/globals.rs
+++ b/src/globals.rs
@@ -88,7 +88,6 @@ where
 // Node mode
 // -----------------------------------------------------------------------------
 
-#[repr(u8)]
 #[derive(Clone, Copy, PartialEq, Eq, Debug, strum::Display)]
 pub enum NodeMode {
     #[strum(to_string = "leader")]
@@ -178,7 +177,7 @@ impl GlobalState {
         format!("{} {}", caller, reason)
     }
 
-    /// Checks if the importer is being shutdown.
+    /// Checks if the importer is shut down or being shut down.
     pub fn is_importer_shutdown() -> bool {
         IMPORTER_SHUTDOWN.load(Ordering::Relaxed)
     }
@@ -202,7 +201,6 @@ impl GlobalState {
         shutdown
     }
 
-    /// Sets the importer shutdown state.
     pub fn set_importer_shutdown(shutdown: bool) {
         IMPORTER_SHUTDOWN.store(shutdown, Ordering::Relaxed);
     }
@@ -257,12 +255,10 @@ impl GlobalState {
         Self::set_importer_shutdown(not(should_run_importer));
     }
 
-    /// Sets the current node mode.
     pub fn set_node_mode(mode: NodeMode) {
         *NODE_MODE.lock_or_clear("set_node_mode") = mode;
     }
 
-    /// Gets the current node mode.
     pub fn get_node_mode() -> NodeMode {
         *NODE_MODE.lock_or_clear("get_node_mode")
     }

--- a/src/globals.rs
+++ b/src/globals.rs
@@ -96,7 +96,7 @@ pub enum NodeMode {
     #[strum(to_string = "follower")]
     Follower,
 
-    /// The fake leader imports blocks like a follower, but executes the blocks's txs locally like a leader.
+    /// Fake leader feches a block, re-executes its txs and then mines it's own block.
     #[strum(to_string = "fake-leader")]
     FakeLeader,
 }


### PR DESCRIPTION
### **User description**
The fake leader imports blocks like a follower, but executes the blocks's txs locally like it's a leader, mining at its own pace.

review pr by commit.


___

### **PR Type**
Enhancement


___

### **Description**
- Implemented a new "Fake Leader" mode, which imports blocks like a follower but executes transactions locally like a leader
- Added `--fake-leader` flag to the configuration options
- Modified the importer, executor, and miner components to support the new Fake Leader mode
- Updated global state management to use a `NodeMode` enum instead of a boolean flag for leader/follower status
- Refactored various parts of the codebase to accommodate the new mode, including RPC server and configuration handlers
- Improved error handling and logging related to node modes
- Updated health checks and transaction processing to consider the new Fake Leader mode



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>importer_offline.rs</strong><dd><code>Simplify external block execution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/bin/importer_offline.rs

<li>Simplified <code>execute_external_block</code> call by moving <br><code>ExternalReceipts::from(receipts)</code> into the function call<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1850/files#diff-9fef7d584818c3db119ea1cd0952a57a953751f85f93ca813af861c4c737c53a">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>config.rs</strong><dd><code>Add fake leader configuration option</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/config.rs

<li>Added <code>fake_leader</code> flag to <code>StratusConfig</code><br> <li> Updated conflict rules for <code>leader</code>, <code>follower</code>, and <code>fake_leader</code> flags<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1850/files#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecd">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>executor.rs</strong><dd><code>Refactor external block execution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/executor/executor.rs

<li>Modified <code>execute_external_block</code> function signature to take ownership <br>of <code>receipts</code><br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1850/files#diff-6b460d7dee8280c0287e8d9d9d59cf66a57ec9fed1bc003c6ede6fef60c7376b">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>importer.rs</strong><dd><code>Implement fake leader mode in importer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/follower/importer/importer.rs

<li>Added <code>ImporterMode</code> enum with <code>NormalFollower</code> and <code>FakeLeader</code> variants<br> <li> Modified <code>Importer</code> struct to include <code>importer_mode</code> field<br> <li> Updated <code>start_block_executor</code> to handle <code>FakeLeader</code> mode differently<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1850/files#diff-bd50f502f039aff8f75753bc780d281ae7d7936fadc9d53482084c647aec94ca">+42/-8</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>importer_config.rs</strong><dd><code>Add fake leader support to importer configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/follower/importer/importer_config.rs

<li>Updated <code>init</code> and <code>init_follower</code> methods to handle <code>FakeLeader</code> mode<br> <li> Modified <code>init_follower_importer</code> to check for <code>Follower</code> mode <br>specifically<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1850/files#diff-d6208b041b3fff7e5d6e8ed530417cc9ac4d6037a7a9737370e05322418d1d34">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>miner_config.rs</strong><dd><code>Add fake leader support to miner configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/miner/miner_config.rs

- Updated miner mode selection to include `FakeLeader`



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1850/files#diff-ea3a8597b909e696993f7e791ab04e5ad784da8077b87088d9c78c804e1ef69d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rpc_server.rs</strong><dd><code>Add fake leader support to RPC server</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/rpc/rpc_server.rs

<li>Modified <code>stratus_health</code> and <code>eth_send_raw_transaction</code> to handle <br><code>FakeLeader</code> mode<br> <li> Updated <code>stratus_shutdown_importer</code> to check for <code>Follower</code> mode <br>specifically<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1850/files#diff-835ba255c9a5c1fe0e13285bc39e058e1c74422e5e03ebba483c9d8a15c45405">+3/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>globals.rs</strong><dd><code>Implement global state changes for fake leader mode</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/globals.rs

<li>Added <code>FakeLeader</code> variant to <code>NodeMode</code> enum<br> <li> Replaced <code>IS_LEADER</code> atomic bool with <code>NODE_MODE</code> mutex<br> <li> Updated <code>initialize_node_mode</code>, <code>set_node_mode</code>, and <code>get_node_mode</code> <br>functions<br> <li> Removed <code>is_follower</code> and <code>is_leader</code> functions<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1850/files#diff-48d6fbc3a4ed67100952dcccfada858623c931e73d6de32984d4d1457e68d3a9">+24/-28</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information