### PR TITLE
enha: add config for linger.ms and batch.size

### DIFF
--- a/src/infra/kafka/kafka.rs
+++ b/src/infra/kafka/kafka.rs
@@ -101,16 +101,17 @@ impl KafkaConnector {
         );
 
         let security_protocol = config.security_protocol;
+        let mut client_config = ClientConfig::new()
+            .set("bootstrap.servers", &config.bootstrap_servers)
+            .set("client.id", &config.client_id)
+            .set("linger.ms", "100")
+            .set("batch.size", "1048576") // 1 MB
+            .to_owned();
 
         let producer = match security_protocol {
-            KafkaSecurityProtocol::None => ClientConfig::new()
-                .set("bootstrap.servers", &config.bootstrap_servers)
-                .set("client.id", &config.client_id)
-                .create()?,
-            KafkaSecurityProtocol::SaslSsl => ClientConfig::new()
+            KafkaSecurityProtocol::None => client_config.create()?,
+            KafkaSecurityProtocol::SaslSsl => client_config
                 .set("security.protocol", "SASL_SSL")
-                .set("bootstrap.servers", &config.bootstrap_servers)
-                .set("client.id", &config.client_id)
                 .set(
                     "sasl.mechanisms",
                     config.sasl_mechanisms.as_ref().expect("sasl mechanisms is required").as_str(),
@@ -118,9 +119,7 @@ impl KafkaConnector {
                 .set("sasl.username", config.sasl_username.as_ref().expect("sasl username is required").as_str())
                 .set("sasl.password", config.sasl_password.as_ref().expect("sasl password is required").as_str())
                 .create()?,
-            KafkaSecurityProtocol::Ssl => ClientConfig::new()
-                .set("bootstrap.servers", &config.bootstrap_servers)
-                .set("client.id", &config.client_id)
+            KafkaSecurityProtocol::Ssl => client_config
                 .set(
                     "ssl.ca.location",
                     config.ssl_ca_location.as_ref().expect("ssl ca location is required").as_str(),


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added Kafka producer configuration for `linger.ms` (100ms) and `batch.size` (1MB) to optimize performance:
  - `linger.ms`: Introduces a small delay in sending messages, allowing for more batching and potentially reducing the number of requests
  - `batch.size`: Sets the maximum size of a request in bytes, helping to accumulate more messages in a single batch
- Refactored Kafka client configuration to reduce code duplication:
  - Created a base `client_config` with common settings
  - Modified security protocol-specific configurations to build upon the base config
- Maintained existing security protocol configurations (None, SASL_SSL, SSL) while incorporating the new performance settings



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>kafka.rs</strong><dd><code>Optimize Kafka producer settings and refactor configuration</code></dd></summary>
<hr>

src/infra/kafka/kafka.rs

<li>Added configuration for <code>linger.ms</code> and <code>batch.size</code> to improve Kafka <br>producer performance<br> <li> Refactored Kafka client configuration to reduce code duplication<br> <li> Maintained existing security protocol configurations<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1869/files#diff-516e87c7aa8eb8e7908ce3727257a1f4ee49127c5e0e7dcd60fac65c3afcafef">+9/-10</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information