### PR TITLE
fix: conflicts_with_all fake_leader

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -176,10 +176,10 @@ impl CommonConfig {
 #[derive(DebugAsJson, Clone, Parser, derive_more::Deref, serde::Serialize)]
 #[clap(group = ArgGroup::new("mode").required(true).args(&["leader", "follower"]))]
 pub struct StratusConfig {
-    #[arg(long = "leader", env = "LEADER", conflicts_with_all = ["follower", "fake-leader", "ImporterConfig"])]
+    #[arg(long = "leader", env = "LEADER", conflicts_with_all = ["follower", "fake_leader", "ImporterConfig"])]
     pub leader: bool,
 
-    #[arg(long = "follower", env = "FOLLOWER", conflicts_with_all = ["leader", "fake-leader"], requires = "ImporterConfig")]
+    #[arg(long = "follower", env = "FOLLOWER", conflicts_with_all = ["leader", "fake_leader"], requires = "ImporterConfig")]
     pub follower: bool,
 
     /// The fake leader imports blocks like a follower, but executes the blocks's txs locally like a leader.


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed a bug in the StratusConfig struct's argument conflicts configuration
- Changed 'fake-leader' to 'fake_leader' in the conflicts_with_all lists for both 'leader' and 'follower' arguments
- This ensures proper conflict handling between leader, follower, and fake leader modes
- Improves consistency in naming conventions for command-line arguments



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.rs</strong><dd><code>Fix argument conflicts in StratusConfig</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/config.rs

<li>Fixed conflicts_with_all attribute for 'leader' and 'follower' <br>arguments<br> <li> Changed 'fake-leader' to 'fake_leader' in conflicts_with_all lists<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1855/files#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecd">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information