### PR TITLE
enha: use parking_lot mutex instead of std::sync

### DIFF
--- a/src/eth/executor/executor.rs
+++ b/src/eth/executor/executor.rs
@@ -2,10 +2,10 @@ use std::cmp::max;
 use std::mem;
 use std::str::FromStr;
 use std::sync::Arc;
-use std::sync::Mutex;
 
 use anyhow::anyhow;
 use cfg_if::cfg_if;
+use parking_lot::Mutex;
 use tracing::info_span;
 use tracing::Span;
 
@@ -35,7 +35,6 @@ use crate::eth::storage::Storage;
 use crate::eth::storage::StratusStorage;
 use crate::ext::spawn_thread;
 use crate::ext::to_json_string;
-use crate::ext::MutexExt;
 #[cfg(feature = "metrics")]
 use crate::ext::OptionExt;
 #[cfg(feature = "metrics")]
@@ -399,7 +398,7 @@ impl Executor {
             // * Conflict detection runs, but it should never trigger because of the Mutex.
             ExecutorStrategy::Serial => {
                 // acquire serial execution lock
-                let _serial_lock = self.locks.serial.lock_or_clear("executor serial lock was poisoned");
+                let _serial_lock = self.locks.serial.lock();
 
                 // execute transaction
                 self.execute_local_transaction_attempts(tx, EvmRoute::Serial, INFINITE_ATTEMPTS)

--- a/src/eth/miner/miner.rs
+++ b/src/eth/miner/miner.rs
@@ -2,13 +2,13 @@ use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::sync::mpsc;
 use std::sync::Arc;
-use std::sync::RwLock;
 use std::time::Duration;
 
 use anyhow::anyhow;
 use itertools::Itertools;
 use keccak_hasher::KeccakHasher;
 use parking_lot::Mutex;
+use parking_lot::RwLock;
 use tokio::sync::broadcast;
 use tokio::sync::Mutex as AsyncMutex;
 use tokio::task::JoinSet;
@@ -157,19 +157,11 @@ impl Miner {
     }
 
     pub fn mode(&self) -> MinerMode {
-        *self.mode.read().unwrap_or_else(|poison_error| {
-            tracing::error!("miner mode read lock was poisoned");
-            self.mode.clear_poison();
-            poison_error.into_inner()
-        })
+        *self.mode.read()
     }
 
     fn set_mode(&self, new_mode: MinerMode) {
-        *self.mode.write().unwrap_or_else(|poison_error| {
-            tracing::error!("miner mode write lock was poisoned");
-            self.mode.clear_poison();
-            poison_error.into_inner()
-        }) = new_mode;
+        *self.mode.write() = new_mode;
     }
 
     pub fn is_interval_miner_running(&self) -> bool {

--- a/src/eth/miner/miner.rs
+++ b/src/eth/miner/miner.rs
@@ -223,13 +223,6 @@ impl Miner {
         Ok(())
     }
 
-    /// Same as [`Self::mine_external`], but automatically commits the block instead of returning it.
-    pub fn mine_external_and_commit(&self, external_block: ExternalBlock) -> anyhow::Result<()> {
-        let _mine_and_commit_lock = self.locks.mine_and_commit.lock();
-
-        let block = self.mine_external(external_block)?;
-        self.commit(block)
-    }
 
     /// Mines external block and external transactions.
     ///

--- a/src/eth/miner/miner.rs
+++ b/src/eth/miner/miner.rs
@@ -223,7 +223,6 @@ impl Miner {
         Ok(())
     }
 
-
     /// Mines external block and external transactions.
     ///
     /// Local transactions are not allowed to be part of the block.

--- a/src/eth/rpc/rpc_context.rs
+++ b/src/eth/rpc/rpc_context.rs
@@ -1,6 +1,7 @@
 use std::fmt::Debug;
 use std::sync::Arc;
-use std::sync::RwLock;
+
+use parking_lot::RwLock;
 
 use crate::alias::JsonValue;
 use crate::eth::executor::Executor;
@@ -33,22 +34,11 @@ pub struct RpcContext {
 
 impl RpcContext {
     pub fn consensus(&self) -> Option<Arc<dyn Consensus>> {
-        self.consensus
-            .read()
-            .unwrap_or_else(|poison_error| {
-                tracing::error!("consensus read lock was poisoned");
-                self.consensus.clear_poison();
-                poison_error.into_inner()
-            })
-            .clone()
+        self.consensus.read().clone()
     }
 
     pub fn set_consensus(&self, new_consensus: Option<Arc<dyn Consensus>>) {
-        *self.consensus.write().unwrap_or_else(|poison_error| {
-            tracing::error!("consensus write lock was poisoned");
-            self.consensus.clear_poison();
-            poison_error.into_inner()
-        }) = new_consensus;
+        *self.consensus.write() = new_consensus;
     }
 }
 

--- a/src/eth/storage/permanent/inmemory.rs
+++ b/src/eth/storage/permanent/inmemory.rs
@@ -5,13 +5,13 @@ use std::fmt::Debug;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
-use std::sync::RwLock;
-use std::sync::RwLockReadGuard;
-use std::sync::RwLockWriteGuard;
 
 use indexmap::IndexMap;
 use itertools::Itertools;
 use nonempty::NonEmpty;
+use parking_lot::RwLock;
+use parking_lot::RwLockReadGuard;
+use parking_lot::RwLockWriteGuard;
 
 use crate::eth::primitives::Account;
 use crate::eth::primitives::Address;
@@ -52,12 +52,12 @@ impl InMemoryPermanentStorage {
 
     /// Locks inner state for reading.
     fn lock_read(&self) -> RwLockReadGuard<'_, InMemoryPermanentStorageState> {
-        self.state.read().unwrap()
+        self.state.read()
     }
 
     /// Locks inner state for writing.
     fn lock_write(&self) -> RwLockWriteGuard<'_, InMemoryPermanentStorageState> {
-        self.state.write().unwrap()
+        self.state.write()
     }
 
     // -------------------------------------------------------------------------

--- a/src/eth/storage/permanent/rocks/rocks_state.rs
+++ b/src/eth/storage/permanent/rocks/rocks_state.rs
@@ -51,15 +51,13 @@ use crate::eth::primitives::PointInTime;
 use crate::eth::primitives::Slot;
 use crate::eth::primitives::SlotIndex;
 use crate::eth::primitives::TransactionMined;
-#[cfg(feature = "metrics")]
-use crate::ext::MutexExt;
 use crate::ext::OptionExt;
 use crate::log_and_err;
 use crate::utils::GIGABYTE;
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "metrics")] {
-        use std::sync::Mutex;
+        use parking_lot::Mutex;
 
         use rocksdb::statistics::Histogram;
         use rocksdb::statistics::Ticker;
@@ -597,7 +595,7 @@ impl RocksStorageState {
         // The stats are cumulative since opening the db
         // we can get the average in the time interval with: avg = (new_sum - sum)/(new_count - count)
 
-        let mut prev_values = self.prev_stats.lock_or_clear("mutex in get_histogram_average_in_interval is poisoned");
+        let mut prev_values = self.prev_stats.lock();
 
         let (prev_sum, prev_count): (Sum, Count) = *prev_values.get(&(hist as u32)).unwrap_or(&(0, 0));
         let data = self.db_options.get_histogram_data(hist);

--- a/src/eth/storage/temporary/inmemory.rs
+++ b/src/eth/storage/temporary/inmemory.rs
@@ -1,11 +1,11 @@
 //! In-memory storage implementations.
 
 use std::collections::HashMap;
-use std::sync::RwLock;
-use std::sync::RwLockReadGuard;
-use std::sync::RwLockWriteGuard;
 
 use nonempty::NonEmpty;
+use parking_lot::RwLock;
+use parking_lot::RwLockReadGuard;
+use parking_lot::RwLockWriteGuard;
 
 use crate::eth::executor::EvmInput;
 use crate::eth::primitives::Account;
@@ -49,12 +49,12 @@ impl InMemoryTemporaryStorage {
 
     /// Locks inner state for reading.
     pub fn lock_read(&self) -> RwLockReadGuard<'_, NonEmpty<InMemoryTemporaryStorageState>> {
-        self.states.read().unwrap()
+        self.states.read()
     }
 
     /// Locks inner state for writing.
     pub fn lock_write(&self) -> RwLockWriteGuard<'_, NonEmpty<InMemoryTemporaryStorageState>> {
-        self.states.write().unwrap()
+        self.states.write()
     }
 }
 

--- a/src/eth/storage/temporary/inmemory.rs
+++ b/src/eth/storage/temporary/inmemory.rs
@@ -1,9 +1,8 @@
 //! In-memory storage implementations.
 
 use std::collections::HashMap;
-use nonempty::NonEmpty;
-use parking_lot::RwLock;
 
+use parking_lot::RwLock;
 
 use crate::eth::executor::EvmInput;
 use crate::eth::primitives::Account;
@@ -231,13 +230,7 @@ impl TemporaryStorage for InMemoryTemporaryStorage {
 
     fn read_slot(&self, address: Address, index: SlotIndex) -> anyhow::Result<Option<Slot>> {
         Ok(
-            match self
-                .pending_block
-                .read()
-                .accounts
-                .get(&address)
-                .and_then(|account| account.slots.get(&index))
-            {
+            match self.pending_block.read().accounts.get(&address).and_then(|account| account.slots.get(&index)) {
                 Some(pending_slot) => Some(*pending_slot),
                 None => self
                     .latest_block

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -2,8 +2,6 @@
 
 use std::collections::BTreeMap;
 use std::collections::HashMap;
-use std::sync::Mutex;
-use std::sync::MutexGuard;
 use std::time::Duration;
 
 use anyhow::anyhow;
@@ -173,20 +171,6 @@ impl<T> MutexResultExt<T> for Result<T, std::sync::PoisonError<T>> {
             .inspect_err(|err| {
                 tracing::error!(reason = ?err, "FATAL: Mutex is poisoned");
             })
-    }
-}
-
-pub trait MutexExt<T> {
-    fn lock_or_clear<'a>(&'a self, error_context: &str) -> MutexGuard<'a, T>;
-}
-
-impl<T> MutexExt<T> for Mutex<T> {
-    fn lock_or_clear<'a>(&'a self, error_context: &str) -> MutexGuard<'a, T> {
-        self.lock().unwrap_or_else(|poison_err| {
-            tracing::error!(error_context, "fatal: failed to lock mutex");
-            self.clear_poison();
-            poison_err.into_inner()
-        })
     }
 }
 

--- a/src/globals.rs
+++ b/src/globals.rs
@@ -1,11 +1,11 @@
 use std::fmt::Debug;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
-use std::sync::Mutex;
 
 use chrono::DateTime;
 use chrono::Utc;
 use once_cell::sync::Lazy;
+use parking_lot::Mutex;
 use sentry::ClientInitGuard;
 use serde::Deserialize;
 use serde::Serialize;
@@ -22,7 +22,6 @@ use crate::eth::follower::importer::Importer;
 use crate::eth::rpc::RpcContext;
 use crate::ext::not;
 use crate::ext::spawn_signal_handler;
-use crate::ext::MutexExt;
 use crate::infra::tracing::warn_task_cancellation;
 
 // -----------------------------------------------------------------------------
@@ -262,11 +261,11 @@ impl GlobalState {
     }
 
     pub fn set_node_mode(mode: NodeMode) {
-        *NODE_MODE.lock_or_clear("set_node_mode") = mode;
+        *NODE_MODE.lock() = mode;
     }
 
     pub fn get_node_mode() -> NodeMode {
-        *NODE_MODE.lock_or_clear("get_node_mode")
+        *NODE_MODE.lock()
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
### **User description**
Parking lot mutexes are faster AND RwLock is fairer. However they don't have a poison detection mechanism. Maybe we should keep the std::sync mutexes in places like the executor or the miner if poisoning is actually concern.

### **PR Type**
Enhancement
___

### **Description**
- Replaced `std::sync::Mutex` with `parking_lot::Mutex` across multiple files for improved performance
- Removed custom `MutexExt` trait and its usage, simplifying the codebase
- Updated mutex locking syntax to use the new `parking_lot::Mutex` methods
- Kept `MutexResultExt` trait, although its usage was removed in the shown changes
- This change affects core components like the executor, miner, storage, and global state management



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>executor.rs</strong><dd><code>Replace std::sync::Mutex with parking_lot::Mutex</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/executor/executor.rs

<li>Replaced <code>std::sync::Mutex</code> with <code>parking_lot::Mutex</code><br> <li> Removed usage of <code>MutexExt</code> trait<br> <li> Updated mutex locking syntax<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1902/files#diff-6b460d7dee8280c0287e8d9d9d59cf66a57ec9fed1bc003c6ede6fef60c7376b">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>miner.rs</strong><dd><code>Switch to parking_lot::Mutex in miner module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/miner/miner.rs

<li>Replaced <code>std::sync::Mutex</code> with <code>parking_lot::Mutex</code><br> <li> Removed usage of <code>MutexExt</code> and <code>MutexResultExt</code> traits<br> <li> Updated mutex locking syntax throughout the file<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1902/files#diff-16f448afc7dae3e8e802f676a86dbd7051e19f6c17cbbeb53eb730d726372629">+10/-17</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>rocks_state.rs</strong><dd><code>Implement parking_lot::Mutex in rocks_state</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/permanent/rocks/rocks_state.rs

<li>Replaced <code>std::sync::Mutex</code> with <code>parking_lot::Mutex</code><br> <li> Removed usage of <code>MutexExt</code> trait<br> <li> Updated mutex locking syntax<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1902/files#diff-9d38c98aa2d77c1665d2e2e11a0abc4787424d1b41a610d2fc1c4ea0311014a9">+2/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ext.rs</strong><dd><code>Remove MutexExt trait and related code</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/ext.rs

<li>Removed <code>MutexExt</code> trait and its implementation<br> <li> Kept <code>MutexResultExt</code> trait (unused in the shown changes)<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1902/files#diff-4ff673578dd06edb71da19750f05cb48bbbd3c78ded3dbeda59409354c35cef6">+0/-16</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>globals.rs</strong><dd><code>Integrate parking_lot::Mutex in globals module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/globals.rs

<li>Replaced <code>std::sync::Mutex</code> with <code>parking_lot::Mutex</code><br> <li> Removed usage of <code>MutexExt</code> trait<br> <li> Updated mutex locking syntax<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1902/files#diff-48d6fbc3a4ed67100952dcccfada858623c931e73d6de32984d4d1457e68d3a9">+3/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information


___

### **PR Type**
Enhancement


___

### **Description**
- Replaced `std::sync::Mutex` and `std::sync::RwLock` with `parking_lot::Mutex` and `parking_lot::RwLock` across multiple files for improved performance.
- Removed custom `MutexExt` trait and its usage, simplifying the codebase.
- Updated mutex and rwlock locking syntax to use the new `parking_lot` methods.
- Removed error handling for poisoned locks, as `parking_lot` locks don't have a poison mechanism.
- Kept `MutexResultExt` trait, although its usage was removed in the shown changes.
- This change affects core components like the executor, miner, storage, and global state management.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>executor.rs</strong><dd><code>Replace std::sync::Mutex with parking_lot::Mutex</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/executor/executor.rs

<li>Replaced <code>std::sync::Mutex</code> with <code>parking_lot::Mutex</code><br> <li> Removed usage of <code>MutexExt</code> trait<br> <li> Updated mutex locking syntax<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1902/files#diff-6b460d7dee8280c0287e8d9d9d59cf66a57ec9fed1bc003c6ede6fef60c7376b">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>miner.rs</strong><dd><code>Replace std::sync locks with parking_lot equivalents</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/miner/miner.rs

<li>Replaced <code>std::sync::Mutex</code> and <code>std::sync::RwLock</code> with <code>parking_lot</code> <br>equivalents<br> <li> Removed usage of <code>MutexExt</code> and <code>MutexResultExt</code> traits<br> <li> Simplified locking operations by removing error handling for poisoned <br>locks<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1902/files#diff-16f448afc7dae3e8e802f676a86dbd7051e19f6c17cbbeb53eb730d726372629">+13/-28</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>rpc_context.rs</strong><dd><code>Replace std::sync::RwLock with parking_lot::RwLock</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/rpc/rpc_context.rs

<li>Replaced <code>std::sync::RwLock</code> with <code>parking_lot::RwLock</code><br> <li> Simplified consensus read and write operations by removing error <br>handling for poisoned locks<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1902/files#diff-a486ea1bd70eb81a959b89f514ed248a5c30fb4dabe7c08344b9bac246b6e92e">+4/-14</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>inmemory.rs</strong><dd><code>Replace std::sync::RwLock with parking_lot::RwLock</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/permanent/inmemory.rs

<li>Replaced <code>std::sync::RwLock</code> with <code>parking_lot::RwLock</code><br> <li> Updated lock methods to use <code>parking_lot</code> syntax<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1902/files#diff-c607e65dc9a14d562375afaede01b9f291d6bc93e7336e85fbf358faee1efdfa">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>rocks_state.rs</strong><dd><code>Replace std::sync::Mutex with parking_lot::Mutex</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/permanent/rocks/rocks_state.rs

<li>Replaced <code>std::sync::Mutex</code> with <code>parking_lot::Mutex</code> for metrics feature<br> <li> Updated locking syntax to use <code>parking_lot</code> methods<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1902/files#diff-9d38c98aa2d77c1665d2e2e11a0abc4787424d1b41a610d2fc1c4ea0311014a9">+2/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>inmemory.rs</strong><dd><code>Replace std::sync::RwLock with parking_lot::RwLock</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/temporary/inmemory.rs

<li>Replaced <code>std::sync::RwLock</code> with <code>parking_lot::RwLock</code><br> <li> Updated locking operations to use <code>parking_lot</code> syntax<br> <li> Removed unwrap calls from lock operations<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1902/files#diff-e51089a92c2c949c8c776644af3cf760132d61d63ff745d676a76041be8e06e9">+12/-20</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ext.rs</strong><dd><code>Remove MutexExt trait</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/ext.rs

<li>Removed <code>MutexExt</code> trait and its implementation<br> <li> Kept <code>MutexResultExt</code> trait<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1902/files#diff-4ff673578dd06edb71da19750f05cb48bbbd3c78ded3dbeda59409354c35cef6">+0/-16</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>globals.rs</strong><dd><code>Replace std::sync::Mutex with parking_lot::Mutex</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/globals.rs

<li>Replaced <code>std::sync::Mutex</code> with <code>parking_lot::Mutex</code><br> <li> Updated locking operations to use <code>parking_lot</code> syntax<br> <li> Removed usage of <code>MutexExt</code> trait<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1902/files#diff-48d6fbc3a4ed67100952dcccfada858623c931e73d6de32984d4d1457e68d3a9">+3/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information