### PR TITLE
enha: add metric for event creation

### DIFF
--- a/src/infra/metrics/metrics_definitions.rs
+++ b/src/infra/metrics/metrics_definitions.rs
@@ -228,5 +228,8 @@ metrics! {
     histogram_duration kafka_send_buffered{},
 
     "Time to run KafkaConnector::create_buffer"
-    histogram_duration kafka_create_buffer{}
+    histogram_duration kafka_create_buffer{},
+
+    "Time to create events"
+    histogram_duration kafka_create_events{}
 }


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Implemented a new metric to measure the time taken for Kafka event creation
- Added conditional compilation for metrics feature in the importer
- Updated metrics definitions to include the new `kafka_create_events` histogram
- Enhances observability of the Kafka event creation process



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>importer.rs</strong><dd><code>Add metrics for Kafka event creation time</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/follower/importer/importer.rs

<li>Added metrics for event creation time measurement<br> <li> Wrapped new code in #[cfg(feature = "metrics")] to conditionally <br>compile<br> <li> Implemented timing for event creation process in Kafka connection<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1866/files#diff-bd50f502f039aff8f75753bc780d281ae7d7936fadc9d53482084c647aec94ca">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>metrics_definitions.rs</strong><dd><code>Add Kafka event creation time metric definition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/infra/metrics/metrics_definitions.rs

<li>Added new histogram duration metric <code>kafka_create_events</code><br> <li> Metric measures time to create events<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1866/files#diff-2ca1adc579301e6de5f9e1d69eb1ed2f70aeee0f3b54fe113346040b4eab652b">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information