### PR TITLE
enha: remove mutex that keeps transactions from executing while a block is being commited

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -67,6 +67,16 @@ jobs:
       group: ${{ github.workflow }}-external-rocks-${{ github.ref || github.run_id }}
       cancel-in-progress: true
 
+  e2e-interval-stratus:
+    name: E2E Inverval Stratus
+    uses: ./.github/workflows/_setup-e2e.yml
+    with:
+      justfile_recipe: "e2e-stratus 10ms"
+
+    concurrency:
+      group: ${{ github.workflow }}-interval-${{ github.ref || github.run_id }}
+      cancel-in-progress: true
+
   e2e-clock-stratus:
     name: E2E Clock Stratus in-memory
     uses: ./.github/workflows/_setup-e2e.yml

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -68,7 +68,7 @@ jobs:
       cancel-in-progress: true
 
   e2e-interval-stratus:
-    name: E2E Inverval Stratus
+    name: E2E Interval Stratus
     uses: ./.github/workflows/_setup-e2e.yml
     with:
       justfile_recipe: "e2e-stratus 10ms"

--- a/e2e/contracts/TestEvmInput.sol
+++ b/e2e/contracts/TestEvmInput.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract TestEvmInput {
+    uint256 public executions;
+    uint256 public result;
+
+    // Define the event for logging
+    event ComputationStarted(uint256 blockNumber, bool isSlow);
+
+    function heavyComputation() public {
+    // Emit event with current block number
+        // Check if this is the first execution
+        if (block.number < 1000) {
+            emit ComputationStarted(block.number, true);
+
+            // Perform a time-consuming loop
+            uint256 temp = 0;
+            for(uint i = 0; i < 10000; i++) {
+                for(uint j = 0; j < 100; j++) {
+                    temp += i * j;
+                    temp = temp % 1000000; // Prevent overflow
+                }
+            }
+            result = temp;
+        } else {
+            emit ComputationStarted(block.number, false);
+            result = 42;
+        }
+        executions += 1;
+    }
+
+    // View function to get current block number (for testing)
+    function getCurrentBlock() public view returns (uint256) {
+        return block.number;
+    }
+
+    // View function to get result
+    function getExecutions() public view returns (uint256) {
+        return executions;
+    }
+}

--- a/e2e/test/helpers/rpc.ts
+++ b/e2e/test/helpers/rpc.ts
@@ -20,6 +20,7 @@ import {
     TestContractBlockTimestamp,
     TestContractCounter,
     TestContractDenseStorage,
+    TestEvmInput,
 } from "../../typechain-types";
 import { Account, CHARLIE } from "./account";
 import { currentMiningIntervalInMs, currentNetwork, isStratus } from "./network";
@@ -159,6 +160,12 @@ export async function sendExpect(method: string, params: any[] = []): Promise<Ch
 // Deploys the "TestContractBalances" contract.
 export async function deployTestContractBalances(): Promise<TestContractBalances> {
     const testContractFactory = await ethers.getContractFactory("TestContractBalances");
+    return await testContractFactory.connect(CHARLIE.signer()).deploy();
+}
+
+// Deploys the "TestEvmInput" contract.
+export async function deployTestEvmInput(): Promise<TestEvmInput> {
+    const testContractFactory = await ethers.getContractFactory("TestEvmInput");
     return await testContractFactory.connect(CHARLIE.signer()).deploy();
 }
 

--- a/e2e/test/interval/evm-input.test.ts
+++ b/e2e/test/interval/evm-input.test.ts
@@ -1,30 +1,27 @@
 import { expect } from "chai";
-
-import {
-    deployTestEvmInput,
-    sendReset,
-} from "../helpers/rpc";
 import { ContractTransactionReceipt, Result } from "ethers";
