### PR TITLE
enha: update importer-online to use faster endpoint for fetching

### DIFF
--- a/src/infra/blockchain_client/blockchain_client.rs
+++ b/src/infra/blockchain_client/blockchain_client.rs
@@ -145,6 +145,17 @@ impl BlockchainClient {
     }
 
     /// Fetches a block by number.
+    pub async fn fetch_block_and_receipts_with_temporary_endpoint(&self, block_number: BlockNumber) -> anyhow::Result<JsonValue> {
+        tracing::debug!(%block_number, "fetching block");
+
+        let number = to_json_value(block_number);
+        match self.http.request::<JsonValue, _>("stratus_getBlockAndReceipts", [number]).await {
+            Ok(json) => Ok(json),
+            Err(e) => log_and_err!(reason = e, "failed to fetch block by number"),
+        }
+    }
+
+    /// Fetches a block by number.
     pub async fn fetch_block(&self, block_number: BlockNumber) -> anyhow::Result<JsonValue> {
         tracing::debug!(%block_number, "fetching block");
 


### PR DESCRIPTION
### **User description**
which fetches blocks and receipts in a single call, while we are just testing this endpoint, the code will fallback to the previous endpoint if it fails


___

### **PR Type**
Enhancement


___

### **Description**
- Implemented a new endpoint `stratus_getBlockAndReceipts` for fetching blocks and receipts in a single call
- Added fallback mechanism to use the previous endpoint if the new one fails
- Improved error handling and logging for better debugging
- Updated `BlockchainClient` to support the new endpoint
- Optimized import process by reducing the number of API calls



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>importer.rs</strong><dd><code>Implement new endpoint for fetching blocks and receipts</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/eth/follower/importer/importer.rs

<li>Added new function <br><code>try_reading_block_and_receipts_with_temporary_endpoint</code><br> <li> Implemented fallback mechanism in <code>fetch_block_and_receipts</code> function<br> <li> Added error handling and logging for the new endpoint<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1898/files#diff-bd50f502f039aff8f75753bc780d281ae7d7936fadc9d53482084c647aec94ca">+23/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>blockchain_client.rs</strong><dd><code>Add new blockchain client method for fetching blocks and receipts</code></dd></summary>
<hr>

src/infra/blockchain_client/blockchain_client.rs

<li>Added new method <code>fetch_block_and_receipts_with_temporary_endpoint</code> to <br><code>BlockchainClient</code><br> <li> Implemented error handling and logging for the new method<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1898/files#diff-05af32e93a38a2ab966d4c4c633284d19cada2fa11c1962fabf9c981ff7fd3e6">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information