### PR TITLE
metrics: metrify cache slot reads

### DIFF
--- a/src/eth/storage/stratus_storage.rs
+++ b/src/eth/storage/stratus_storage.rs
@@ -204,6 +204,7 @@ impl Storage for StratusStorage {
                 if let Some(slot) = timed(|| self.cache.get_slot(address, index)).with(|m| {
                     metrics::inc_storage_read_slot(m.elapsed, label::CACHE, point_in_time, true);
                 }) {
+                    tracing::debug!(storage = %label::CACHE, %address, %index, value = %slot.value, "slot found in cache");
                     return Ok(slot);
                 };
 

--- a/src/eth/storage/stratus_storage.rs
+++ b/src/eth/storage/stratus_storage.rs
@@ -29,6 +29,7 @@ use crate::infra::tracing::SpanExt;
 mod label {
     pub(super) const TEMP: &str = "temporary";
     pub(super) const PERM: &str = "permanent";
+    pub(super) const CACHE: &str = "cache";
 }
 
 /// Proxy that simplifies interaction with permanent and temporary storages.
@@ -200,7 +201,9 @@ impl Storage for StratusStorage {
 
         let slot = 'query: {
             if point_in_time.is_pending() {
-                if let Some(slot) = self.cache.get_slot(address, index) {
+                if let Some(slot) = timed(|| self.cache.get_slot(address, index)).with(|m| {
+                    metrics::inc_storage_read_slot(m.elapsed, label::CACHE, point_in_time, true);
+                }) {
                     return Ok(slot);
                 };
 


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Introduced a new label constant `CACHE` for better categorization of cache-related operations
- Implemented metrics for cache slot reads using the `timed` function to measure performance
- Added metrics increment for storage read slot operations, specifically for cache reads
- Enhanced the `read_slot` function to provide more detailed performance insights
- Improved observability of the cache system in the Stratus storage implementation



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>stratus_storage.rs</strong><dd><code>Add metrics for cache slot reads</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/stratus_storage.rs

<li>Added a new label constant <code>CACHE</code> for cache-related operations<br> <li> Implemented metrics for cache slot reads using the <code>timed</code> function<br> <li> Incremented storage read slot metrics with cache-specific information<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1912/files#diff-3b2e36e47959decdfe26b2c4fab90b41f9242bfdad29cc43b2377ee851f4f40a">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information