### PR TITLE
enha: make pending block header required

### DIFF
--- a/src/eth/executor/executor.rs
+++ b/src/eth/executor/executor.rs
@@ -244,7 +244,6 @@ impl Executor {
         let block_number = block.number();
         let block_timestamp = block.timestamp();
         let block_transactions = mem::take(&mut block.transactions);
-        self.storage.set_pending_block_number(block_number)?;
 
         // determine how to execute each transaction
         for tx in block_transactions {
@@ -483,7 +482,7 @@ impl Executor {
             });
 
             // prepare evm input
-            let pending_header = self.storage.read_pending_block_header()?.unwrap_or_default();
+            let pending_header = self.storage.read_pending_block_header();
             let evm_input = EvmInput::from_eth_transaction(tx_input.clone(), pending_header);
 
             // execute transaction in evm (retry only in case of conflict, but do not retry on other failures)
@@ -546,7 +545,7 @@ impl Executor {
         );
 
         // retrieve block info
-        let pending_header = self.storage.read_pending_block_header()?.unwrap_or_default();
+        let pending_header = self.storage.read_pending_block_header();
         let mined_block = match point_in_time {
             PointInTime::MinedPast(number) => {
                 let Some(block) = self.storage.read_block(BlockFilter::Number(number))? else {

--- a/src/eth/primitives/execution_conflict.rs
+++ b/src/eth/primitives/execution_conflict.rs
@@ -1,6 +1,7 @@
 use display_json::DebugAsJson;
 use nonempty::NonEmpty;
 
+use super::BlockNumber;
 use crate::eth::primitives::Address;
 use crate::eth::primitives::Nonce;
 use crate::eth::primitives::SlotIndex;
@@ -57,9 +58,6 @@ pub enum ExecutionConflict {
         actual: SlotValue,
     },
 
-    /// Number of modified accounts mismatch.
-    AccountModifiedCount { expected: usize, actual: usize },
-
-    /// Number of modified slots mismatch.
-    SlotModifiedCount { expected: usize, actual: usize },
+    /// Transaction was executed in block A but the current pending block is B (A != B)
+    BlockNumber { execution: BlockNumber, pending: BlockNumber },
 }

--- a/src/eth/primitives/execution_conflict.rs
+++ b/src/eth/primitives/execution_conflict.rs
@@ -55,5 +55,5 @@ pub enum ExecutionConflict {
         slot: SlotIndex,
         expected: SlotValue,
         actual: SlotValue,
-    }
+    },
 }

--- a/src/eth/primitives/execution_conflict.rs
+++ b/src/eth/primitives/execution_conflict.rs
@@ -1,7 +1,6 @@
 use display_json::DebugAsJson;
 use nonempty::NonEmpty;
 
-use super::BlockNumber;
 use crate::eth::primitives::Address;
 use crate::eth::primitives::Nonce;
 use crate::eth::primitives::SlotIndex;
@@ -56,8 +55,5 @@ pub enum ExecutionConflict {
         slot: SlotIndex,
         expected: SlotValue,
         actual: SlotValue,
-    },
-
-    /// Transaction was executed in block A but the current pending block is B (A != B)
-    BlockNumber { execution: BlockNumber, pending: BlockNumber },
+    }
 }