+
+import { deployTestEvmInput, sendReset } from "../helpers/rpc";
 
 // This test needs to be ran with stratus on a very fast block production rate (around 10ms is fast enough)
 describe("Evm Input", () => {
-  describe("Transaction Execution", () => {
-      it("should not be executed in one block but added to another", async () => {
-          await sendReset();
-          const contract = await deployTestEvmInput();
-          await contract.waitForDeployment();
-          let tx = await contract.heavyComputation()
-          let receipt = await tx.wait() as ContractTransactionReceipt;
-          const event = receipt.logs[0];
-          const logs = contract.interface.parseLog({
-              topics: event.topics,
-              data: event.data,
-          })?.args as Result;
+    describe("Transaction Execution", () => {
+        it("should not be executed in one block but added to another", async () => {
+            await sendReset();
+            const contract = await deployTestEvmInput();
+            await contract.waitForDeployment();
+            let tx = await contract.heavyComputation();
+            let receipt = (await tx.wait()) as ContractTransactionReceipt;
+            const event = receipt.logs[0];
+            const logs = contract.interface.parseLog({
+                topics: event.topics,
+                data: event.data,
+            })?.args as Result;
 
-          expect(receipt.blockNumber).to.eq(logs.blockNumber);
-          expect(logs.blockNumber).gt(1000);
-          expect(logs.isSlow).to.be.false;
-          expect(await contract.getExecutions()).to.eq(1);
-      });
-  });
+            expect(receipt.blockNumber).to.eq(logs.blockNumber);
+            expect(logs.blockNumber).gt(1000);
+            expect(logs.isSlow).to.be.false;
+            expect(await contract.getExecutions()).to.eq(1);
+        });
+    });
 });

--- a/e2e/test/interval/evm-input.test.ts
+++ b/e2e/test/interval/evm-input.test.ts
@@ -1,0 +1,30 @@
+import { expect } from "chai";
+
+import {
+    deployTestEvmInput,
+    sendReset,
+} from "../helpers/rpc";
+import { ContractTransactionReceipt, Result } from "ethers";
+
+// This test needs to be ran with stratus on a very fast block production rate (around 10ms is fast enough)
+describe("Evm Input", () => {
+  describe("Transaction Execution", () => {
+      it("should not be executed in one block but added to another", async () => {
+          await sendReset();
+          const contract = await deployTestEvmInput();
+          await contract.waitForDeployment();
+          let tx = await contract.heavyComputation()
+          let receipt = await tx.wait() as ContractTransactionReceipt;
+          const event = receipt.logs[0];
+          const logs = contract.interface.parseLog({
+              topics: event.topics,
+              data: event.data,
+          })?.args as Result;
+
+          expect(receipt.blockNumber).to.eq(logs.blockNumber);
+          expect(logs.blockNumber).gt(1000);
+          expect(logs.isSlow).to.be.false;
+          expect(await contract.getExecutions()).to.eq(1);
+      });
+  });
+});

--- a/justfile
+++ b/justfile
@@ -192,7 +192,11 @@ e2e-stratus block-mode="automine" test="":
     just _wait_for_stratus
 
     just _log "Running E2E tests"
-    just e2e stratus {{block-mode}} "{{test}}"
+    if [[ {{block-mode}} =~ ^[0-9]+(ms|s)$ ]]; then
+        just e2e stratus interval "{{test}}"
+    else
+        just e2e stratus {{block-mode}} "{{test}}"
+    fi
     result_code=$?
 
     just _log "Killing Stratus"
@@ -213,7 +217,6 @@ e2e-stratus-rocks block-mode="automine" test="":
     just _wait_for_stratus
 
     just _log "Running E2E tests"
-    just e2e stratus {{block-mode}} "{{test}}"
     result_code=$?
 
     just _log "Killing Stratus"

--- a/src/eth/executor/evm_input.rs
+++ b/src/eth/executor/evm_input.rs
@@ -21,7 +21,7 @@ use crate::if_else;
 use crate::log_and_err;
 
 /// EVM input data. Usually derived from a transaction or call.
-#[derive(DebugAsJson, Clone, Default, serde::Serialize)]
+#[derive(DebugAsJson, Clone, Default, serde::Serialize, serde::Deserialize, fake::Dummy, PartialEq)]
 pub struct EvmInput {
     /// Operation party address.
     ///

--- a/src/eth/executor/executor.rs
+++ b/src/eth/executor/executor.rs
@@ -397,17 +397,6 @@ impl Executor {
                 // acquire serial execution lock
                 let _serial_lock = self.locks.serial.lock_or_clear("executor serial lock was poisoned");
 
-                // WORKAROUND: prevents interval miner mining blocks while a transaction is being executed.
-                // this can be removed when we implement conflict detection for block number
-                let _miner_lock = {
-                    if self.miner.mode().is_interval() {
-                        let miner_lock = Some(self.miner.locks.mine_and_commit.lock_or_clear("miner mine_and_commit lock was poisoned"));
-                        miner_lock
-                    } else {
-                        None
-                    }
-                };
-
                 // execute transaction
                 self.execute_local_transaction_attempts(tx.clone(), EvmRoute::Serial, INFINITE_ATTEMPTS)
             }
@@ -418,12 +407,13 @@ impl Executor {
                 let parallel_attempt = self.execute_local_transaction_attempts(tx.clone(), EvmRoute::Parallel, 1);
                 match parallel_attempt {
                     Ok(tx_execution) => Ok(tx_execution),
-                    Err(e) =>
+                    Err(e) => {
                         if let StratusError::TransactionConflict(_) = e {
                             self.execute_local_transaction_attempts(tx.clone(), EvmRoute::Serial, INFINITE_ATTEMPTS)
                         } else {
                             Err(e)
-                        },
+                        }
+                    }
                 }
             }
         };
