### PR TITLE
chore: update default env var values

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -92,11 +92,11 @@ pub struct CommonConfig {
     pub env: Environment,
 
     /// Number of threads to execute global async tasks.
-    #[arg(long = "async-threads", env = "ASYNC_THREADS", default_value = "10")]
+    #[arg(long = "async-threads", env = "ASYNC_THREADS", default_value = "32")]
     pub num_async_threads: usize,
 
     /// Number of threads to execute global blocking tasks.
-    #[arg(long = "blocking-threads", env = "BLOCKING_THREADS", default_value = "10")]
+    #[arg(long = "blocking-threads", env = "BLOCKING_THREADS", default_value = "512")]
     pub num_blocking_threads: usize,
 
     #[clap(flatten)]

--- a/src/eth/executor/executor_config.rs
+++ b/src/eth/executor/executor_config.rs
@@ -18,7 +18,7 @@ pub struct ExecutorConfig {
     /// Number of EVM instances to run.
     ///
     /// TODO: should be configured for each kind of EvmRoute instead of being a single value.
-    #[arg(long = "executor-evms", alias = "evms", env = "EXECUTOR_EVMS")]
+    #[arg(long = "executor-evms", alias = "evms", env = "EXECUTOR_EVMS", default_value = "30")]
     pub executor_evms: usize,
 
     /// EVM execution strategy.

--- a/src/eth/rpc/rpc_config.rs
+++ b/src/eth/rpc/rpc_config.rs
@@ -10,10 +10,10 @@ pub struct RpcServerConfig {
     pub rpc_address: SocketAddr,
 
     /// JSON-RPC server max active connections
-    #[arg(long = "max-connections", env = "MAX_CONNECTIONS", default_value = "200")]
+    #[arg(long = "max-connections", env = "MAX_CONNECTIONS", default_value = "400")]
     pub rpc_max_connections: u32,
 
     /// JSON-RPC server max active subscriptions per client.
-    #[arg(long = "max-subscriptions", env = "MAX_SUBSCRIPTIONS", default_value = "15")]
+    #[arg(long = "max-subscriptions", env = "MAX_SUBSCRIPTIONS", default_value = "30")]
     pub rpc_max_subscriptions: u32,
 }

--- a/src/eth/storage/temporary_storage.rs
+++ b/src/eth/storage/temporary_storage.rs
@@ -70,7 +70,7 @@ pub trait TemporaryStorage: Send + Sync + 'static {
 #[derive(Parser, DebugAsJson, Clone, serde::Serialize)]
 pub struct TemporaryStorageConfig {
     /// Temporary storage implementation.
-    #[arg(long = "temp-storage", env = "TEMP_STORAGE")]
+    #[arg(long = "temp-storage", env = "TEMP_STORAGE", default_value = "inmemory")]
     pub temp_storage_kind: TemporaryStorageKind,
 }
 


### PR DESCRIPTION
### **User description**
vars updated: `ASYNC_THREADS, BLOCKING_THREADS, EXECUTOR_EVMS, MAX_CONNECTIONS, MAX_SUBSCRIPTIONS, TEMP_STORAGE`


___

### **PR Type**
Enhancement


___

### **Description**
This PR updates default values for several environment variables to optimize performance and resource allocation:

- Increased thread counts:
  - `ASYNC_THREADS`: 10 -> 32
  - `BLOCKING_THREADS`: 10 -> 512
- Set default `EXECUTOR_EVMS` to 30
- Increased RPC server limits:
  - `MAX_CONNECTIONS`: 200 -> 400
  - `MAX_SUBSCRIPTIONS`: 15 -> 30
- Set default `TEMP_STORAGE` to "inmemory"

These changes aim to improve the application's performance and resource utilization out of the box, while still allowing for custom configuration through environment variables.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.rs</strong><dd><code>Update default thread counts for async and blocking tasks</code></dd></summary>
<hr>

src/config.rs

<li>Increased default value for <code>ASYNC_THREADS</code> from 10 to 32<br> <li> Increased default value for <code>BLOCKING_THREADS</code> from 10 to 512<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1851/files#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecd">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>executor_config.rs</strong><dd><code>Set default value for EVM instances</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/executor/executor_config.rs

- Added default value of 30 for `EXECUTOR_EVMS` environment variable



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1851/files#diff-6cf7fa175d8d21c44043aca3b3690957542a08dc37446bf33cc7e5cf5c330024">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rpc_config.rs</strong><dd><code>Increase default RPC server connection and subscription limits</code></dd></summary>
<hr>

src/eth/rpc/rpc_config.rs

<li>Increased default value for <code>MAX_CONNECTIONS</code> from 200 to 400<br> <li> Increased default value for <code>MAX_SUBSCRIPTIONS</code> from 15 to 30<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1851/files#diff-0239797ab58ae7374edfac3a5bfb40adb1475955b35ea0923766577337efc1de">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>temporary_storage.rs</strong><dd><code>Set default temporary storage implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/temporary_storage.rs

<li>Added default value of "inmemory" for <code>TEMP_STORAGE</code> environment <br>variable<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1851/files#diff-58337f46f036f808e0166f195e0ed5dfbfdc092fc1665c3424f01d799a5195de">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information