### PR TITLE
chore: pin crate versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,7 +119,7 @@ sqlx = { version = "=0.8.2", features = [
 # test
 fake = { version = "=2.9.2", features = ["chrono", "derive"] }
 rdkafka = {version = "=0.36.2", features = ["ssl", "sasl"] }
-openssl = { version = "=0.10.32", features = ["vendored"] }
+openssl = { version = "=0.10.68", features = ["vendored"] }
 sasl2-sys = { version = "=0.1.22", features = ["vendored"] }
 
 # Historic events processor

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,9 +118,9 @@ sqlx = { version = "=0.8.2", features = [
 
 # test
 fake = { version = "=2.9.2", features = ["chrono", "derive"] }
-rdkafka = {version = "0.36.2", features = ["ssl", "sasl"] }
-openssl = { version = "0.10.32", features = ["vendored"] }
-sasl2-sys = { version = "0.1.22", features = ["vendored"] }
+rdkafka = {version = "=0.36.2", features = ["ssl", "sasl"] }
+openssl = { version = "=0.10.32", features = ["vendored"] }
+sasl2-sys = { version = "=0.1.22", features = ["vendored"] }
 
 # Historic events processor
 indicatif = "=0.17.8"


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Pinned versions for three Rust crates in Cargo.toml:
  - `rdkafka`: From `0.36.2` to `=0.36.2`
  - `openssl`: From `0.10.32` to `=0.10.32`
  - `sasl2-sys`: From `0.1.22` to `=0.1.22`
- This change ensures consistent builds by locking these dependencies to specific versions
- Helps prevent potential issues from unexpected updates in dependencies



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Pin versions for Rust dependencies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Cargo.toml

<li>Pinned versions for <code>rdkafka</code>, <code>openssl</code>, and <code>sasl2-sys</code> crates<br> <li> Changed version specifiers from <code>0.36.2</code>, <code>0.10.32</code>, and <code>0.1.22</code> to <br><code>=0.36.2</code>, <code>=0.10.32</code>, and <code>=0.1.22</code> respectively<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1890/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information