### PR TITLE
enha: change how llvm-cov runs so that we can build before running

### DIFF
--- a/justfile_helpers
+++ b/justfile_helpers
@@ -12,8 +12,8 @@ _log message:
 # Wait for Stratus to start.
 _wait_for_stratus port="3000":
     #!/bin/bash
-    just _log "Waiting 1500 seconds for Stratus on port {{port}} to start"
-    wait-service --tcp 0.0.0.0:{{port}} -t 1500 -- echo
+    just _log "Waiting 300 seconds for Stratus on port {{port}} to start"
+    wait-service --tcp 0.0.0.0:{{port}} -t 300 -- echo
     if [ $? -eq 0 ]; then
         just _log "Stratus on port {{port}} started"
     else


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Improved build process by allowing specification of binary and features in the `build` recipe
- Added explicit `just build` step to various e2e test recipes to ensure up-to-date binary
- Refactored `stratus-test-coverage` recipe to use LLVM coverage environment variables
- Removed `CARGO_COMMAND` variable from test commands, simplifying the process
- Reduced Stratus startup wait time from 1500 to 300 seconds for faster test execution
- Updated various recipes to use the new build process, ensuring consistency across tests



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>justfile</strong><dd><code>Enhance build process and test coverage workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

justfile

<li>Modified <code>build</code> recipe to accept <code>binary</code> and <code>features</code> parameters<br> <li> Updated various e2e test recipes to include <code>just build</code> step<br> <li> Refactored <code>stratus-test-coverage</code> recipe to use environment variables <br>for LLVM coverage<br> <li> Removed <code>CARGO_COMMAND</code> variable from test commands<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1856/files#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1">+30/-19</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>justfile_helpers</strong><dd><code>Adjust Stratus startup wait time</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

justfile_helpers

<li>Reduced wait time for Stratus to start from 1500 seconds to 300 <br>seconds<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1856/files#diff-ceafeefe0a05bcfb7f2605021b3a6023e055ac359102cb979fbb80fee7a2e2cd">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information