### PR TITLE
enha: reduce coverage disk usage (attempt to make github runner work)

### DIFF
--- a/justfile
+++ b/justfile
@@ -465,39 +465,48 @@ stratus-test-coverage output="":
     # setup
     just contracts-clone
     source <(cargo llvm-cov show-env --export-prefix)
+    export RUST_LOG=error
+
     cargo llvm-cov clean --workspace
     just build
 
     # inmemory
     just e2e-stratus automine
     sleep 10
+    -rm stratus.log
 
     just e2e-stratus external
     sleep 10
+    -rm stratus.log
 
     just e2e-clock-stratus
     sleep 10
+    -rm stratus.log
 
     just contracts-test-stratus
     sleep 10
+    -rm stratus.log
 
     # rocksdb
     -rm -r data/rocksdb
     just e2e-stratus-rocks automine
     sleep 10
+    -rm stratus.log
 
     -rm -r data/rocksdb
     just e2e-stratus-rocks external
     sleep 10
+    -rm stratus.log
 
     -rm -r data/rocksdb
     just e2e-clock-stratus-rocks
     sleep 10
+    -rm stratus.log
 
     -rm -r data/rocksdb
     just contracts-test-stratus-rocks
     sleep 10
-
+    -rm stratus.log
 
     # other
     cargo llvm-cov --no-report
@@ -510,30 +519,48 @@ stratus-test-coverage output="":
     -docker compose down -v
     just e2e-leader-follower-up kafka " "
     sleep 10
+    -rm -r e2e_logs
+    -rm utils/deploy/deploy_01.log
+    -rm utils/deploy/deploy_02.log
 
     -rm -r temp_3000-rocksdb
     -rm -r temp_3001-rocksdb
     just e2e-leader-follower-up deploy " "
     sleep 10
+    -rm -r e2e_logs
+    -rm utils/deploy/deploy_01.log
+    -rm utils/deploy/deploy_02.log
 
     -rm -r temp_3000-rocksdb
     -rm -r temp_3001-rocksdb
     just e2e-leader-follower-up brlc " "
     sleep 10
+    -rm -r e2e_logs
+    -rm utils/deploy/deploy_01.log
+    -rm utils/deploy/deploy_02.log
 
     -rm -r temp_3000-rocksdb
     -rm -r temp_3001-rocksdb
     just e2e-leader-follower-up change " "
     sleep 10
+    -rm -r e2e_logs
+    -rm utils/deploy/deploy_01.log
+    -rm utils/deploy/deploy_02.log
 
     -rm -r temp_3000-rocksdb
     -rm -r temp_3001-rocksdb
     just e2e-leader-follower-up miner " "
     sleep 10
+    -rm -r e2e_logs
+    -rm utils/deploy/deploy_01.log
+    -rm utils/deploy/deploy_02.log
 
     -rm -r temp_3000-rocksdb
     -rm -r temp_3001-rocksdb
     just e2e-leader-follower-up importer " "
     sleep 10
+    -rm -r e2e_logs
+    -rm utils/deploy/deploy_01.log
+    -rm utils/deploy/deploy_02.log
 
     cargo llvm-cov report {{output}}

--- a/justfile
+++ b/justfile
@@ -435,6 +435,8 @@ contracts-test-stratus *args="":
 # Contracts: Start Stratus and run contracts tests with RocksDB storage
 contracts-test-stratus-rocks *args="":
     #!/bin/bash
+    just build
+
     just _log "Starting Stratus"
     just run -a 0.0.0.0:3000 --perm-storage=rocks > stratus.log &
 


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Reduced disk usage during test coverage by removing log files and directories after each test run
- Set `RUST_LOG=error` to minimize log output
- Cleaned up unnecessary whitespace in the justfile
- These changes aim to optimize the GitHub runner's performance by reducing disk usage



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>justfile</strong><dd><code>Optimize test coverage process and reduce disk usage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

justfile

<li>Added <code>export RUST_LOG=error</code> to reduce log output<br> <li> Added commands to remove log files and directories after each test<br> <li> Removed unnecessary whitespace<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1857/files#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1">+28/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information