### PR TITLE
chore: remove manual serialization

### DIFF
--- a/src/ledger/events.rs
+++ b/src/ledger/events.rs
@@ -11,7 +11,7 @@ use ethereum_types::U256;
 use hex_literal::hex;
 use itertools::Itertools;
 use serde::ser::SerializeStruct;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::eth::primitives::Address;
@@ -128,7 +128,8 @@ pub struct AccountTransfer {
 }
 
 /// Direction of a transfer relative to the primary account address.
-#[derive(DebugAsJson, strum::EnumIs)]
+#[derive(DebugAsJson, strum::EnumIs, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum AccountTransferDirection {
     /// `account_address` is being credited.
     Credit,
@@ -175,18 +176,6 @@ impl Serialize for AccountTransfer {
         state.serialize_field("amount", &self.amount.to_string())?;
         state.serialize_field("direction", &self.direction)?;
         state.end()
-    }
-}
-
-impl Serialize for AccountTransferDirection {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        match self {
-            Self::Credit => serializer.serialize_str("credit"),
-            Self::Debit => serializer.serialize_str("debit"),
-        }
     }
 }
 


### PR DESCRIPTION
### PR Type
Enhancement

---
### Description
- Automatically derived `Serialize` for `AccountTransferDirection` enum with `#[serde(rename_all = "snake_case")]` to serialize variants as "credit" and "debit".