### PR TITLE
chore: add e2e-admin-password test to coverage recipe

### DIFF
--- a/e2e/test/admin/e2e-admin-password-enabled.test.ts
+++ b/e2e/test/admin/e2e-admin-password-enabled.test.ts
@@ -9,7 +9,6 @@ describe("Admin Password (with password set)", () => {
 
     it("should reject requests without password", async () => {
         const error = await sendAndGetError("stratus_enableTransactions", []);
-        console.log(error);
         expect(error.code).eq(-32009); // Internal error
         expect(error.message).to.contain("Incorrect password");
     });

--- a/justfile
+++ b/justfile
@@ -169,14 +169,14 @@ e2e-admin-password:
     ADMIN_PASSWORD=test123 just run -a 0.0.0.0:3000 > /dev/null &
     just _wait_for_stratus
     npx hardhat test test/admin/e2e-admin-password-enabled.test.ts --network stratus
-    killport 3000
+    killport 3000 -s sigterm
 
     # Start Stratus without password set
     just _log "Running admin password tests without password set"
     just run -a 0.0.0.0:3000 > /dev/null  &
     just _wait_for_stratus
     npx hardhat test test/admin/e2e-admin-password-disabled.test.ts --network stratus
-    killport 3000
+    killport 3000 -s sigterm
 
 # E2E: Starts and execute Hardhat tests in Hardhat
 e2e-hardhat block-mode="automine" test="":
@@ -505,14 +505,20 @@ contracts-coverage-erase:
 stratus-test-coverage *args="":
     #!/bin/bash
     # setup
-    just contracts-clone
+    cargo llvm-cov clean --workspace
+    just build
     source <(cargo llvm-cov show-env --export-prefix)
     export RUST_LOG=error
 
-    cargo llvm-cov clean --workspace
-    just build
+    just contracts-clone
+
+    # cargo test
+    cargo llvm-cov --no-report
+    sleep 10
+
 
     # inmemory
+
     just e2e-stratus automine
     sleep 10
     -rm stratus.log
@@ -551,8 +557,6 @@ stratus-test-coverage *args="":
     -rm stratus.log
 
     # other
-    cargo llvm-cov --no-report
-    sleep 10
 
     -just contracts-clone --token
     -just contracts-flatten --token
@@ -616,7 +620,6 @@ stratus-test-coverage *args="":
     -rm -r e2e_logs
     -rm utils/deploy/deploy_01.log
     -rm utils/deploy/deploy_02.log
-    */
 
     just e2e-admin-password
 

--- a/justfile
+++ b/justfile
@@ -619,4 +619,5 @@ stratus-test-coverage *args="":
     */
 
     just e2e-admin-password
+
     cargo llvm-cov report {{args}}

--- a/justfile
+++ b/justfile
@@ -618,4 +618,5 @@ stratus-test-coverage *args="":
     -rm utils/deploy/deploy_02.log
     */
 
+    just e2e-admin-password
     cargo llvm-cov report {{args}}


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Added e2e-admin-password test to the stratus-test-coverage recipe, improving overall test coverage.
- Updated killport commands in justfile to use '-s sigterm' flag for more graceful process termination.
- Reorganized the stratus-test-coverage recipe for better efficiency:
  - Moved cargo llvm-cov clean and build steps to the beginning of the recipe.
  - Added cargo llvm-cov --no-report before running e2e tests.
- Removed a debug console.log statement from the admin password enabled test.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>e2e-admin-password-enabled.test.ts</strong><dd><code>Remove debug logging in admin password test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

e2e/test/admin/e2e-admin-password-enabled.test.ts

- Removed a console.log statement from the test case



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1929/files#diff-f5eb3e0fddaf4dfb49740a21d95efc9f96e200ebe53e2783aa29e6a357b94226">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>justfile</strong><dd><code>Enhance test coverage and improve process termination</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

justfile

<li>Updated killport commands to use '-s sigterm' flag<br> <li> Reorganized the stratus-test-coverage recipe:<br>   - Moved cargo llvm-cov <br>clean and build steps to the beginning<br>   - Added cargo llvm-cov <br>--no-report before e2e tests<br>   - Added e2e-admin-password test to the <br>coverage recipe<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1929/files#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1">+13/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information