@@ -499,28 +489,35 @@ impl Executor {
                 "executing local transaction attempt"
             );
 
-            let evm_result = match self.evms.execute(evm_input, evm_route) {
+            let evm_result = match self.evms.execute(evm_input.clone(), evm_route) {
                 Ok(evm_result) => evm_result,
                 Err(e) => return Err(e),
             };
 
             // save execution to temporary storage
             // in case of failure, retry if conflict or abandon if unexpected error
-            let tx_execution = TransactionExecution::new_local(tx_input.clone(), evm_result.clone());
-            match self.miner.save_execution(tx_execution.clone(), true) {
+            let tx_execution = TransactionExecution::new_local(tx_input.clone(), evm_input, evm_result.clone());
+            match self.miner.save_execution(tx_execution.clone(), matches!(evm_route, EvmRoute::Parallel)) {
                 Ok(_) => {
                     return Ok(tx_execution);
                 }
-                Err(e) =>
-                    if let StratusError::TransactionConflict(ref conflicts) = e {
+                Err(e) => match e {
+                    StratusError::TransactionConflict(ref conflicts) => {
                         tracing::warn!(%attempt, ?conflicts, "temporary storage conflict detected when saving execution");
                         if attempt >= max_attempts {
                             return Err(e);
                         }
                         continue;
-                    } else {
-                        return Err(e);
-                    },
+                    }
+                    StratusError::TransactionEvmInputMismatch {ref expected, ref actual} => {
+                        tracing::warn!(?expected, ?actual, "evm input and block header mismatch");
+                        if attempt >= max_attempts {
+                            return Err(e);
+                        }
+                        continue;
+                    }
+                    _ => return Err(e),
+                },
             }
         }
     }

--- a/src/eth/executor/executor.rs
+++ b/src/eth/executor/executor.rs
@@ -407,13 +407,12 @@ impl Executor {
                 let parallel_attempt = self.execute_local_transaction_attempts(tx.clone(), EvmRoute::Parallel, 1);
                 match parallel_attempt {
                     Ok(tx_execution) => Ok(tx_execution),
-                    Err(e) => {
+                    Err(e) =>
                         if let StratusError::TransactionConflict(_) = e {
                             self.execute_local_transaction_attempts(tx.clone(), EvmRoute::Serial, INFINITE_ATTEMPTS)
                         } else {
                             Err(e)
-                        }
-                    }
+                        },
                 }
             }
         };
@@ -509,7 +508,7 @@ impl Executor {
                         }
                         continue;
                     }
