### PR TITLE
enha: make save_pending_execution cheaper

### DIFF
--- a/src/eth/executor/evm_input.rs
+++ b/src/eth/executor/evm_input.rs
@@ -161,12 +161,12 @@ impl EvmInput {
 impl PartialEq<(&TransactionInput, &PendingBlockHeader)> for EvmInput {
     fn eq(&self, other: &(&TransactionInput, &PendingBlockHeader)) -> bool {
         self.block_number == other.1.number
-        && self.block_timestamp == *other.1.timestamp
-        && self.chain_id == other.0.chain_id
-        && self.data == other.0.input
-        && self.from == other.0.signer
-        && self.nonce.is_some_and(|inner| inner == other.0.nonce)
-        && self.value == other.0.value
-        && self.to == other.0.to
+            && self.block_timestamp == *other.1.timestamp
+            && self.chain_id == other.0.chain_id
+            && self.data == other.0.input
+            && self.from == other.0.signer
+            && self.nonce.is_some_and(|inner| inner == other.0.nonce)
+            && self.value == other.0.value
+            && self.to == other.0.to
     }
 }

--- a/src/eth/executor/evm_input.rs
+++ b/src/eth/executor/evm_input.rs
@@ -157,3 +157,16 @@ impl EvmInput {
         self.to.is_some() && not(self.data.is_empty())
     }
 }
+
+impl PartialEq<(&TransactionInput, &PendingBlockHeader)> for EvmInput {
+    fn eq(&self, other: &(&TransactionInput, &PendingBlockHeader)) -> bool {
+        self.block_number == other.1.number
+        && self.block_timestamp == *other.1.timestamp
+        && self.chain_id == other.0.chain_id
+        && self.data == other.0.input
+        && self.from == other.0.signer
+        && self.nonce.is_some_and(|inner| inner == other.0.nonce)
+        && self.value == other.0.value
+        && self.to == other.0.to
+    }
+}

--- a/src/eth/storage/temporary/inmemory.rs
+++ b/src/eth/storage/temporary/inmemory.rs
@@ -19,7 +19,6 @@ use crate::eth::primitives::Slot;
 use crate::eth::primitives::SlotIndex;
 use crate::eth::primitives::StratusError;
 use crate::eth::primitives::TransactionExecution;
-use crate::eth::primitives::TransactionInput;
 #[cfg(feature = "dev")]
 use crate::eth::primitives::UnixTime;
 #[cfg(feature = "dev")]


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Implemented `PartialEq` trait for `EvmInput` struct in `evm_input.rs`, enabling efficient comparison with transaction input and block header.
- Optimized `save_pending_execution` method in `inmemory.rs`:
  - Replaced write lock with upgradable read lock for better concurrency.
  - Utilized new `PartialEq` implementation for simplified conflict checking.
  - Upgraded to write lock only when necessary, reducing lock contention.
- These changes aim to improve performance and reduce overhead in the transaction execution process.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>evm_input.rs</strong><dd><code>Add PartialEq implementation for EvmInput</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/executor/evm_input.rs

<li>Implemented <code>PartialEq</code> trait for <code>EvmInput</code> struct, comparing it with a <br>tuple of <code>(&TransactionInput, &PendingBlockHeader)</code><br> <li> The new implementation allows for efficient comparison of <code>EvmInput</code> <br>with transaction input and block header<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1911/files#diff-9dbdf7472d01464e439067cbd23dfe3648c7fb38a307bee0cf8642ad16a1a252">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>inmemory.rs</strong><dd><code>Optimize save_pending_execution with upgradable read lock</code></dd></summary>
<hr>

src/eth/storage/temporary/inmemory.rs

<li>Added <code>RwLockUpgradableReadGuard</code> import from <code>parking_lot</code><br> <li> Modified <code>save_pending_execution</code> method to use upgradable read lock<br> <li> Simplified conflict checking logic using the new <code>PartialEq</code> <br>implementation<br> <li> Upgraded read lock to write lock only when necessary<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1911/files#diff-e51089a92c2c949c8c776644af3cf760132d61d63ff745d676a76041be8e06e9">+7/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information