--- a/src/eth/primitives/log_filter_input.rs
+++ b/src/eth/primitives/log_filter_input.rs
@@ -61,7 +61,7 @@ impl LogFilterInput {
 
         // translate point-in-time to block according to context
         let from = match from {
-            PointInTime::Pending => storage.read_pending_block_header()?.unwrap_or_default().number,
+            PointInTime::Pending => storage.read_pending_block_header().number,
             PointInTime::Mined => storage.read_mined_block_number()?,
             PointInTime::MinedPast(number) => number,
         };

--- a/src/eth/storage/mod.rs
+++ b/src/eth/storage/mod.rs
@@ -46,15 +46,9 @@ pub trait Storage: Sized {
 
     fn read_block_number_to_resume_import(&self) -> Result<BlockNumber, StratusError>;
 
-    fn read_pending_block_header(&self) -> Result<Option<PendingBlockHeader>, StratusError>;
+    fn read_pending_block_header(&self) -> PendingBlockHeader;
 
     fn read_mined_block_number(&self) -> Result<BlockNumber, StratusError>;
-
-    fn set_pending_block_number(&self, block_number: BlockNumber) -> Result<(), StratusError>;
-
-    fn set_pending_block_number_as_next(&self) -> Result<(), StratusError>;
-
-    fn set_pending_block_number_as_next_if_not_set(&self) -> Result<(), StratusError>;
 
     fn set_mined_block_number(&self, block_number: BlockNumber) -> Result<(), StratusError>;
 
@@ -121,8 +115,9 @@ pub struct StorageConfig {
 impl StorageConfig {
     /// Initializes Stratus storage.
     pub fn init(&self) -> Result<Arc<StratusStorage>, StratusError> {
-        let temp_storage = self.temp_storage.init()?;
         let perm_storage = self.perm_storage.init()?;
+        let temp_storage = self.temp_storage.init(&*perm_storage)?;
+
         let StorageKind::StratusStorage = self.storage_kind;
         let storage = StratusStorage::new(temp_storage, perm_storage)?;
 

--- a/src/eth/storage/stratus_storage.rs
+++ b/src/eth/storage/stratus_storage.rs
@@ -464,7 +464,6 @@ impl Storage for StratusStorage {
 
         // block number
         self.set_mined_block_number(BlockNumber::ZERO)?;
-        self.set_pending_block_number_as_next()?;
 
         Ok(())
     }

--- a/src/eth/storage/temporary/inmemory.rs
+++ b/src/eth/storage/temporary/inmemory.rs
@@ -81,7 +81,7 @@ impl InMemoryTemporaryStorageState {
     }
 
     pub fn reset(&mut self) {
-        self.block = PendingBlock::default();
+        self.block = PendingBlock::new_at_now(1.into());
         self.accounts.clear();
     }
 }

--- a/src/eth/storage/temporary/inmemory.rs
+++ b/src/eth/storage/temporary/inmemory.rs
@@ -40,7 +40,7 @@ impl InMemoryTemporaryStorage {
         Self {
             states: RwLock::new(NonEmpty::new(InMemoryTemporaryStorageState {
                 block: PendingBlock::new_at_now(block_number),
-                ..Default::default()
+                accounts: Default::default()
             })),
         }
     }
@@ -60,7 +60,7 @@ impl InMemoryTemporaryStorage {
 // Inner State
 // -----------------------------------------------------------------------------
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct InMemoryTemporaryStorageState {
     /// Block that is being mined.
     pub block: PendingBlock,
@@ -70,6 +70,13 @@ pub struct InMemoryTemporaryStorageState {
 }
 
 impl InMemoryTemporaryStorageState {
+    pub fn new(block_number: BlockNumber) -> Self {
+        Self {
+            block: PendingBlock::new_at_now(block_number),
+            accounts: Default::default()
+        }
+    }
+
     /// Validates there is a pending block being mined and returns a reference to it.
     fn require_pending_block(&self) -> &PendingBlock {
         &self.block
@@ -191,8 +198,7 @@ impl TemporaryStorage for InMemoryTemporaryStorage {
         }
 
         // create new state
-        states.insert(0, InMemoryTemporaryStorageState::default());
-        states.head.block = PendingBlock::new_at_now(finished_block.header.number.next_block_number());
+        states.insert(0, InMemoryTemporaryStorageState::new(finished_block.header.number.next_block_number()));
 
         Ok(finished_block)
     }

--- a/src/eth/storage/temporary/inmemory.rs
+++ b/src/eth/storage/temporary/inmemory.rs
@@ -77,16 +77,6 @@ impl InMemoryTemporaryStorageState {
         }
     }
 
-    /// Validates there is a pending block being mined and returns a reference to it.
-    fn require_pending_block(&self) -> &PendingBlock {
-        &self.block
-    }
-
-    /// Validates there is a pending block being mined and returns a mutable reference to it.
-    fn require_pending_block_mut(&mut self) -> &mut PendingBlock {
-        &mut self.block
-    }
-
     pub fn reset(&mut self) {
         self.block = PendingBlock::new_at_now(1.into());
         self.accounts.clear();
@@ -165,7 +155,7 @@ impl TemporaryStorage for InMemoryTemporaryStorage {
         }
 
         // save execution
-        states.head.require_pending_block_mut().push_transaction(tx);
+        states.head.block.push_transaction(tx);
 
         Ok(())
     }
@@ -179,9 +169,9 @@ impl TemporaryStorage for InMemoryTemporaryStorage {
         let mut states = self.lock_write();
 
         #[cfg(feature = "dev")]
-        let mut finished_block = states.head.require_pending_block().clone();
+        let mut finished_block = states.head.block.clone();
         #[cfg(not(feature = "dev"))]
-        let finished_block = states.head.require_pending_block().clone();
+        let finished_block = states.head.block.clone();
 
         #[cfg(feature = "dev")]
         {

--- a/src/eth/storage/temporary/inmemory.rs
+++ b/src/eth/storage/temporary/inmemory.rs
@@ -40,7 +40,7 @@ impl InMemoryTemporaryStorage {
         Self {
             states: RwLock::new(NonEmpty::new(InMemoryTemporaryStorageState {
                 block: PendingBlock::new_at_now(block_number),
-                accounts: Default::default()
+                accounts: Default::default(),
             })),
         }
     }
@@ -73,7 +73,7 @@ impl InMemoryTemporaryStorageState {
     pub fn new(block_number: BlockNumber) -> Self {
         Self {
             block: PendingBlock::new_at_now(block_number),
-            accounts: Default::default()
+            accounts: Default::default(),
         }
     }
 

--- a/src/eth/storage/temporary/inmemory.rs
+++ b/src/eth/storage/temporary/inmemory.rs
@@ -25,7 +25,6 @@ use crate::eth::primitives::UnixTime;
 #[cfg(feature = "dev")]
 use crate::eth::primitives::UnixTimeNow;
 use crate::eth::storage::TemporaryStorage;
-use crate::log_and_err;
 
 /// Number of previous blocks to keep inmemory to detect conflicts between different blocks.
 const MAX_BLOCKS: usize = 64;
@@ -36,16 +35,16 @@ pub struct InMemoryTemporaryStorage {
     pub states: RwLock<NonEmpty<InMemoryTemporaryStorageState>>,
 }
 
-impl Default for InMemoryTemporaryStorage {
-    fn default() -> Self {
-        tracing::info!("creating inmemory temporary storage");
+impl InMemoryTemporaryStorage {
+    pub fn new(block_number: BlockNumber) -> Self {
         Self {
-            states: RwLock::new(NonEmpty::new(InMemoryTemporaryStorageState::default())),
+            states: RwLock::new(NonEmpty::new(InMemoryTemporaryStorageState {
+                block: PendingBlock::new_at_now(block_number),
+                ..Default::default()
+            })),
         }
     }
-}
 
-impl InMemoryTemporaryStorage {
     /// Locks inner state for reading.
     pub fn lock_read(&self) -> RwLockReadGuard<'_, NonEmpty<InMemoryTemporaryStorageState>> {
         self.states.read().unwrap()
@@ -64,7 +63,7 @@ impl InMemoryTemporaryStorage {
 #[derive(Debug, Default)]
 pub struct InMemoryTemporaryStorageState {
     /// Block that is being mined.
-    pub block: Option<PendingBlock>,
+    pub block: PendingBlock,
 
     /// Last state of accounts and slots. Can be recreated from the executions inside the pending block.
     pub accounts: HashMap<Address, InMemoryTemporaryAccount, hash_hasher::HashBuildHasher>,
@@ -72,23 +71,17 @@ pub struct InMemoryTemporaryStorageState {
 
 impl InMemoryTemporaryStorageState {
     /// Validates there is a pending block being mined and returns a reference to it.
-    fn require_pending_block(&self) -> anyhow::Result<&PendingBlock> {
-        match &self.block {
-            Some(block) => Ok(block),
-            None => log_and_err!("no pending block being mined"), // try calling set_pending_block_number_as_next_if_not_set or any other method to create a new block on temp storage
-        }
+    fn require_pending_block(&self) -> &PendingBlock {
+        &self.block
     }
 
     /// Validates there is a pending block being mined and returns a mutable reference to it.
-    fn require_pending_block_mut(&mut self) -> anyhow::Result<&mut PendingBlock> {
-        match &mut self.block {
-            Some(block) => Ok(block),
-            None => log_and_err!("no pending block being mined"), // try calling set_pending_block_number_as_next_if_not_set or any other method to create a new block on temp storage
-        }
+    fn require_pending_block_mut(&mut self) -> &mut PendingBlock {
+        &mut self.block
     }
 
     pub fn reset(&mut self) {
-        self.block = None;
+        self.block = PendingBlock::default();
         self.accounts.clear();
     }
 }
@@ -114,23 +107,10 @@ impl TemporaryStorage for InMemoryTemporaryStorage {
     // Block number
     // -------------------------------------------------------------------------
 
-    fn set_pending_block_number(&self, number: BlockNumber) -> anyhow::Result<()> {
-        let mut states = self.lock_write();
-        match states.head.block.as_mut() {
-            Some(block) => block.header.number = number,
-            None => {
-                states.head.block = Some(PendingBlock::new_at_now(number));
-            }
-        }
-        Ok(())
-    }
-
-    fn read_pending_block_header(&self) -> anyhow::Result<Option<PendingBlockHeader>> {
+    // Uneeded clone here, return Cow
+    fn read_pending_block_header(&self) -> PendingBlockHeader {
         let states = self.lock_read();
-        match &states.head.block {
-            Some(block) => Ok(Some(block.header.clone())),
-            None => Ok(None),
-        }
+        states.head.block.header.clone()
     }
 
     // -------------------------------------------------------------------------
@@ -140,6 +120,7 @@ impl TemporaryStorage for InMemoryTemporaryStorage {
     fn save_pending_execution(&self, tx: TransactionExecution, check_conflicts: bool) -> Result<(), StratusError> {
         // check conflicts
         let mut states = self.lock_write();
+
         if check_conflicts {
             if let Some(conflicts) = do_check_conflicts(&states, tx.execution()) {
                 return Err(StratusError::TransactionConflict(conflicts.into()));
@@ -177,18 +158,13 @@ impl TemporaryStorage for InMemoryTemporaryStorage {
         }
 
         // save execution
-        states.head.require_pending_block_mut()?.push_transaction(tx);
+        states.head.require_pending_block_mut().push_transaction(tx);
 
         Ok(())
     }
 
     fn read_pending_executions(&self) -> Vec<TransactionExecution> {
-        self.lock_read()
-            .head
-            .block
-            .as_ref()
-            .map(|pending_block| pending_block.transactions.iter().map(|(_, tx)| tx.clone()).collect())
-            .unwrap_or_default()
+        self.lock_read().head.block.transactions.iter().map(|(_, tx)| tx.clone()).collect()
     }
 
     /// TODO: we cannot allow more than one pending block. Where to put this check?
@@ -196,9 +172,9 @@ impl TemporaryStorage for InMemoryTemporaryStorage {
         let mut states = self.lock_write();
 
         #[cfg(feature = "dev")]
-        let mut finished_block = states.head.require_pending_block()?.clone();
+        let mut finished_block = states.head.require_pending_block().clone();
         #[cfg(not(feature = "dev"))]
-        let finished_block = states.head.require_pending_block()?.clone();
+        let finished_block = states.head.require_pending_block().clone();
 
         #[cfg(feature = "dev")]
         {
@@ -216,15 +192,14 @@ impl TemporaryStorage for InMemoryTemporaryStorage {
 
         // create new state
         states.insert(0, InMemoryTemporaryStorageState::default());
-        states.head.block = Some(PendingBlock::new_at_now(finished_block.header.number.next_block_number()));
+        states.head.block = PendingBlock::new_at_now(finished_block.header.number.next_block_number());
 
         Ok(finished_block)
     }
 
     fn read_pending_execution(&self, hash: Hash) -> anyhow::Result<Option<TransactionExecution>> {
         let states = self.lock_read();
-        let Some(ref pending_block) = states.head.block else { return Ok(None) };
-        match pending_block.transactions.get(&hash) {
+        match states.head.block.transactions.get(&hash) {
             Some(tx) => Ok(Some(tx.clone())),
             None => Ok(None),
         }

--- a/src/eth/storage/temporary/inmemory.rs
+++ b/src/eth/storage/temporary/inmemory.rs
@@ -40,7 +40,7 @@ impl InMemoryTemporaryStorage {
         Self {
             states: RwLock::new(NonEmpty::new(InMemoryTemporaryStorageState {
                 block: PendingBlock::new_at_now(block_number),
-                accounts: Default::default(),
+                accounts: HashMap::default(),
             })),
         }
     }
@@ -73,7 +73,7 @@ impl InMemoryTemporaryStorageState {
     pub fn new(block_number: BlockNumber) -> Self {
         Self {
             block: PendingBlock::new_at_now(block_number),
-            accounts: Default::default(),
+            accounts: HashMap::default(),
         }
     }
 


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Made pending block header a required field in storage, removing the Option wrapper
- Simplified the storage interface by removing methods related to setting pending block number
- Updated executor and other components to work with non-optional pending block header
- Refactored InMemoryTemporaryStorage to always have a pending block
- Removed unnecessary ExecutionConflict variants
- Updated TemporaryStorage trait and its implementation to reflect these changes
- Modified storage initialization to use mined block number for setting initial pending block



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>executor.rs</strong><dd><code>Simplify pending block header handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/executor/executor.rs

<li>Removed <code>set_pending_block_number</code> call<br> <li> Changed <code>read_pending_block_header</code> to no longer return an Option<br> <li> Removed unwrap_or_default() calls on pending_header<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1885/files#diff-6b460d7dee8280c0287e8d9d9d59cf66a57ec9fed1bc003c6ede6fef60c7376b">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>execution_conflict.rs</strong><dd><code>Simplify ExecutionConflict enum</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/execution_conflict.rs

<li>Removed <code>AccountModifiedCount</code> and <code>SlotModifiedCount</code> variants from <br><code>ExecutionConflict</code> enum<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1885/files#diff-989664061f5331343a7fe685e7bbc19f01044105c3e966afd41233c163671df1">+0/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>log_filter_input.rs</strong><dd><code>Update pending block header usage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/log_filter_input.rs

<li>Updated <code>read_pending_block_header</code> usage to no longer use <br>unwrap_or_default()<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1885/files#diff-1fc314c5ef2bb71e10a986847e852f50d787c67b002131aa6f4afae62ebd4555">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Simplify pending block header storage interface</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/mod.rs

<li>Changed <code>read_pending_block_header</code> to return <code>PendingBlockHeader</code> instead <br>of <code>Option<PendingBlockHeader></code><br> <li> Removed <code>set_pending_block_number</code> and related methods<br> <li> Updated <code>StorageConfig::init</code> to pass permanent storage to temporary <br>storage initialization<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1885/files#diff-5afdbcb51a1480f953cef6a4d26ac8eb7770439927a0ed17ca4316390633a0ac">+3/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>stratus_storage.rs</strong><dd><code>Simplify pending block header handling in StratusStorage</code>&nbsp; </dd></summary>
<hr>

src/eth/storage/stratus_storage.rs

<li>Simplified <code>read_block_number_to_resume_import</code> to use <br><code>read_pending_block_header</code><br> <li> Updated <code>read_pending_block_header</code> to return <code>PendingBlockHeader</code> <br>directly<br> <li> Removed <code>set_pending_block_number</code> and related methods<br> <li> Updated block number conflict checks to use non-optional pending <br>header<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1885/files#diff-3b2e36e47959decdfe26b2c4fab90b41f9242bfdad29cc43b2377ee851f4f40a">+20/-89</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>inmemory.rs</strong><dd><code>Refactor InMemoryTemporaryStorage for non-optional pending block</code></dd></summary>
<hr>

src/eth/storage/temporary/inmemory.rs

<li>Removed <code>Default</code> implementation for <code>InMemoryTemporaryStorage</code><br> <li> Added <code>new</code> method to <code>InMemoryTemporaryStorage</code> and <br><code>InMemoryTemporaryStorageState</code><br> <li> Updated <code>read_pending_block_header</code> to return <code>PendingBlockHeader</code> <br>directly<br> <li> Simplified methods that interact with pending block<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1885/files#diff-e51089a92c2c949c8c776644af3cf760132d61d63ff745d676a76041be8e06e9">+30/-49</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Update TemporaryStorage trait and config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/temporary/mod.rs

<li>Updated <code>TemporaryStorage</code> trait to return <code>PendingBlockHeader</code> directly<br> <li> Removed <code>set_pending_block_number</code> method from trait<br> <li> Updated <code>TemporaryStorageConfig::init</code> to take <code>PermanentStorage</code> <br>reference<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1885/files#diff-c652bd8773e9540002a0330f78c15f0474c7b3ef9f85df4e7cda6e09b8951314">+6/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information