### PR TITLE
tests: fix: add build step to e2e clock test

### DIFF
--- a/justfile
+++ b/justfile
@@ -204,6 +204,7 @@ e2e-stratus-rocks block-mode="automine" test="":
 # E2E Clock: Builds and runs Stratus with block-time flag, then validates average block generation time
 e2e-clock-stratus:
     #!/bin/bash
+    just build
     just _log "Starting Stratus"
     just run --block-mode 1s -a 0.0.0.0:3000 > stratus.log &
 


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Added a build step to the E2E clock test for Stratus
- Ensures that the latest version of Stratus is built before running the test
- Improves test reliability by using the most up-to-date build
- Aligns with best practices for running E2E tests



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>justfile</strong><dd><code>Add build step to E2E clock test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

justfile

<li>Added a <code>just build</code> command before starting Stratus in the <br><code>e2e-clock-stratus</code> recipe<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1865/files#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information