### PR TITLE
enha: send all events at once

### DIFF
--- a/src/eth/follower/importer/importer.rs
+++ b/src/eth/follower/importer/importer.rs
@@ -266,18 +266,12 @@ impl Importer {
             };
 
             if let Some(ref kafka_conn) = kafka_connector {
-                #[cfg(feature = "metrics")]
-                let start = metrics::now();
-
                 let events = mined_block
                     .transactions
                     .iter()
                     .flat_map(|tx| transaction_to_events(mined_block.header.timestamp, Cow::Borrowed(tx)));
 
                 kafka_conn.send_buffered(events, 50).await?;
-
-                #[cfg(feature = "metrics")]
-                metrics::inc_kafka_create_events(start.elapsed());
             }
 
             match miner.commit(mined_block) {

--- a/src/eth/follower/importer/importer.rs
+++ b/src/eth/follower/importer/importer.rs
@@ -269,10 +269,12 @@ impl Importer {
                 #[cfg(feature = "metrics")]
                 let start = metrics::now();
 
-                for tx in &mined_block.transactions {
-                    let events = transaction_to_events(mined_block.header.timestamp, Cow::Borrowed(tx));
-                    kafka_conn.send_buffered(events, 30).await?;
-                }
+                let events = mined_block
+                    .transactions
+                    .iter()
+                    .flat_map(|tx| transaction_to_events(mined_block.header.timestamp, Cow::Borrowed(tx)));
+
+                kafka_conn.send_buffered(events, 50).await?;
 
                 #[cfg(feature = "metrics")]
                 metrics::inc_kafka_create_events(start.elapsed());

--- a/src/infra/kafka/kafka.rs
+++ b/src/infra/kafka/kafka.rs
@@ -171,7 +171,11 @@ impl KafkaConnector {
         handle_delivery_result(self.queue_event(event)?.await)
     }
 
-    pub fn create_buffer<T: Event>(&self, events: Vec<T>, buffer_size: usize) -> Result<impl Stream<Item = Result<()>>> {
+    pub fn create_buffer<T, I>(&self, events: I, buffer_size: usize) -> Result<impl Stream<Item = Result<()>>>
+    where
+        T: Event,
+        I: IntoIterator<Item = T>,
+    {
         #[cfg(feature = "metrics")]
         let start = metrics::now();
 
@@ -190,7 +194,11 @@ impl KafkaConnector {
         Ok(futures::stream::iter(futures).buffered(buffer_size).map(handle_delivery_result))
     }
 
-    pub async fn send_buffered<T: Event>(&self, events: Vec<T>, buffer_size: usize) -> Result<()> {
+    pub async fn send_buffered<T, I>(&self, events: I, buffer_size: usize) -> Result<()>
+    where
+        T: Event,
+        I: IntoIterator<Item = T>,
+    {
         #[cfg(feature = "metrics")]
         let start = metrics::now();
 

--- a/src/infra/metrics/metrics_definitions.rs
+++ b/src/infra/metrics/metrics_definitions.rs
@@ -228,8 +228,5 @@ metrics! {
     histogram_duration kafka_send_buffered{},
 
     "Time to run KafkaConnector::create_buffer"
-    histogram_duration kafka_create_buffer{},
-
-    "Time to create events"
-    histogram_duration kafka_create_events{}
+    histogram_duration kafka_create_buffer{}
 }


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Optimized transaction event processing in the Importer:
  - Replaced individual transaction processing with a single operation using `flat_map`
  - Increased buffer size from 30 to 50 for improved performance
- Enhanced Kafka connector flexibility:
  - Modified `create_buffer` and `send_buffered` methods to accept generic `IntoIterator`
  - Updated method signatures for better type flexibility
- These changes aim to improve performance and efficiency when sending events to Kafka



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>importer.rs</strong><dd><code>Optimize transaction event processing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/follower/importer/importer.rs

<li>Replaced loop for sending individual transactions with a single <br>operation<br> <li> Changed to use <code>flat_map</code> to process all transactions at once<br> <li> Increased buffer size from 30 to 50<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1868/files#diff-bd50f502f039aff8f75753bc780d281ae7d7936fadc9d53482084c647aec94ca">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>kafka.rs</strong><dd><code>Enhance Kafka connector flexibility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/infra/kafka/kafka.rs

<li>Modified <code>create_buffer</code> and <code>send_buffered</code> methods to accept generic <br><code>IntoIterator</code> instead of <code>Vec</code><br> <li> Updated method signatures to be more flexible with input types<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1868/files#diff-516e87c7aa8eb8e7908ce3727257a1f4ee49127c5e0e7dcd60fac65c3afcafef">+10/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information