### PR TITLE
chore: fix Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2993,9 +2993,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.66"
+version = "0.10.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
+checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
 dependencies = [
  "bitflags 2.6.0",
  "cfg-if",
@@ -3034,9 +3034,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.103"
+version = "0.9.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
+checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
 dependencies = [
  "cc",
  "libc",

--- a/src/bin/importer_offline.rs
+++ b/src/bin/importer_offline.rs
@@ -51,8 +51,8 @@ const RPC_FETCHER_CHANNEL_CAPACITY: usize = 10;
 /// block right away, but the information from that block still needs to be
 /// found in the cache.
 ///
-/// These constants are organized to guarantee that accounts and slots can
-/// still be found in the storage cache.
+/// NOTE: The size below will only work if the cache is big enough to hold
+/// slots and accounts for this number of blocks.
 const CACHE_SIZE: usize = 10_000;
 const MAX_BLOCKS_NOT_SAVED: usize = CACHE_SIZE - 1;
 


### PR DESCRIPTION
### **PR Type**
Enhancement, Documentation


___

### **Description**
- Updated the comment for `CACHE_SIZE` and `MAX_BLOCKS_NOT_SAVED` constants in `src/bin/importer_offline.rs`
- Clarified that the cache size must be large enough to hold slots and accounts for the specified number of blocks
- Improved documentation to better explain the relationship between cache size and block processing



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>importer_offline.rs</strong><dd><code>Improve documentation for cache size constants</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/bin/importer_offline.rs

<li>Updated comment for <code>CACHE_SIZE</code> and <code>MAX_BLOCKS_NOT_SAVED</code> constants<br> <li> Clarified the relationship between cache size and block processing<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1893/files#diff-9fef7d584818c3db119ea1cd0952a57a953751f85f93ca813af861c4c737c53a">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information