### PR TITLE
metrics: metrify cache account reads

### DIFF
--- a/src/eth/storage/stratus_storage.rs
+++ b/src/eth/storage/stratus_storage.rs
@@ -152,7 +152,10 @@ impl Storage for StratusStorage {
 
         let account = 'query: {
             if point_in_time.is_pending() {
-                if let Some(account) = self.cache.get_account(address) {
+                if let Some(account) = timed(|| self.cache.get_account(address)).with(|m| {
+                    metrics::inc_storage_read_account(m.elapsed, label::CACHE, point_in_time, true);
+                }) {
+                    tracing::debug!(storage = %label::CACHE, %address, ?account, "account found in cache");
                     return Ok(account);
                 };
 

--- a/src/eth/storage/stratus_storage.rs
+++ b/src/eth/storage/stratus_storage.rs
@@ -204,6 +204,7 @@ impl Storage for StratusStorage {
                 if let Some(slot) = timed(|| self.cache.get_slot(address, index)).with(|m| {
                     metrics::inc_storage_read_slot(m.elapsed, label::CACHE, point_in_time, true);
                 }) {
+                    tracing::debug!(storage = %label::CACHE, %address, %index, value = %slot.value, "slot found in cache");
                     return Ok(slot);
                 };
 

--- a/src/eth/storage/stratus_storage.rs
+++ b/src/eth/storage/stratus_storage.rs
@@ -29,6 +29,7 @@ use crate::infra::tracing::SpanExt;
 mod label {
     pub(super) const TEMP: &str = "temporary";
     pub(super) const PERM: &str = "permanent";
+    pub(super) const CACHE: &str = "cache";
 }
 
 /// Proxy that simplifies interaction with permanent and temporary storages.
@@ -200,7 +201,9 @@ impl Storage for StratusStorage {
 
         let slot = 'query: {
             if point_in_time.is_pending() {
-                if let Some(slot) = self.cache.get_slot(address, index) {
+                if let Some(slot) = timed(|| self.cache.get_slot(address, index)).with(|m| {
+                    metrics::inc_storage_read_slot(m.elapsed, label::CACHE, point_in_time, true);
+                }) {
                     return Ok(slot);
                 };
 


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Implemented metrics for cache account reads in the `read_account` function
- Added timing measurement for the `cache.get_account` operation
- Introduced debug logging when an account is found in the cache
- These changes improve observability and performance tracking for cache operations



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>stratus_storage.rs</strong><dd><code>Enhance cache read account with metrics and logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/stratus_storage.rs

<li>Added metrics for cache account reads<br> <li> Implemented timing for cache get_account operation<br> <li> Added debug logging for when an account is found in cache<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1914/files#diff-3b2e36e47959decdfe26b2c4fab90b41f9242bfdad29cc43b2377ee851f4f40a">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information