-                    StratusError::TransactionEvmInputMismatch {ref expected, ref actual} => {
+                    StratusError::TransactionEvmInputMismatch { ref expected, ref actual } => {
                         tracing::warn!(?expected, ?actual, "evm input and block header mismatch");
                         if attempt >= max_attempts {
                             return Err(e);

--- a/src/eth/primitives/point_in_time.rs
+++ b/src/eth/primitives/point_in_time.rs
@@ -2,7 +2,7 @@ use crate::eth::primitives::BlockNumber;
 use crate::infra::metrics::MetricLabelValue;
 
 /// EVM storage point-in-time indicator.
-#[derive(Debug, strum::Display, Clone, Copy, Default, strum::EnumIs, serde::Serialize)]
+#[derive(Debug, strum::Display, Clone, Copy, Default, strum::EnumIs, serde::Serialize, serde::Deserialize, fake::Dummy, PartialEq)]
 pub enum PointInTime {
     /// State of `Account` or `Slot` at the pending block being mined.
     ///

--- a/src/eth/primitives/stratus_error.rs
+++ b/src/eth/primitives/stratus_error.rs
@@ -7,6 +7,7 @@ use jsonrpsee::types::ErrorObjectOwned;
 use strum::EnumProperty;
 
 use crate::alias::JsonValue;
+use crate::eth::executor::EvmInput;
 use crate::eth::primitives::Address;
 use crate::eth::primitives::BlockFilter;
 use crate::eth::primitives::BlockNumber;
@@ -100,6 +101,10 @@ pub enum StratusError {
     #[error("Transaction from zero address is not allowed.")]
     #[strum(props(kind = "execution"))]
     TransactionFromZeroAddress,
+
+    #[error("Transaction input does not match block header")]
+    #[strum(props(kind = "execution"))]
+    TransactionEvmInputMismatch { expected: EvmInput, actual: EvmInput },
 
     // -------------------------------------------------------------------------
     // Storage

--- a/src/eth/primitives/stratus_error.rs
+++ b/src/eth/primitives/stratus_error.rs
@@ -104,7 +104,7 @@ pub enum StratusError {
 
     #[error("Transaction input does not match block header")]
     #[strum(props(kind = "execution"))]
-    TransactionEvmInputMismatch { expected: EvmInput, actual: EvmInput },
+    TransactionEvmInputMismatch { expected: Box<EvmInput>, actual: Box<EvmInput> },
 
     // -------------------------------------------------------------------------
     // Storage

--- a/src/eth/primitives/transaction_execution.rs
+++ b/src/eth/primitives/transaction_execution.rs
@@ -1,6 +1,7 @@
 use display_json::DebugAsJson;
 
 use crate::eth::executor::EvmExecutionResult;
+use crate::eth::executor::EvmInput;
 use crate::eth::primitives::EvmExecution;
 use crate::eth::primitives::EvmExecutionMetrics;
 use crate::eth::primitives::ExternalReceipt;
@@ -20,8 +21,8 @@ pub enum TransactionExecution {
 
 impl TransactionExecution {
     /// Creates a new local transaction execution.
-    pub fn new_local(tx: TransactionInput, result: EvmExecutionResult) -> Self {
-        Self::Local(LocalTransactionExecution { input: tx, result })
+    pub fn new_local(tx: TransactionInput, evm_input: EvmInput, result: EvmExecutionResult) -> Self {
+        Self::Local(LocalTransactionExecution { input: tx, evm_input, result })
     }
 
     /// Extracts the inner [`LocalTransactionExecution`] if the execution is a local execution.
@@ -85,6 +86,7 @@ impl TransactionExecution {
 #[cfg_attr(test, derive(serde::Deserialize, fake::Dummy, PartialEq))]
 pub struct LocalTransactionExecution {
     pub input: TransactionInput,
+    pub evm_input: EvmInput,
     pub result: EvmExecutionResult,
 }
 

--- a/src/eth/storage/temporary/inmemory.rs
+++ b/src/eth/storage/temporary/inmemory.rs
@@ -125,8 +125,8 @@ impl TemporaryStorage for InMemoryTemporaryStorage {
 
             if expected_input != tx.evm_input {
                 return Err(StratusError::TransactionEvmInputMismatch {
-                    expected: expected_input,
-                    actual: tx.evm_input.clone(),
+                    expected: Box::new(expected_input),
+                    actual: Box::new(tx.evm_input.clone()),
                 });
             }
         }

--- a/src/eth/storage/temporary/inmemory.rs
+++ b/src/eth/storage/temporary/inmemory.rs
@@ -119,8 +119,6 @@ impl TemporaryStorage for InMemoryTemporaryStorage {
         // check conflicts
         let mut states = self.lock_write();
         if let TransactionExecution::Local(tx) = &tx {
-            tracing::info!("hereeeeee");
-
             let expected_input = EvmInput::from_eth_transaction(tx.input.clone(), states.head.block.header.clone());
 
             if expected_input != tx.evm_input {


### PR DESCRIPTION

### **PR Type**
Enhancement


___

### **Description**
- Removed mutex that prevents transactions from executing while a block is being committed
- Implemented EVM input validation to ensure transaction input matches block header
- Added new error type `TransactionEvmInputMismatch` for handling mismatched EVM inputs
- Updated `LocalTransactionExecution` to include `evm_input` field
- Added new test contract `TestEvmInput` and corresponding E2E tests for EVM input validation
- Modified CI workflow to include interval-based Stratus testing
- Updated `justfile` to support interval-based block mode in E2E tests
- Added derive macros to `EvmInput` and `PointInTime` structs for improved serialization and testing support



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>evm_input.rs</strong><dd><code>Add derive macros to EvmInput struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/executor/evm_input.rs

<li>Added <code>serde::Deserialize</code>, <code>fake::Dummy</code>, and <code>PartialEq</code> derive macros to <br><code>EvmInput</code> struct<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1888/files#diff-9dbdf7472d01464e439067cbd23dfe3648c7fb38a307bee0cf8642ad16a1a252">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>executor.rs</strong><dd><code>Refactor transaction execution and error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/executor/executor.rs

<li>Removed miner lock in serial execution strategy<br> <li> Modified parallel execution strategy error handling<br> <li> Updated <code>execute_local_transaction_attempts</code> function to include <br><code>evm_input</code> in <code>TransactionExecution</code><br> <li> Added handling for <code>TransactionEvmInputMismatch</code> error<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1888/files#diff-6b460d7dee8280c0287e8d9d9d59cf66a57ec9fed1bc003c6ede6fef60c7376b">+18/-21</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>point_in_time.rs</strong><dd><code>Add derive macros to PointInTime enum</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/point_in_time.rs

<li>Added <code>serde::Deserialize</code>, <code>fake::Dummy</code>, and <code>PartialEq</code> derive macros to <br><code>PointInTime</code> enum<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1888/files#diff-9af519bf0b347d2df882fcba689b6356ab0eece767980919283b9f7c260eac37">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>stratus_error.rs</strong><dd><code>Add TransactionEvmInputMismatch error variant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/stratus_error.rs

<li>Added new <code>TransactionEvmInputMismatch</code> variant to <code>StratusError</code> enum<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1888/files#diff-301cded01d772388e3e5c08ede093b91c3e4478c08e11a48f70e3d44351385fb">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>transaction_execution.rs</strong><dd><code>Add evm_input to LocalTransactionExecution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/transaction_execution.rs

<li>Added <code>evm_input</code> field to <code>LocalTransactionExecution</code> struct<br> <li> Updated <code>new_local</code> function to include <code>evm_input</code> parameter<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1888/files#diff-363d860c6f773a2fea3a060866e15cdfa2fbe9e355b16a7567d9b2ed465fc987">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>inmemory.rs</strong><dd><code>Implement EVM input validation in temporary storage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/temporary/inmemory.rs

<li>Added EVM input validation in <code>save_pending_execution</code> function<br> <li> Introduced check for <code>TransactionEvmInputMismatch</code> error<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1888/files#diff-e51089a92c2c949c8c776644af3cf760132d61d63ff745d676a76041be8e06e9">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>rpc.ts</strong><dd><code>Add helper function for TestEvmInput contract deployment</code>&nbsp; </dd></summary>
<hr>

e2e/test/helpers/rpc.ts

<li>Added <code>deployTestEvmInput</code> function to deploy <code>TestEvmInput</code> contract<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1888/files#diff-de92f3345fb0b828a3a1af4938646038808ddee426127f029255c9c10bdaa1bb">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>evm-input.test.ts</strong><dd><code>Add EVM input validation test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

e2e/test/interval/evm-input.test.ts

<li>Added new test file for EVM input validation<br> <li> Implemented test case for transaction execution across blocks<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1888/files#diff-ba990cc0eef69250fb66927f6717fd8e1405ad5089621b1137cc47603ac75689">+30/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TestEvmInput.sol</strong><dd><code>Add TestEvmInput contract for EVM input testing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

e2e/contracts/TestEvmInput.sol

<li>Added new contract <code>TestEvmInput</code> for testing EVM input validation<br> <li> Implemented <code>heavyComputation</code> function to simulate time-consuming <br>operations<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1888/files#diff-7171d3ce7d42d10b19e3e55e88fb1e026d026e7b7400f644e5af019ca27bd629">+42/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>e2e-test.yml</strong><dd><code>Add e2e-interval-stratus job to workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/e2e-test.yml

<li>Added new job <code>e2e-interval-stratus</code> for interval-based Stratus testing<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1888/files#diff-5cc2c864012004f60ee3f9078fa1c4a8721c6b841e386c57f12bea58b692e6e2">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>justfile</strong><dd><code>Update e2e-stratus recipe for interval testing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

justfile

<li>Modified <code>e2e-stratus</code> recipe to handle interval-based block mode<br> <li> Removed unnecessary code in <code>e2e-stratus-rocks</code> recipe<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1888/files#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information