### PR TITLE
style(e2e): remove commit hashes from contracts-remove.sh

### DIFF
--- a/e2e/cloudwalk-contracts/contracts-remove.sh
+++ b/e2e/cloudwalk-contracts/contracts-remove.sh
@@ -99,28 +99,28 @@ done
 log "Removing repositories"
 
 if [ "$token" == 1 ]; then
-    remove brlc-token 80bdba3
+    remove brlc-token
 fi
 
 if [ "$pix" == 1 ]; then
     # Cashier Transition: remove regardless of the repository name at the moment
-    remove brlc-cashier && remove brlc-pix-cashier a528d0c
+    remove brlc-cashier && remove brlc-pix-cashier
 fi
 
 if [ "$yield" == 1 ]; then
     remove brlc-balance-tracker
-    remove brlc-yield-streamer 7683517
+    remove brlc-yield-streamer
 fi
 
 if [ "$periphery" == 1 ]; then
     # Periphery Transition: remove regardless of the repository name at the moment
-    remove brlc-card-payment-processor && remove brlc-periphery fed9fcb
+    remove brlc-card-payment-processor && remove brlc-periphery
 fi
 
 if [ "$multisig" == 1 ]; then
-    remove brlc-multisig 918a226
+    remove brlc-multisig
 fi
 
 if [ "$compound" == 1 ]; then
-    remove compound-periphery e4d68df
+    remove compound-periphery
 fi


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Removed hardcoded commit hashes from the `remove` function calls in the `contracts-remove.sh` script.
- Simplified the script to make it more maintainable and less dependent on specific commit references.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>contracts-remove.sh</strong><dd><code>Remove commit hashes from repository removal script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

e2e/cloudwalk-contracts/contracts-remove.sh

<li>Removed commit hashes from <code>remove</code> function calls.<br> <li> Simplified the script by eliminating hardcoded commit references.<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1878/files#diff-d90c58ee8f3707cd2e12178cd9db784f66d7d26a9dcbbcd9e7c4d03c7c10abde">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information