### PR TITLE
test: fix multiget test again

### DIFF
--- a/src/eth/storage/rocks/rocks_state.rs
+++ b/src/eth/storage/rocks/rocks_state.rs
@@ -624,7 +624,6 @@ impl fmt::Debug for RocksStorageState {
 
 #[cfg(test)]
 mod tests {
-
     use fake::Fake;
     use fake::Faker;
 
@@ -635,6 +634,9 @@ mod tests {
     #[test]
     #[cfg(feature = "dev")]
     fn test_rocks_multi_get() {
+        use std::collections::HashSet;
+        use std::iter;
+
         type Key = (AddressRocksdb, SlotIndexRocksdb);
         type Value = CfAccountSlotsValue;
 


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
This PR includes several enhancements and bug fixes across multiple files in the project:

- Removed unnecessary references in method calls throughout the codebase, improving performance and readability.
- Changed several methods to take arguments by value instead of by reference, which can lead to more efficient code in some cases.
- Modified some data structures to use owned values instead of references, potentially reducing memory usage and improving cache locality.
- Fixed a bug in the log filter where a reference was missing in a contains method call.
- Updated method signatures in storage-related modules to be more consistent with the changes made elsewhere.

These changes should result in cleaner, more idiomatic Rust code and may lead to minor performance improvements in some areas.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>14 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>importer_offline.rs</strong><dd><code>Removed unnecessary reference in count_to method call</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/bin/importer_offline.rs

<li>Changed <code>block_start.count_to(&block_end)</code> to <br><code>block_start.count_to(block_end)</code><br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1876/files#diff-9fef7d584818c3db119ea1cd0952a57a953751f85f93ca813af861c4c737c53a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>rpc_downloader.rs</strong><dd><code>Removed unnecessary reference in fetch_balance method call</code></dd></summary>
<hr>

src/bin/rpc_downloader.rs

<li>Changed <code>chain.fetch_balance(&address, Some(BlockNumber::ZERO))</code> to <br><code>chain.fetch_balance(address, Some(BlockNumber::ZERO))</code><br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1876/files#diff-34137b2d44a1c2a35b30a2515f309e99ecd04277d9b2d681ff55c5bbe30ac5c1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>evm.rs</strong><dd><code>Removed unnecessary references in method calls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/executor/evm.rs

<li>Changed <code>&session_point_in_time</code> to <code>session_point_in_time</code> in <br>metrics::inc_evm_execution call<br> <li> Modified <code>read_account</code> and <code>read_slot</code> method calls to pass arguments by <br>value instead of reference<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1876/files#diff-7fabd204a68cff51c55ee1391074463fa8ac005dc8ba443218bc83a9dda96658">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>executor.rs</strong><dd><code>Removed unnecessary references in method calls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/executor/executor.rs

<li>Changed <code>receipts.try_remove(&tx.hash())</code> to <br><code>receipts.try_remove(tx.hash())</code><br> <li> Modified <code>read_account</code> and <code>read_block</code> method calls to pass arguments by <br>value instead of reference<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1876/files#diff-6b460d7dee8280c0287e8d9d9d59cf66a57ec9fed1bc003c6ede6fef60c7376b">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>miner.rs</strong><dd><code>Changed vector type from references to owned values</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/miner/miner.rs

- Changed `Vec<&Hash>` to `Vec<Hash>` in transactions_hashes declaration



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1876/files#diff-16f448afc7dae3e8e802f676a86dbd7051e19f6c17cbbeb53eb730d726372629">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>block.rs</strong><dd><code>Removed unnecessary references in method calls and pattern matching</code></dd></summary>
<hr>

src/eth/primitives/block.rs

<li>Modified several method calls to pass arguments by value instead of <br>reference<br> <li> Changed pattern matching to use value semantics instead of reference <br>semantics<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1876/files#diff-1713a99b45fd64ac0570786603a3a17edc97657646bd333e5e214e4a531def10">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>block_number.rs</strong><dd><code>Modified count_to method to take self by value</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/block_number.rs

<li>Changed <code>pub fn count_to(&self, higher_end: &BlockNumber) -> u64</code> to <code>pub </code><br><code>fn count_to(self, higher_end: BlockNumber) -> u64</code><br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1876/files#diff-23597a90086820357b399bf33f2db790baaf7f0d4617a74a134c4d200022bb93">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>external_receipts.rs</strong><dd><code>Modified try_remove method to take tx_hash by value</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/external_receipts.rs

<li>Changed <code>pub fn try_remove(&mut self, tx_hash: &Hash)</code> to <code>pub fn </code><br><code>try_remove(&mut self, tx_hash: Hash)</code><br> <li> Modified <code>self.0.remove(tx_hash)</code> to <code>self.0.remove(&tx_hash)</code><br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1876/files#diff-c485a8d59ab59b4a46365a97e16383a9e39a985dc9e5cd297992b94fcb382bce">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>log_filter_input.rs</strong><dd><code>Removed unnecessary references in method calls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/log_filter_input.rs

<li>Modified <code>translate_to_point_in_time</code> method calls to pass arguments by <br>value instead of reference<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1876/files#diff-1fc314c5ef2bb71e10a986847e852f50d787c67b002131aa6f4afae62ebd4555">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>log_mined.rs</strong><dd><code>Changed address method to return owned value instead of reference</code></dd></summary>
<hr>

src/eth/primitives/log_mined.rs

<li>Changed <code>pub fn address(&self) -> &Address</code> to <code>pub fn address(&self) -> </code><br><code>Address</code><br> <li> Modified the return statement to <code>self.log.address</code> instead of <br><code>&self.log.address</code><br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1876/files#diff-0ce210a69394a14d9a6424cf5ddf8b84c10a535b9ecae1dd34c0dbcff4beaf07">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>transaction_execution.rs</strong><dd><code>Changed metrics method to return owned value instead of reference</code></dd></summary>
<hr>

src/eth/primitives/transaction_execution.rs

<li>Changed <code>pub fn metrics(&self) -> &EvmExecutionMetrics</code> to <code>pub fn </code><br><code>metrics(&self) -> EvmExecutionMetrics</code><br> <li> Modified return statements to return owned values instead of <br>references<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1876/files#diff-363d860c6f773a2fea3a060866e15cdfa2fbe9e355b16a7567d9b2ed465fc987">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>rpc_server.rs</strong><dd><code>Removed unnecessary references in method calls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/rpc/rpc_server.rs

<li>Modified several method calls to pass arguments by value instead of <br>reference<br> <li> Changed <code>blocks_in_range = filter.from_block.count_to(&to_block)</code> to <br><code>blocks_in_range = filter.from_block.count_to(to_block)</code><br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1876/files#diff-835ba255c9a5c1fe0e13285bc39e058e1c74422e5e03ebba483c9d8a15c45405">+14/-14</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>inmemory_history.rs</strong><dd><code>Changed methods to take arguments by value</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/inmemory/inmemory_history.rs

<li>Modified <code>get_at_point</code>, <code>get_at_block</code> methods to take arguments by value <br>instead of reference<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1876/files#diff-322061156099977548ec07fa5d628c583d880f23259fdb3a53fd4e2ad9a21789">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>inmemory_permanent.rs</strong><dd><code>Changed methods to take arguments by value</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/inmemory/inmemory_permanent.rs

<li>Modified several method signatures to take arguments by value instead <br>of reference<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1876/files#diff-6cc83da72398cf1ba410cb7dd95e4e8f232f5db52c81bc92de5261dfe6d8e429">+12/-12</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>log_filter.rs</strong><dd><code>Added reference operator in contains method call</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/log_filter.rs

<li>Changed <code>self.addresses.contains(log.address())</code> to <br><code>self.addresses.contains(&log.address())</code><br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1876/files#diff-8a77d8af3c5d907f1763771a0823aa4cab0b90e55eb6b7b173943381b7388ff8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information