### PR TITLE
enha: log miner block number after importing

### DIFF
--- a/src/eth/follower/importer/importer.rs
+++ b/src/eth/follower/importer/importer.rs
@@ -254,7 +254,7 @@ impl Importer {
 
             let mined_block = match miner.mine_external(block) {
                 Ok(mined_block) => {
-                    tracing::info!("mined external block");
+                    tracing::info!(number = %mined_block.number(), "mined external block");
                     mined_block
                 }
                 Err(e) => {


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Improved logging in the `Importer` implementation:
  - Added the block number to the log message when an external block is successfully mined
- This enhancement provides more detailed information during the mining process, making it easier to track and debug block imports



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>importer.rs</strong><dd><code>Enhance logging for mined external blocks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/follower/importer/importer.rs

- Added block number logging when mining an external block



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1860/files#diff-bd50f502f039aff8f75753bc780d281ae7d7936fadc9d53482084c647aec94ca">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information