### PR TITLE
chore: put rocks metrics collection behind a feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -201,6 +201,9 @@ dev = []
 # Enable runtime metrics collection.
 metrics = ["dep:metrics-exporter-prometheus"]
 
+# Enable runtime rocksdb metrics collection.
+rocks_metrics = ["metrics"]
+
 # Enable runtime tracing/spans collection.
 tracing = []
 

--- a/src/eth/storage/permanent/rocks/rocks_cf.rs
+++ b/src/eth/storage/permanent/rocks/rocks_cf.rs
@@ -18,7 +18,7 @@ use rocksdb::DB;
 use serde::Deserialize;
 use serde::Serialize;
 
-#[cfg(feature = "metrics")]
+#[cfg(feature = "rocks_metrics")]
 use crate::infra::metrics;
 
 /// A RocksDB Column Family (CF) reference.
@@ -232,7 +232,7 @@ where
         }
     }
 
-    #[cfg(feature = "metrics")]
+    #[cfg(feature = "rocks_metrics")]
     pub fn export_metrics(&self) {
         let handle = self.handle();
         let cur_size_active_mem_table = self

--- a/src/eth/storage/permanent/rocks/rocks_config.rs
+++ b/src/eth/storage/permanent/rocks/rocks_config.rs
@@ -39,7 +39,7 @@ impl DbConfig {
         opts.increase_parallelism(16);
 
         // NOTE: As per the rocks db wiki: "The overhead of statistics is usually small but non-negligible. We usually observe an overhead of 5%-10%."
-        #[cfg(feature = "metrics")]
+        #[cfg(feature = "rocks_metrics")]
         {
             opts.enable_statistics();
             opts.set_statistics_level(rocksdb::statistics::StatsLevel::ExceptTimeForMutex);

--- a/src/eth/storage/permanent/rocks/rocks_permanent.rs
+++ b/src/eth/storage/permanent/rocks/rocks_permanent.rs
@@ -125,7 +125,7 @@ impl PermanentStorage for RocksPermanentStorage {
     }
 
     fn save_block(&self, block: Block) -> anyhow::Result<()> {
-        #[cfg(feature = "metrics")]
+        #[cfg(feature = "rocks_metrics")]
         {
             self.state.export_metrics().inspect_err(|e| {
                 tracing::error!(reason = ?e, "failed to export metrics in RocksPermanent");

--- a/src/eth/storage/permanent/rocks/rocks_state.rs
+++ b/src/eth/storage/permanent/rocks/rocks_state.rs
@@ -52,17 +52,19 @@ use crate::eth::primitives::Slot;
 use crate::eth::primitives::SlotIndex;
 use crate::eth::primitives::TransactionMined;
 use crate::ext::OptionExt;
+#[cfg(feature = "metrics")]
+use crate::infra::metrics;
 use crate::log_and_err;
 use crate::utils::GIGABYTE;
 
 cfg_if::cfg_if! {
-    if #[cfg(feature = "metrics")] {
+    if #[cfg(feature = "rocks_metrics")] {
         use parking_lot::Mutex;
 
         use rocksdb::statistics::Histogram;
         use rocksdb::statistics::Ticker;
 
-        use crate::infra::metrics::{self, Count, HistogramInt, Sum};
+        use crate::infra::metrics::{Count, HistogramInt, Sum};
     }
 }
 
@@ -119,13 +121,13 @@ pub struct RocksStorageState {
     blocks_by_hash: RocksCfRef<HashRocksdb, CfBlocksByHashValue>,
     logs: RocksCfRef<(HashRocksdb, IndexRocksdb), CfLogsValue>,
     /// Last collected stats for a histogram
-    #[cfg(feature = "metrics")]
+    #[cfg(feature = "rocks_metrics")]
     prev_stats: Mutex<HashMap<HistogramInt, (Sum, Count)>>,
     /// Options passed at DB creation, stored for metrics
     ///
     /// a newly created `rocksdb::Options` object is unique, with an underlying pointer identifier inside of it, and is used to access
     /// the DB metrics, `Options` can be cloned, but two equal `Options` might not retrieve the same metrics
-    #[cfg(feature = "metrics")]
+    #[cfg(feature = "rocks_metrics")]
     db_options: Options,
     shutdown_timeout: Duration,
     enable_sync_write: bool,
@@ -137,7 +139,7 @@ impl RocksStorageState {
 
         let cf_options_map = generate_cf_options_map(cache_multiplier);
 
-        #[cfg_attr(not(feature = "metrics"), allow(unused_variables))]
+        #[cfg_attr(not(feature = "rocks_metrics"), allow(unused_variables))]
         let (db, db_options) = create_or_open_db(&path, &cf_options_map).context("when trying to create (or open) rocksdb")?;
 
         if db.path().to_str().is_none() {
@@ -157,9 +159,9 @@ impl RocksStorageState {
             blocks_by_number: new_cf_ref(&db, "blocks_by_number", &cf_options_map)?,
             blocks_by_hash: new_cf_ref(&db, "blocks_by_hash", &cf_options_map)?,
             logs: new_cf_ref(&db, "logs", &cf_options_map)?,
-            #[cfg(feature = "metrics")]
+            #[cfg(feature = "rocks_metrics")]
             prev_stats: Mutex::default(),
-            #[cfg(feature = "metrics")]
+            #[cfg(feature = "rocks_metrics")]
             db_options,
             db,
             shutdown_timeout,
@@ -525,7 +527,7 @@ impl RocksStorageState {
     }
 }
 
-#[cfg(feature = "metrics")]
+#[cfg(feature = "rocks_metrics")]
 impl RocksStorageState {
     pub fn export_metrics(&self) -> Result<()> {
         let db_get = self.db_options.get_histogram_data(Histogram::DbGet);


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Introduced a new feature flag "rocks_metrics" for RocksDB-specific metrics collection
- Updated all occurrences of the "metrics" feature flag to "rocks_metrics" in RocksDB-related files
- Modified conditional compilation directives to use the new feature flag
- Adjusted imports and dependencies to align with the new feature flag
- Maintained backwards compatibility by making "rocks_metrics" depend on "metrics"
- This change allows for more granular control over metrics collection, specifically for RocksDB



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rocks_cf.rs</strong><dd><code>Update feature flag for RocksDB metrics</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/permanent/rocks/rocks_cf.rs

<li>Changed feature flag from "metrics" to "rocks_metrics" for metrics <br>collection<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1922/files#diff-194abd1b13610c68a3fa6226ecef3f097710fda1b5630e2aecfb1afdceab056e">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>rocks_config.rs</strong><dd><code>Adjust feature flag for RocksDB statistics</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/permanent/rocks/rocks_config.rs

<li>Updated feature flag from "metrics" to "rocks_metrics" for RocksDB <br>statistics<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1922/files#diff-8f09ddf1ee290769ad87d67b994627ad2357a63824fa23b8275d1e766a28a777">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>rocks_permanent.rs</strong><dd><code>Update feature flag for metrics export</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/permanent/rocks/rocks_permanent.rs

<li>Modified feature flag from "metrics" to "rocks_metrics" for exporting <br>metrics<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1922/files#diff-d582062cac05f2b057f597f872d3f0415f29f579876306b2d9289c278c3bd3fd">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>rocks_state.rs</strong><dd><code>Refactor RocksDB state metrics feature flag</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/permanent/rocks/rocks_state.rs

<li>Changed feature flag from "metrics" to "rocks_metrics" throughout the <br>file<br> <li> Updated conditional compilation directives<br> <li> Modified imports to accommodate the new feature flag<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1922/files#diff-9d38c98aa2d77c1665d2e2e11a0abc4787424d1b41a610d2fc1c4ea0311014a9">+10/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Add new RocksDB metrics feature flag</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Cargo.toml

- Added new feature flag "rocks_metrics" that depends on "metrics"



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1922/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information