### PR TITLE
enha: add stratus_version commit sha test case

### DIFF
--- a/e2e/cloudwalk-contracts/integration/test/leader-follower-change.test.ts
+++ b/e2e/cloudwalk-contracts/integration/test/leader-follower-change.test.ts
@@ -3,7 +3,7 @@ import { expect } from "chai";
 import { sendAndGetFullResponse, sendWithRetry, updateProviderUrl } from "./helpers/rpc";
 
 describe("Leader & Follower change integration test", function () {
-    it("Validate initial Leader state and health", async function () {
+    it("Validate initial Leader state, health and version", async function () {
         updateProviderUrl("stratus");
         const leaderNode = await sendWithRetry("stratus_state", []);
         expect(leaderNode.is_importer_shutdown).to.equal(true);
@@ -13,9 +13,13 @@ describe("Leader & Follower change integration test", function () {
         expect(leaderNode.transactions_enabled).to.equal(true);
         const leaderHealth = await sendWithRetry("stratus_health", []);
         expect(leaderHealth).to.equal(true);
+        const version = await sendWithRetry("stratus_version", []);
+        expect(version).to.have.nested.property('git.commit');
+        expect(version.git.commit).to.be.a('string');
+        expect(version.git.commit).to.have.lengthOf(7);
     });
 
-    it("Validate initial Follower state and health", async function () {
+    it("Validate initial Follower state, health and version", async function () {
         updateProviderUrl("stratus-follower");
         const followerNode = await sendWithRetry("stratus_state", []);
         expect(followerNode.is_importer_shutdown).to.equal(false);
@@ -25,6 +29,10 @@ describe("Leader & Follower change integration test", function () {
         expect(followerNode.transactions_enabled).to.equal(true);
         const followerHealth = await sendWithRetry("stratus_health", []);
         expect(followerHealth).to.equal(true);
+        const version = await sendWithRetry("stratus_version", []);
+        expect(version).to.have.nested.property('git.commit');
+        expect(version.git.commit).to.be.a('string');
+        expect(version.git.commit).to.have.lengthOf(7);
     });
 
     it("Change Leader to Leader should return false", async function () {

--- a/e2e/cloudwalk-contracts/integration/test/leader-follower-change.test.ts
+++ b/e2e/cloudwalk-contracts/integration/test/leader-follower-change.test.ts
@@ -14,8 +14,8 @@ describe("Leader & Follower change integration test", function () {
         const leaderHealth = await sendWithRetry("stratus_health", []);
         expect(leaderHealth).to.equal(true);
         const version = await sendWithRetry("stratus_version", []);
-        expect(version).to.have.nested.property('git.commit');
-        expect(version.git.commit).to.be.a('string');
+        expect(version).to.have.nested.property("git.commit");
+        expect(version.git.commit).to.be.a("string");
         expect(version.git.commit).to.have.lengthOf(7);
     });
 
@@ -30,8 +30,8 @@ describe("Leader & Follower change integration test", function () {
         const followerHealth = await sendWithRetry("stratus_health", []);
         expect(followerHealth).to.equal(true);
         const version = await sendWithRetry("stratus_version", []);
-        expect(version).to.have.nested.property('git.commit');
-        expect(version.git.commit).to.be.a('string');
+        expect(version).to.have.nested.property("git.commit");
+        expect(version.git.commit).to.be.a("string");
         expect(version.git.commit).to.have.lengthOf(7);
     });
 


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Added new test cases to validate the `stratus_version` API response for both Leader and Follower nodes
- Implemented checks to ensure the git commit hash is present and has the correct format (string of length 7)
- Updated existing test case titles to reflect the addition of version validation
- Enhanced the overall test coverage for the Leader-Follower integration tests



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>leader-follower-change.test.ts</strong><dd><code>Add version validation to Leader-Follower integration tests</code></dd></summary>
<hr>

e2e/cloudwalk-contracts/integration/test/leader-follower-change.test.ts

<li>Added version checks using <code>stratus_version</code> API for both Leader and <br>Follower nodes<br> <li> Extended test cases to validate the git commit hash in the version <br>response<br> <li> Updated test case titles to reflect the addition of version checks<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1900/files#diff-7236d4b676b75ced96eb321337290326efe4e91a261edc4e83b688c4da09dd7c">+10/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information