### PR TITLE
refac: don't use references with `Copy` types

### DIFF
--- a/src/bin/importer_offline.rs
+++ b/src/bin/importer_offline.rs
@@ -135,7 +135,7 @@ fn execute_block_importer(
         tracing::info!(parent: None, %block_start, %block_end, %receipts_len, "reexecuting blocks");
 
         // ensure block range have no gaps
-        if block_start.count_to(&block_end) != batch_blocks_len as u64 {
+        if block_start.count_to(block_end) != batch_blocks_len as u64 {
             let message = GlobalState::shutdown_from(TASK_NAME, "received block range with gaps to reexecute");
             return log_and_err!(message);
         }

--- a/src/bin/rpc_downloader.rs
+++ b/src/bin/rpc_downloader.rs
@@ -82,7 +82,7 @@ async fn download_balances(rpc_storage: Arc<dyn ExternalRpcStorage>, chain: &Blo
 
     // download missing balances
     for address in address_to_download {
-        let balance = chain.fetch_balance(&address, Some(BlockNumber::ZERO)).await?;
+        let balance = chain.fetch_balance(address, Some(BlockNumber::ZERO)).await?;
         rpc_storage.save_initial_account(address, balance).await?;
     }
 

--- a/src/eth/executor/evm.rs
+++ b/src/eth/executor/evm.rs
@@ -174,7 +174,7 @@ impl Evm {
         // track metrics
         #[cfg(feature = "metrics")]
         {
-            metrics::inc_evm_execution(start.elapsed(), &session_point_in_time, execution.is_ok());
+            metrics::inc_evm_execution(start.elapsed(), session_point_in_time, execution.is_ok());
             metrics::inc_evm_execution_account_reads(session_metrics.account_reads);
         }
 
@@ -235,7 +235,7 @@ impl Database for RevmSession {
 
         // retrieve account
         let address: Address = revm_address.into();
-        let account = self.storage.read_account(&address, &self.input.point_in_time)?;
+        let account = self.storage.read_account(address, self.input.point_in_time)?;
 
         // warn if the loaded account is the `to` account and it does not have a bytecode
         if let Some(ref to_address) = self.input.to {
@@ -272,7 +272,7 @@ impl Database for RevmSession {
         let index: SlotIndex = revm_index.into();
 
         // load slot from storage
-        let slot = self.storage.read_slot(&address, &index, &self.input.point_in_time)?;
+        let slot = self.storage.read_slot(address, index, self.input.point_in_time)?;
 
         // track original value, except if ignored address
         if not(address.is_ignored()) {

--- a/src/eth/executor/executor.rs
+++ b/src/eth/executor/executor.rs
@@ -247,7 +247,7 @@ impl Executor {
 
         // determine how to execute each transaction
         for tx in block_transactions {
-            let receipt = receipts.try_remove(&tx.hash())?;
+            let receipt = receipts.try_remove(tx.hash())?;
             self.execute_external_transaction(
                 tx,
                 receipt,
@@ -329,7 +329,7 @@ impl Executor {
             //
             // failed external transaction, re-create from receipt without re-executing
             false => {
-                let sender = self.storage.read_account(&receipt.from.into(), &StoragePointInTime::Pending)?;
+                let sender = self.storage.read_account(receipt.from.into(), StoragePointInTime::Pending)?;
                 let execution = EvmExecution::from_failed_external_transaction(sender, &receipt, block_timestamp)?;
                 let evm_result = EvmExecutionResult {
                     execution,
@@ -548,7 +548,7 @@ impl Executor {
         let pending_header = self.storage.read_pending_block_header()?.unwrap_or_default();
         let mined_block = match point_in_time {
             StoragePointInTime::MinedPast(number) => {
-                let Some(block) = self.storage.read_block(&BlockFilter::Number(number))? else {
+                let Some(block) = self.storage.read_block(BlockFilter::Number(number))? else {
                     let filter = BlockFilter::Number(number);
                     return Err(StratusError::RpcBlockFilterInvalid { filter });
                 };

--- a/src/eth/miner/miner.rs
+++ b/src/eth/miner/miner.rs
@@ -421,7 +421,7 @@ pub fn block_from_local(pending_header: PendingBlockHeader, txs: Vec<LocalTransa
 
     // calculate transactions hash
     if not(block.transactions.is_empty()) {
-        let transactions_hashes: Vec<&Hash> = block.transactions.iter().map(|x| &x.input.hash).collect();
+        let transactions_hashes: Vec<Hash> = block.transactions.iter().map(|x| x.input.hash).collect();
         block.header.transactions_root = triehash::ordered_trie_root::<KeccakHasher, _>(transactions_hashes).into();
     }
 

--- a/src/eth/primitives/block.rs
+++ b/src/eth/primitives/block.rs
@@ -130,8 +130,8 @@ impl Block {
                     .entry(transaction_changes.address)
                     .or_insert(transaction_changes.clone());
 
-                if let Some(nonce) = transaction_changes.nonce.take_modified_ref() {
-                    account_compacted_changes.nonce.set_modified(*nonce);
+                if let Some(&nonce) = transaction_changes.nonce.take_modified_ref() {
+                    account_compacted_changes.nonce.set_modified(nonce);
                 }
 
                 if let Some(balance) = transaction_changes.balance.take_modified_ref() {
@@ -142,10 +142,10 @@ impl Block {
                     account_compacted_changes.bytecode.set_modified(bytecode.clone());
                 }
 
-                for (slot_index, slot) in &transaction_changes.slots {
-                    let slot_compacted_changes = account_compacted_changes.slots.entry(*slot_index).or_insert(slot.clone());
-                    if let Some(slot_value) = slot.take_modified_ref() {
-                        slot_compacted_changes.set_modified(*slot_value);
+                for (&slot_index, slot) in &transaction_changes.slots {
+                    let slot_compacted_changes = account_compacted_changes.slots.entry(slot_index).or_insert(slot.clone());
+                    if let Some(&slot_value) = slot.take_modified_ref() {
+                        slot_compacted_changes.set_modified(slot_value);
                     }
                 }
             }

--- a/src/eth/primitives/block_number.rs
+++ b/src/eth/primitives/block_number.rs
@@ -69,7 +69,7 @@ impl BlockNumber {
     /// Count how many blocks there is between itself and the othe block.
     ///
     /// Assumes that self is the lower-end of the range.
-    pub fn count_to(&self, higher_end: &BlockNumber) -> u64 {
+    pub fn count_to(self, higher_end: BlockNumber) -> u64 {
         if higher_end >= self {
             higher_end.as_u64() - self.as_u64() + 1
         } else {

--- a/src/eth/primitives/external_receipts.rs
+++ b/src/eth/primitives/external_receipts.rs
@@ -11,8 +11,8 @@ pub struct ExternalReceipts(HashMap<Hash, ExternalReceipt>);
 
 impl ExternalReceipts {
     /// Tries to remove a receipt by its hash.
-    pub fn try_remove(&mut self, tx_hash: &Hash) -> anyhow::Result<ExternalReceipt> {
-        match self.0.remove(tx_hash) {
+    pub fn try_remove(&mut self, tx_hash: Hash) -> anyhow::Result<ExternalReceipt> {
+        match self.0.remove(&tx_hash) {
             Some(receipt) => Ok(receipt),
             None => {
                 tracing::error!(%tx_hash, "receipt is missing for hash");

--- a/src/eth/primitives/log_filter.rs
+++ b/src/eth/primitives/log_filter.rs
@@ -32,7 +32,7 @@ impl LogFilter {
 
         // filter address
         let has_addresses = not(self.addresses.is_empty());
-        if has_addresses && not(self.addresses.contains(log.address())) {
+        if has_addresses && not(self.addresses.contains(&log.address())) {
             return false;
         }
 

--- a/src/eth/primitives/log_filter_input.rs
+++ b/src/eth/primitives/log_filter_input.rs
@@ -48,12 +48,12 @@ impl LogFilterInput {
         // parse point-in-time
         let (from, to) = match self.block_hash {
             Some(hash) => {
-                let from_to = storage.translate_to_point_in_time(&BlockFilter::Hash(hash))?;
+                let from_to = storage.translate_to_point_in_time(BlockFilter::Hash(hash))?;
                 (from_to, from_to)
             }
             None => {
-                let from = storage.translate_to_point_in_time(&self.from_block.unwrap_or(BlockFilter::Latest))?;
-                let to = storage.translate_to_point_in_time(&self.to_block.unwrap_or(BlockFilter::Latest))?;
+                let from = storage.translate_to_point_in_time(self.from_block.unwrap_or(BlockFilter::Latest))?;
+                let to = storage.translate_to_point_in_time(self.to_block.unwrap_or(BlockFilter::Latest))?;
                 (from, to)
             }
         };

--- a/src/eth/primitives/log_mined.rs
+++ b/src/eth/primitives/log_mined.rs
@@ -36,8 +36,8 @@ pub struct LogMined {
 
 impl LogMined {
     /// Returns the address that emitted the log.
-    pub fn address(&self) -> &Address {
-        &self.log.address
+    pub fn address(&self) -> Address {
+        self.log.address
     }
 
     /// Returns all non-empty topics in the log.

--- a/src/eth/primitives/transaction_execution.rs
+++ b/src/eth/primitives/transaction_execution.rs
@@ -73,10 +73,10 @@ impl TransactionExecution {
     }
 
     /// Returns the EVM execution metrics.
-    pub fn metrics(&self) -> &EvmExecutionMetrics {
+    pub fn metrics(&self) -> EvmExecutionMetrics {
         match self {
-            Self::Local(LocalTransactionExecution { result, .. }) => &result.metrics,
-            Self::External(ExternalTransactionExecution { evm_execution: result, .. }) => &result.metrics,
+            Self::Local(LocalTransactionExecution { result, .. }) => result.metrics,
+            Self::External(ExternalTransactionExecution { evm_execution: result, .. }) => result.metrics,
         }
     }
 }

--- a/src/eth/storage/inmemory/inmemory_history.rs
+++ b/src/eth/storage/inmemory/inmemory_history.rs
@@ -45,7 +45,7 @@ where
     }
 
     /// Returns the value at the given point in time.
-    pub fn get_at_point(&self, point_in_time: &StoragePointInTime) -> Option<T> {
+    pub fn get_at_point(&self, point_in_time: StoragePointInTime) -> Option<T> {
         match point_in_time {
             StoragePointInTime::Mined | StoragePointInTime::Pending => Some(self.get_current()),
             StoragePointInTime::MinedPast(block_number) => self.get_at_block(block_number),
@@ -53,8 +53,8 @@ where
     }
 
     /// Returns the most recent value before or at the given block number.
-    pub fn get_at_block(&self, block_number: &BlockNumber) -> Option<T> {
-        self.0.iter().take_while(|x| x.block_number <= *block_number).map(|x| &x.value).last().cloned()
+    pub fn get_at_block(&self, block_number: BlockNumber) -> Option<T> {
+        self.0.iter().take_while(|x| x.block_number <= block_number).map(|x| &x.value).last().cloned()
     }
 
     /// Returns the most recent value.

--- a/src/eth/storage/permanent_storage.rs
+++ b/src/eth/storage/permanent_storage.rs
@@ -43,10 +43,10 @@ pub trait PermanentStorage: Send + Sync + 'static {
     fn save_block(&self, block: Block) -> anyhow::Result<()>;
 
     /// Retrieves a block from the storage.
-    fn read_block(&self, block_filter: &BlockFilter) -> anyhow::Result<Option<Block>>;
+    fn read_block(&self, block_filter: BlockFilter) -> anyhow::Result<Option<Block>>;
 
     /// Retrieves a transaction from the storage.
-    fn read_transaction(&self, hash: &Hash) -> anyhow::Result<Option<TransactionMined>>;
+    fn read_transaction(&self, hash: Hash) -> anyhow::Result<Option<TransactionMined>>;
 
     /// Retrieves logs from the storage.
     fn read_logs(&self, filter: &LogFilter) -> anyhow::Result<Vec<LogMined>>;
@@ -59,10 +59,10 @@ pub trait PermanentStorage: Send + Sync + 'static {
     fn save_accounts(&self, accounts: Vec<Account>) -> anyhow::Result<()>;
 
     /// Retrieves an account from the storage. Returns Option when not found.
-    fn read_account(&self, address: &Address, point_in_time: &StoragePointInTime) -> anyhow::Result<Option<Account>>;
+    fn read_account(&self, address: Address, point_in_time: StoragePointInTime) -> anyhow::Result<Option<Account>>;
 
     /// Retrieves an slot from the storage. Returns Option when not found.
-    fn read_slot(&self, address: &Address, index: &SlotIndex, point_in_time: &StoragePointInTime) -> anyhow::Result<Option<Slot>>;
+    fn read_slot(&self, address: Address, index: SlotIndex, point_in_time: StoragePointInTime) -> anyhow::Result<Option<Slot>>;
 
     // -------------------------------------------------------------------------
     // Global state

--- a/src/eth/storage/rocks/rocks_permanent.rs
+++ b/src/eth/storage/rocks/rocks_permanent.rs
@@ -85,19 +85,19 @@ impl PermanentStorage for RocksPermanentStorage {
     // State operations
     // -------------------------------------------------------------------------
 
-    fn read_account(&self, address: &Address, point_in_time: &StoragePointInTime) -> anyhow::Result<Option<Account>> {
+    fn read_account(&self, address: Address, point_in_time: StoragePointInTime) -> anyhow::Result<Option<Account>> {
         self.state.read_account(address, point_in_time).inspect_err(|e| {
             tracing::error!(reason = ?e, "failed to read account in RocksPermanent");
         })
     }
 
-    fn read_slot(&self, address: &Address, index: &SlotIndex, point_in_time: &StoragePointInTime) -> anyhow::Result<Option<Slot>> {
+    fn read_slot(&self, address: Address, index: SlotIndex, point_in_time: StoragePointInTime) -> anyhow::Result<Option<Slot>> {
         self.state.read_slot(address, index, point_in_time).inspect_err(|e| {
             tracing::error!(reason = ?e, "failed to read slot in RocksPermanent");
         })
     }
 
-    fn read_block(&self, selection: &BlockFilter) -> anyhow::Result<Option<Block>> {
+    fn read_block(&self, selection: BlockFilter) -> anyhow::Result<Option<Block>> {
         let block = self.state.read_block(selection).inspect_err(|e| {
             tracing::error!(reason = ?e, "failed to read block in RocksPermanent");
         });
@@ -107,7 +107,7 @@ impl PermanentStorage for RocksPermanentStorage {
         block
     }
 
-    fn read_transaction(&self, hash: &Hash) -> anyhow::Result<Option<TransactionMined>> {
+    fn read_transaction(&self, hash: Hash) -> anyhow::Result<Option<TransactionMined>> {
         self.state.read_transaction(hash).inspect_err(|e| {
             tracing::error!(reason = ?e, "failed to read transaction in RocksPermanent");
         })

--- a/src/eth/storage/rocks/types/account.rs
+++ b/src/eth/storage/rocks/types/account.rs
@@ -18,9 +18,9 @@ pub struct AccountRocksdb {
 }
 
 impl AccountRocksdb {
-    pub fn to_account(&self, address: &Address) -> Account {
+    pub fn to_account(&self, address: Address) -> Account {
         Account {
-            address: *address,
+            address,
             nonce: self.nonce.clone().into(),
             balance: self.balance.clone().into(),
             bytecode: self.bytecode.clone().map_into(),

--- a/src/eth/storage/storage_point_in_time.rs
+++ b/src/eth/storage/storage_point_in_time.rs
@@ -23,8 +23,8 @@ pub enum StoragePointInTime {
 // -----------------------------------------------------------------------------
 // Conversions: Self -> Other
 // -----------------------------------------------------------------------------
-impl From<&StoragePointInTime> for MetricLabelValue {
-    fn from(value: &StoragePointInTime) -> Self {
+impl From<StoragePointInTime> for MetricLabelValue {
+    fn from(value: StoragePointInTime) -> Self {
         Self::Some(value.to_string())
     }
 }

--- a/src/eth/storage/temporary_storage.rs
+++ b/src/eth/storage/temporary_storage.rs
@@ -42,17 +42,17 @@ pub trait TemporaryStorage: Send + Sync + 'static {
     fn read_pending_executions(&self) -> Vec<TransactionExecution>;
 
     /// Retrieves a single transaction execution from the pending block.
-    fn read_pending_execution(&self, hash: &Hash) -> anyhow::Result<Option<TransactionExecution>>;
+    fn read_pending_execution(&self, hash: Hash) -> anyhow::Result<Option<TransactionExecution>>;
 
     // -------------------------------------------------------------------------
     // Accounts and slots
     // -------------------------------------------------------------------------
 
     /// Retrieves an account from the storage. Returns Option when not found.
-    fn read_account(&self, address: &Address) -> anyhow::Result<Option<Account>>;
+    fn read_account(&self, address: Address) -> anyhow::Result<Option<Account>>;
 
     /// Retrieves an slot from the storage. Returns Option when not found.
-    fn read_slot(&self, address: &Address, index: &SlotIndex) -> anyhow::Result<Option<Slot>>;
+    fn read_slot(&self, address: Address, index: SlotIndex) -> anyhow::Result<Option<Slot>>;
 
     // -------------------------------------------------------------------------
     // Global state

--- a/src/infra/blockchain_client/blockchain_client.rs
+++ b/src/infra/blockchain_client/blockchain_client.rs
@@ -185,7 +185,7 @@ impl BlockchainClient {
     }
 
     /// Fetches account balance by address and block number.
-    pub async fn fetch_balance(&self, address: &Address, block_number: Option<BlockNumber>) -> anyhow::Result<Wei> {
+    pub async fn fetch_balance(&self, address: Address, block_number: Option<BlockNumber>) -> anyhow::Result<Wei> {
         tracing::debug!(%address, block_number = %block_number.or_empty(), "fetching account balance");
 
         let address = to_json_value(address);


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Removed unnecessary references for Copy types across multiple files in the project.
- Updated method signatures, function calls, and comparisons to use values instead of references for types like Address, Hash, BlockNumber, and StoragePointInTime.
- Modified data structures to store and return values instead of references where appropriate.
- Adjusted iterator and collection operations to work with values rather than references.
- These changes should improve performance by reducing indirection and potentially allowing for better optimizations by the compiler.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>15 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>rpc_downloader.rs</strong><dd><code>Remove reference for address in fetch_balance</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/bin/rpc_downloader.rs

<li>Changed <code>chain.fetch_balance(&address, ...)</code> to <br><code>chain.fetch_balance(address, ...)</code><br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1875/files#diff-34137b2d44a1c2a35b30a2515f309e99ecd04277d9b2d681ff55c5bbe30ac5c1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>evm.rs</strong><dd><code>Remove references for Copy types in EVM execution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/executor/evm.rs

<li>Removed reference for <code>session_point_in_time</code> in <br><code>metrics::inc_evm_execution</code><br> <li> Changed <code>self.storage.read_account(&address, &self.input.point_in_time)</code> <br>to <code>self.storage.read_account(address, self.input.point_in_time)</code><br> <li> Changed <code>self.storage.read_slot(&address, &index, </code><br><code>&self.input.point_in_time)</code> to <code>self.storage.read_slot(address, index, </code><br><code>self.input.point_in_time)</code><br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1875/files#diff-7fabd204a68cff51c55ee1391074463fa8ac005dc8ba443218bc83a9dda96658">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>executor.rs</strong><dd><code>Remove references for Copy types in Executor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/executor/executor.rs

<li>Changed <code>receipts.try_remove(&tx.hash())</code> to <br><code>receipts.try_remove(tx.hash())</code><br> <li> Changed <code>self.storage.read_account(&receipt.from.into(), </code><br><code>&StoragePointInTime::Pending)</code> to <br><code>self.storage.read_account(receipt.from.into(), </code><br><code>StoragePointInTime::Pending)</code><br> <li> Changed <code>self.storage.read_block(&BlockFilter::Number(number))</code> to <br><code>self.storage.read_block(BlockFilter::Number(number))</code><br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1875/files#diff-6b460d7dee8280c0287e8d9d9d59cf66a57ec9fed1bc003c6ede6fef60c7376b">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>miner.rs</strong><dd><code>Remove references for Hash type in miner</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/miner/miner.rs

<li>Changed <code>Vec<&Hash></code> to <code>Vec<Hash></code> in transactions_hashes<br> <li> Removed reference operator in <code>x.input.hash</code><br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1875/files#diff-16f448afc7dae3e8e802f676a86dbd7051e19f6c17cbbeb53eb730d726372629">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>block.rs</strong><dd><code>Remove references for Copy types in Block</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/block.rs

<li>Changed <code>if let Some(nonce) = </code><br><code>transaction_changes.nonce.take_modified_ref()</code> to <code>if let Some(&nonce) = </code><br><code>transaction_changes.nonce.take_modified_ref()</code><br> <li> Changed <code>for (slot_index, slot) in &transaction_changes.slots</code> to <code>for </code><br><code>(&slot_index, slot) in &transaction_changes.slots</code><br> <li> Changed <code>if let Some(slot_value) = slot.take_modified_ref()</code> to <code>if let </code><br><code>Some(&slot_value) = slot.take_modified_ref()</code><br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1875/files#diff-1713a99b45fd64ac0570786603a3a17edc97657646bd333e5e214e4a531def10">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>block_number.rs</strong><dd><code>Remove reference for BlockNumber in count_to</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/block_number.rs

<li>Changed <code>pub fn count_to(&self, higher_end: &BlockNumber) -> u64</code> to <code>pub </code><br><code>fn count_to(self, higher_end: BlockNumber) -> u64</code><br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1875/files#diff-23597a90086820357b399bf33f2db790baaf7f0d4617a74a134c4d200022bb93">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>external_receipts.rs</strong><dd><code>Remove reference for Hash in try_remove</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/external_receipts.rs

<li>Changed <code>pub fn try_remove(&mut self, tx_hash: &Hash) -> anyhow::Result<ExternalReceipt></code> <br>to <code>pub fn try_remove(&mut self, tx_hash: Hash) -> anyhow::Result<ExternalReceipt></code><br> <li> Changed <code>self.0.remove(tx_hash)</code> to <code>self.0.remove(&tx_hash)</code><br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1875/files#diff-c485a8d59ab59b4a46365a97e16383a9e39a985dc9e5cd297992b94fcb382bce">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>log_filter.rs</strong><dd><code>Add reference for address in contains check</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/log_filter.rs

<li>Changed <code>if has_addresses && </code><br><code>not(self.addresses.contains(log.address()))</code> to <code>if has_addresses && </code><br><code>not(self.addresses.contains(&log.address()))</code><br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1875/files#diff-8a77d8af3c5d907f1763771a0823aa4cab0b90e55eb6b7b173943381b7388ff8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>log_filter_input.rs</strong><dd><code>Remove references for BlockFilter in translate_to_point_in_time</code></dd></summary>
<hr>

src/eth/primitives/log_filter_input.rs

<li>Changed <code>storage.translate_to_point_in_time(&BlockFilter::Hash(hash))</code> <br>to <code>storage.translate_to_point_in_time(BlockFilter::Hash(hash))</code><br> <li> Changed <br><code>storage.translate_to_point_in_time(&self.from_block.unwrap_or(BlockFilter::Latest))</code> <br>to <br><code>storage.translate_to_point_in_time(self.from_block.unwrap_or(BlockFilter::Latest))</code><br> <li> Changed <br><code>storage.translate_to_point_in_time(&self.to_block.unwrap_or(BlockFilter::Latest))</code> <br>to <br><code>storage.translate_to_point_in_time(self.to_block.unwrap_or(BlockFilter::Latest))</code><br> <br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1875/files#diff-1fc314c5ef2bb71e10a986847e852f50d787c67b002131aa6f4afae62ebd4555">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>log_mined.rs</strong><dd><code>Return Address by value instead of reference</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/log_mined.rs

<li>Changed <code>pub fn address(&self) -> &Address</code> to <code>pub fn address(&self) -> </code><br><code>Address</code><br> <li> Changed <code>&self.log.address</code> to <code>self.log.address</code><br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1875/files#diff-0ce210a69394a14d9a6424cf5ddf8b84c10a535b9ecae1dd34c0dbcff4beaf07">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>transaction_execution.rs</strong><dd><code>Return EvmExecutionMetrics by value instead of reference</code>&nbsp; </dd></summary>
<hr>

src/eth/primitives/transaction_execution.rs

<li>Changed <code>pub fn metrics(&self) -> &EvmExecutionMetrics</code> to <code>pub fn </code><br><code>metrics(&self) -> EvmExecutionMetrics</code><br> <li> Changed <code>&result.metrics</code> to <code>result.metrics</code><br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1875/files#diff-363d860c6f773a2fea3a060866e15cdfa2fbe9e355b16a7567d9b2ed465fc987">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>rpc_server.rs</strong><dd><code>Remove references for Copy types in RPC server</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/rpc/rpc_server.rs

<li>Changed multiple instances of <code>read_block(&BlockFilter::...)</code> to <br><code>read_block(BlockFilter::...)</code><br> <li> Changed <code>ctx.storage.read_transaction(&tx_hash)</code> to <br><code>ctx.storage.read_transaction(tx_hash)</code><br> <li> Changed <code>ctx.storage.translate_to_point_in_time(&filter)</code> to <br><code>ctx.storage.translate_to_point_in_time(filter)</code><br> <li> Changed <code>filter.from_block.count_to(&to_block)</code> to <br><code>filter.from_block.count_to(to_block)</code><br> <li> Changed multiple instances of <code>ctx.storage.read_account(&address, </code><br><code>&point_in_time)</code> to <code>ctx.storage.read_account(address, point_in_time)</code><br> <li> Changed multiple instances of <code>ctx.storage.read_slot(&address, &index, </code><br><code>&point_in_time)</code> to <code>ctx.storage.read_slot(address, index, </code><br><code>point_in_time)</code><br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1875/files#diff-835ba255c9a5c1fe0e13285bc39e058e1c74422e5e03ebba483c9d8a15c45405">+14/-14</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>inmemory_history.rs</strong><dd><code>Remove references for Copy types in InMemoryHistory</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/inmemory/inmemory_history.rs

<li>Changed <code>pub fn get_at_point(&self, point_in_time: &StoragePointInTime) </code><br><code>-> Option<T></code> to <code>pub fn get_at_point(&self, point_in_time: </code><br><code>StoragePointInTime) -> Option<T></code><br> <li> Changed <code>pub fn get_at_block(&self, block_number: &BlockNumber) -> </code><br><code>Option<T></code> to <code>pub fn get_at_block(&self, block_number: BlockNumber) -> </code><br><code>Option<T></code><br> <li> Changed <code>self.0.iter().take_while(|x| x.block_number <= *block_number)</code> <br>to <code>self.0.iter().take_while(|x| x.block_number <= block_number)</code><br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1875/files#diff-322061156099977548ec07fa5d628c583d880f23259fdb3a53fd4e2ad9a21789">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>inmemory_permanent.rs</strong><dd><code>Remove references for Copy types in InMemoryPermanentStorage</code></dd></summary>
<hr>

src/eth/storage/inmemory/inmemory_permanent.rs

<li>Changed multiple instances of method signatures to remove references <br>for Copy types<br> <li> Updated method calls to pass values instead of references<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1875/files#diff-6cc83da72398cf1ba410cb7dd95e4e8f232f5db52c81bc92de5261dfe6d8e429">+12/-12</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>inmemory_temporary.rs</strong><dd><code>Remove references for Copy types in InMemoryTemporaryStorage</code></dd></summary>
<hr>

src/eth/storage/inmemory/inmemory_temporary.rs

<li>Changed multiple method signatures to remove references for Copy types<br> <li> Updated method calls and comparisons to use values instead of <br>references<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1875/files#diff-6f4ee832c01927be4b428028743a37022368d351f09fd177f59e81a5a58dd661">+23/-23</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information