### PR TITLE
fix: error on e2e not propagating

### DIFF
--- a/e2e/cloudwalk-contracts/integration/package-lock.json
+++ b/e2e/cloudwalk-contracts/integration/package-lock.json
@@ -12,7 +12,7 @@
             },
             "devDependencies": {
                 "@nomicfoundation/hardhat-toolbox": "^4.0.0",
-                "@openzeppelin/hardhat-upgrades": "^3.0.1",
+                "@openzeppelin/hardhat-upgrades": "3.3.0",
                 "@trivago/prettier-plugin-sort-imports": "^4.3.0",
                 "axios": "^1.6.7",
                 "ethers": "^6.9.0",
@@ -1909,15 +1909,15 @@
             }
         },
         "node_modules/@openzeppelin/hardhat-upgrades": {
-            "version": "3.5.0",
-            "resolved": "https://registry.npmjs.org/@openzeppelin/hardhat-upgrades/-/hardhat-upgrades-3.5.0.tgz",
-            "integrity": "sha512-Ju/JnT7NRiOMi5m5Y0dGiz37d8wnjVBep1v5Vr7+6+MFNuQa1yddUEVWhWhoEw4udI3/mYwyw4Sfz3sq7vhicQ==",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@openzeppelin/hardhat-upgrades/-/hardhat-upgrades-3.3.0.tgz",
+            "integrity": "sha512-0RwCpkBKWViG0nIERk8tV5E71DCtZ6PXgsjoCYg+Bi2IWYgD8Skt4Q8b6QqE7tuWsFCK5yVQIVfCFL99JKMK5A==",
             "dev": true,
             "dependencies": {
                 "@openzeppelin/defender-sdk-base-client": "^1.14.4",
                 "@openzeppelin/defender-sdk-deploy-client": "^1.14.4",
                 "@openzeppelin/defender-sdk-network-client": "^1.14.4",
-                "@openzeppelin/upgrades-core": "^1.40.0",
+                "@openzeppelin/upgrades-core": "^1.35.0",
                 "chalk": "^4.1.0",
                 "debug": "^4.1.1",
                 "ethereumjs-util": "^7.1.5",

--- a/e2e/cloudwalk-contracts/integration/package.json
+++ b/e2e/cloudwalk-contracts/integration/package.json
@@ -2,7 +2,7 @@
     "name": "hardhat-project",
     "devDependencies": {
         "@nomicfoundation/hardhat-toolbox": "^4.0.0",
-        "@openzeppelin/hardhat-upgrades": "^3.0.1",
+        "@openzeppelin/hardhat-upgrades": "3.3.0",
         "@trivago/prettier-plugin-sort-imports": "^4.3.0",
         "axios": "^1.6.7",
         "ethers": "^6.9.0",

--- a/justfile
+++ b/justfile
@@ -299,7 +299,6 @@ e2e-flamegraph:
 # E2E: Leader & Follower Up
 e2e-leader-follower-up test="brlc" release_flag="--release":
     #!/bin/bash
-    set -e
     
     just build
 
@@ -359,6 +358,8 @@ e2e-leader-follower-up test="brlc" release_flag="--release":
         npx hardhat test test/leader-follower-{{test}}.test.ts --bail --network stratus --show-stack-traces
         if [ $? -ne 0 ]; then
             just _log "Tests failed"
+            killport 3000 -s sigterm
+            killport 3001 -s sigterm
             exit 1
         else
             just _log "Tests passed successfully"
@@ -366,8 +367,6 @@ e2e-leader-follower-up test="brlc" release_flag="--release":
         fi
     )
     fi
-    killport 3000 -s sigterm
-    killport 3001 -s sigterm
 
 # E2E: Leader & Follower Down
 e2e-leader-follower-down:

--- a/justfile
+++ b/justfile
@@ -299,7 +299,6 @@ e2e-flamegraph:
 # E2E: Leader & Follower Up
 e2e-leader-follower-up test="brlc" release_flag="--release":
     #!/bin/bash
-    
     just build
 
     mkdir e2e_logs

--- a/justfile
+++ b/justfile
@@ -299,6 +299,8 @@ e2e-flamegraph:
 # E2E: Leader & Follower Up
 e2e-leader-follower-up test="brlc" release_flag="--release":
     #!/bin/bash
+    set -e
+    
     just build
 
     mkdir e2e_logs

--- a/justfile
+++ b/justfile
@@ -358,8 +358,6 @@ e2e-leader-follower-up test="brlc" release_flag="--release":
         npx hardhat test test/leader-follower-{{test}}.test.ts --bail --network stratus --show-stack-traces
         if [ $? -ne 0 ]; then
             just _log "Tests failed"
-            killport 3000 -s sigterm
-            killport 3001 -s sigterm
             exit 1
         else
             just _log "Tests passed successfully"
@@ -544,6 +542,8 @@ stratus-test-coverage output="":
     -rm -r temp_3001-rocksdb
     -docker compose down -v
     just e2e-leader-follower-up kafka " "
+    killport 3000 -s sigterm
+    killport 3001 -s sigterm
     sleep 10
     -rm -r e2e_logs
     -rm utils/deploy/deploy_01.log
@@ -552,6 +552,8 @@ stratus-test-coverage output="":
     -rm -r temp_3000-rocksdb
     -rm -r temp_3001-rocksdb
     just e2e-leader-follower-up deploy " "
+    killport 3000 -s sigterm
+    killport 3001 -s sigterm
     sleep 10
     -rm -r e2e_logs
     -rm utils/deploy/deploy_01.log
@@ -560,6 +562,8 @@ stratus-test-coverage output="":
     -rm -r temp_3000-rocksdb
     -rm -r temp_3001-rocksdb
     just e2e-leader-follower-up brlc " "
+    killport 3000 -s sigterm
+    killport 3001 -s sigterm
     sleep 10
     -rm -r e2e_logs
     -rm utils/deploy/deploy_01.log
@@ -568,6 +572,8 @@ stratus-test-coverage output="":
     -rm -r temp_3000-rocksdb
     -rm -r temp_3001-rocksdb
     just e2e-leader-follower-up change " "
+    killport 3000 -s sigterm
+    killport 3001 -s sigterm
     sleep 10
     -rm -r e2e_logs
     -rm utils/deploy/deploy_01.log
@@ -576,6 +582,8 @@ stratus-test-coverage output="":
     -rm -r temp_3000-rocksdb
     -rm -r temp_3001-rocksdb
     just e2e-leader-follower-up miner " "
+    killport 3000 -s sigterm
+    killport 3001 -s sigterm
     sleep 10
     -rm -r e2e_logs
     -rm utils/deploy/deploy_01.log
@@ -584,6 +592,8 @@ stratus-test-coverage output="":
     -rm -r temp_3000-rocksdb
     -rm -r temp_3001-rocksdb
     just e2e-leader-follower-up importer " "
+    killport 3000 -s sigterm
+    killport 3001 -s sigterm
     sleep 10
     -rm -r e2e_logs
     -rm utils/deploy/deploy_01.log


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed an issue where errors in E2E tests were not propagating correctly
- Pinned @openzeppelin/hardhat-upgrades to version 3.3.0 in both package.json and package-lock.json
- Improved process termination in E2E tests by adding killport commands for ports 3000 and 3001
- Restructured the justfile to ensure proper cleanup after each test section
- Enhanced readability of the e2e-leader-follower-up function



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package-lock.json</strong><dd><code>Pin OpenZeppelin Hardhat Upgrades dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

e2e/cloudwalk-contracts/integration/package-lock.json

<li>Pinned @openzeppelin/hardhat-upgrades to version 3.3.0<br> <li> Updated related dependencies to match the pinned version<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1916/files#diff-45669edece661ade02ee786084d313c76d4a1ea24044e66e5e3fd655d5bce0a6">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Update OpenZeppelin Hardhat Upgrades version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

e2e/cloudwalk-contracts/integration/package.json

- Pinned @openzeppelin/hardhat-upgrades to version 3.3.0



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1916/files#diff-5654927eddcf71300bf8bd33b67f22e981dab7e566ead27d32e070fe79228a77">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>justfile</strong><dd><code>Improve process termination in E2E tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

justfile

<li>Added killport commands to terminate processes on ports 3000 and 3001<br> <li> Moved killport commands from e2e-leader-follower-up to individual test <br>sections<br> <li> Added a blank line in e2e-leader-follower-up for better readability<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1916/files#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1">+13/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information