### PR TITLE
enha: make finish_pending_block hold write locks for less time

### DIFF
--- a/src/eth/storage/temporary/inmemory.rs
+++ b/src/eth/storage/temporary/inmemory.rs
@@ -184,8 +184,8 @@ impl TemporaryStorage for InMemoryTemporaryStorage {
 
         let next_state = InMemoryTemporaryStorageState::new(pending_block.block.header.number.next_block_number());
 
-        let mut pending_block = RwLockUpgradableReadGuard::<'_, parking_lot::RawRwLock, InMemoryTemporaryStorageState>::upgrade(pending_block);
         let mut latest = self.latest_block.write();
+        let mut pending_block = RwLockUpgradableReadGuard::<'_, parking_lot::RawRwLock, InMemoryTemporaryStorageState>::upgrade(pending_block);
         *latest = Some(std::mem::replace(&mut *pending_block, next_state));
         let latest = parking_lot::lock_api::RwLockWriteGuard::<'_, parking_lot::RawRwLock, std::option::Option<InMemoryTemporaryStorageState>>::downgrade(latest);
 

--- a/src/eth/storage/temporary/inmemory.rs
+++ b/src/eth/storage/temporary/inmemory.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 
 use parking_lot::RwLock;
 use parking_lot::RwLockUpgradableReadGuard;
+#[cfg(not(feature = "dev"))]
 use parking_lot::RwLockWriteGuard;
 
 use crate::eth::executor::EvmInput;
@@ -184,23 +185,10 @@ impl TemporaryStorage for InMemoryTemporaryStorage {
     fn finish_pending_block(&self) -> anyhow::Result<PendingBlock> {
         let pending_block = self.pending_block.upgradable_read();
 
-        let next_state = InMemoryTemporaryStorageState::new(pending_block.block.header.number.next_block_number());
-
-        let mut pending_block = RwLockUpgradableReadGuard::<InMemoryTemporaryStorageState>::upgrade(pending_block);
-        let mut latest = self.latest_block.write();
-
-        *latest = Some(std::mem::replace(&mut *pending_block, next_state));
-
-        drop(pending_block);
-        let latest = RwLockWriteGuard::<Option<InMemoryTemporaryStorageState>>::downgrade(latest);
-
+        // This has to happen BEFORE creating the new state, because UnixTimeNow::default() may change the offset.
         #[cfg(feature = "dev")]
         let finished_block = {
-            let mut finished_block = latest
-                .as_ref()
-                .expect("latest should be Some after finishing the pending block")
-                .block
-                .clone();
+            let mut finished_block = pending_block.block.clone();
             // Update block timestamp only if evm_setNextBlockTimestamp was called,
             // otherwise keep the original timestamp from pending block creation
             if UnixTime::evm_set_next_block_timestamp_was_called() {
@@ -209,8 +197,20 @@ impl TemporaryStorage for InMemoryTemporaryStorage {
             finished_block
         };
 
+        let next_state = InMemoryTemporaryStorageState::new(pending_block.block.header.number.next_block_number());
+
+        let mut pending_block = RwLockUpgradableReadGuard::<InMemoryTemporaryStorageState>::upgrade(pending_block);
+        let mut latest = self.latest_block.write();
+
+        *latest = Some(std::mem::replace(&mut *pending_block, next_state));
+
+        drop(pending_block);
+
         #[cfg(not(feature = "dev"))]
-        let finished_block = latest.as_ref().expect("latest should be Some after finishing the pending block").block.clone();
+        let finished_block = {
+            let latest = RwLockWriteGuard::<Option<InMemoryTemporaryStorageState>>::downgrade(latest);
+            latest.as_ref().expect("latest should be Some after finishing the pending block").block.clone()
+        };
 
         Ok(finished_block)
     }

--- a/src/eth/storage/temporary/inmemory.rs
+++ b/src/eth/storage/temporary/inmemory.rs
@@ -190,17 +190,9 @@ impl TemporaryStorage for InMemoryTemporaryStorage {
         drop(pending_block);
 
         #[cfg(feature = "dev")]
-        let mut finished_block = latest
-            .as_ref()
-            .expect("latest should be Some after finishing the pending block")
-            .block
-            .clone();
+        let mut finished_block = latest.as_ref().expect("latest should be Some after finishing the pending block").block.clone();
         #[cfg(not(feature = "dev"))]
-        let finished_block = latest
-            .as_ref()
-            .expect("latest should be Some after finishing the pending block")
-            .block
-            .clone();
+        let finished_block = latest.as_ref().expect("latest should be Some after finishing the pending block").block.clone();
 
         #[cfg(feature = "dev")]
         {

--- a/src/eth/storage/temporary/inmemory.rs
+++ b/src/eth/storage/temporary/inmemory.rs
@@ -184,12 +184,13 @@ impl TemporaryStorage for InMemoryTemporaryStorage {
 
         let next_state = InMemoryTemporaryStorageState::new(pending_block.block.header.number.next_block_number());
 
-        let mut latest = self.latest_block.write();
         let mut pending_block = RwLockUpgradableReadGuard::<'_, parking_lot::RawRwLock, InMemoryTemporaryStorageState>::upgrade(pending_block);
+        let mut latest = self.latest_block.write();
+
         *latest = Some(std::mem::replace(&mut *pending_block, next_state));
-        let latest = parking_lot::lock_api::RwLockWriteGuard::<'_, parking_lot::RawRwLock, std::option::Option<InMemoryTemporaryStorageState>>::downgrade(latest);
 
         drop(pending_block);
+        let latest = parking_lot::lock_api::RwLockWriteGuard::<'_, parking_lot::RawRwLock, std::option::Option<InMemoryTemporaryStorageState>>::downgrade(latest);
 
         #[cfg(feature = "dev")]
         let mut finished_block = latest.as_ref().expect("latest should be Some after finishing the pending block").block.clone();

--- a/src/eth/storage/temporary/inmemory.rs
+++ b/src/eth/storage/temporary/inmemory.rs
@@ -196,7 +196,7 @@ impl TemporaryStorage for InMemoryTemporaryStorage {
 
         #[cfg(feature = "dev")]
         let finished_block = {
-            let mut finished_block = pending_block
+            let mut finished_block = latest
                 .as_ref()
                 .expect("latest should be Some after finishing the pending block")
                 .block

--- a/src/eth/storage/temporary/inmemory.rs
+++ b/src/eth/storage/temporary/inmemory.rs
@@ -182,7 +182,7 @@ impl TemporaryStorage for InMemoryTemporaryStorage {
         let mut pending_block = self.pending_block.write();
         let mut latest = self.latest_block.write();
 
-        let next_number = (*pending_block).block.header.number.next_block_number();
+        let next_number = pending_block.block.header.number.next_block_number();
         *latest = Some(std::mem::replace(&mut *pending_block, InMemoryTemporaryStorageState::new(next_number)));
 
         drop(latest);
@@ -190,13 +190,13 @@ impl TemporaryStorage for InMemoryTemporaryStorage {
         drop(pending_block);
 
         #[cfg(feature = "dev")]
-        let mut finished_block = (*latest)
+        let mut finished_block = latest
             .as_ref()
             .expect("latest should be Some after finishing the pending block")
             .block
             .clone();
         #[cfg(not(feature = "dev"))]
-        let finished_block = (*latest)
+        let finished_block = latest
             .as_ref()
             .expect("latest should be Some after finishing the pending block")
             .block


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Improved performance of `finish_pending_block` method by reducing the time write locks are held
- Reordered operations to minimize lock contention:
  - Write operations are now performed first, then locks are dropped
  - Read operations and block cloning are done after releasing write locks
- Added error handling for accessing the latest block after finishing the pending block
- Simplified code by removing redundant assignments and leveraging existing variables
- Maintained conditional compilation for dev features



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>inmemory.rs</strong><dd><code>Optimize lock usage in finish_pending_block method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/temporary/inmemory.rs

<li>Reordered operations in <code>finish_pending_block</code> to reduce lock holding <br>time<br> <li> Moved block cloning outside of write lock<br> <li> Simplified code by removing redundant assignments<br> <li> Added error handling for <code>latest</code> block access<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1910/files#diff-e51089a92c2c949c8c776644af3cf760132d61d63ff745d676a76041be8e06e9">+18/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information