### PR TITLE
enha: make the health check consider network failures

### DIFF
--- a/.github/workflows/e2e-leader-follower.yml
+++ b/.github/workflows/e2e-leader-follower.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test: [brlc, importer, miner, change, deploy, kafka]
+        test: [brlc, importer, miner, change, deploy, kafka, health]
     name: E2E Leader & Follower on ${{ matrix.test }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
@@ -86,7 +86,7 @@ jobs:
 
       - name: Install Poetry
         run: curl -sSL https://install.python-poetry.org | python3 -
-      
+
       - name: Install Docker Compose
         if: matrix.test == 'kafka'
         run: |

--- a/e2e/cloudwalk-contracts/integration/test/leader-follower-change.test.ts
+++ b/e2e/cloudwalk-contracts/integration/test/leader-follower-change.test.ts
@@ -214,4 +214,24 @@ describe("Leader & Follower change integration test", function () {
 
         expect(semaphoreFailureCount).to.be.greaterThan(0);
     });
+    it("Test follower health is based on leader miner enabled", async function () {
+        updateProviderUrl("stratus");
+        await sendWithRetry("stratus_disableMiner", []);
+
+        await new Promise((resolve) => setTimeout(resolve, 5000));
+
+        updateProviderUrl("stratus-follower");
+        const unhealthyResponse = await sendAndGetFullResponse("stratus_health", []);
+        expect(unhealthyResponse.data.error.code).to.equal(-32009);
+        expect(unhealthyResponse.data.error.message).to.equal("Stratus is not ready to start servicing requests.");
+
+        updateProviderUrl("stratus");
+        await sendWithRetry("stratus_enableMiner", []);
+
+        await new Promise((resolve) => setTimeout(resolve, 5000));
+
+        updateProviderUrl("stratus-follower");
+        const healthyResponse = await sendWithRetry("stratus_health", []);
+        expect(healthyResponse).to.equal(true);
+    });
 });

--- a/e2e/cloudwalk-contracts/integration/test/leader-follower-change.test.ts
+++ b/e2e/cloudwalk-contracts/integration/test/leader-follower-change.test.ts
@@ -214,24 +214,4 @@ describe("Leader & Follower change integration test", function () {
 
         expect(semaphoreFailureCount).to.be.greaterThan(0);
     });
-    it("Test follower health is based on leader miner enabled", async function () {
-        updateProviderUrl("stratus");
-        await sendWithRetry("stratus_disableMiner", []);
-
-        await new Promise((resolve) => setTimeout(resolve, 5000));
-
-        updateProviderUrl("stratus-follower");
-        const unhealthyResponse = await sendAndGetFullResponse("stratus_health", []);
-        expect(unhealthyResponse.data.error.code).to.equal(-32009);
-        expect(unhealthyResponse.data.error.message).to.equal("Stratus is not ready to start servicing requests.");
-
-        updateProviderUrl("stratus");
-        await sendWithRetry("stratus_enableMiner", []);
-
-        await new Promise((resolve) => setTimeout(resolve, 5000));
-
-        updateProviderUrl("stratus-follower");
-        const healthyResponse = await sendWithRetry("stratus_health", []);
-        expect(healthyResponse).to.equal(true);
-    });
 });

--- a/e2e/cloudwalk-contracts/integration/test/leader-follower-health.test.ts
+++ b/e2e/cloudwalk-contracts/integration/test/leader-follower-health.test.ts
@@ -1,0 +1,25 @@
+import { expect } from "chai";
+
+import { sendAndGetFullResponse, sendWithRetry, updateProviderUrl } from "./helpers/rpc";
+
+it("Test follower health is based on getting new blocks", async function () {
+    updateProviderUrl("stratus-follower");
+    var healthyResponse = await sendWithRetry("stratus_health", []);
+    expect(healthyResponse).to.equal(true);
+    // Kill port 3000 to interrupt leader
+    require("child_process").execSync("killport 3000 -s sigterm", { stdio: "inherit" });
+
+    await new Promise((resolve) => setTimeout(resolve, 5000));
+
+    const unhealthyResponse = await sendAndGetFullResponse("stratus_health", []);
+    expect(unhealthyResponse.data.error.code).to.equal(-32009);
+    expect(unhealthyResponse.data.error.message).to.equal("Stratus is not ready to start servicing requests.");
+
+    // Start the leader again
+    require("child_process").execSync("just e2e-leader", { stdio: "inherit" });
+
+    await new Promise((resolve) => setTimeout(resolve, 5000));
+
+    var healthyResponse = await sendWithRetry("stratus_health", []);
+    expect(healthyResponse).to.equal(true);
+});

--- a/src/eth/follower/importer/importer.rs
+++ b/src/eth/follower/importer/importer.rs
@@ -60,7 +60,7 @@ pub enum ImporterMode {
 /// Current block number of the external RPC blockchain.
 static EXTERNAL_RPC_CURRENT_BLOCK: AtomicU64 = AtomicU64::new(0);
 
-/// Current block number of the external RPC blockchain.
+/// Timestamp of when EXTERNAL_RPC_CURRENT_BLOCK was updated last.
 static LATEST_FETCHED_BLOCK_TIME: AtomicU64 = AtomicU64::new(0);
 
 /// Only sets the external RPC current block number if it is equals or greater than the current one.

--- a/src/eth/follower/importer/importer.rs
+++ b/src/eth/follower/importer/importer.rs
@@ -60,10 +60,14 @@ pub enum ImporterMode {
 /// Current block number of the external RPC blockchain.
 static EXTERNAL_RPC_CURRENT_BLOCK: AtomicU64 = AtomicU64::new(0);
 
+/// Current block number of the external RPC blockchain.
+static LATEST_FETCHED_BLOCK_TIME: AtomicU64 = AtomicU64::new(0);
+
 /// Only sets the external RPC current block number if it is equals or greater than the current one.
 fn set_external_rpc_current_block(new_number: BlockNumber) {
     let new_number_u64 = new_number.as_u64();
     let _ = EXTERNAL_RPC_CURRENT_BLOCK.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current_number| {
+        LATEST_FETCHED_BLOCK_TIME.store(chrono::Utc::now().timestamp() as u64, Ordering::Relaxed);
         if_else!(new_number_u64 >= current_number, Some(new_number_u64), None)
     });
 }
@@ -572,7 +576,15 @@ async fn fetch_receipt(chain: Arc<BlockchainClient>, block_number: BlockNumber, 
 #[async_trait]
 impl Consensus for Importer {
     async fn lag(&self) -> anyhow::Result<u64> {
-        Ok(EXTERNAL_RPC_CURRENT_BLOCK.load(Ordering::SeqCst) - self.storage.read_mined_block_number()?.as_u64())
+        let elapsed = chrono::Utc::now().timestamp() as u64 - LATEST_FETCHED_BLOCK_TIME.load(Ordering::Relaxed);
+        if elapsed > 4 {
+            Err(anyhow::anyhow!(
+                "too much time elapsed without communicating with the leader. elapsed: {}s",
+                elapsed
+            ))
+        } else {
+            Ok(EXTERNAL_RPC_CURRENT_BLOCK.load(Ordering::SeqCst) - self.storage.read_mined_block_number()?.as_u64())
+        }
     }
 
     fn get_chain(&self) -> anyhow::Result<&Arc<BlockchainClient>> {

--- a/src/eth/follower/importer/importer.rs
+++ b/src/eth/follower/importer/importer.rs
@@ -66,8 +66,8 @@ static LATEST_FETCHED_BLOCK_TIME: AtomicU64 = AtomicU64::new(0);
 /// Only sets the external RPC current block number if it is equals or greater than the current one.
 fn set_external_rpc_current_block(new_number: BlockNumber) {
     let new_number_u64 = new_number.as_u64();
+    LATEST_FETCHED_BLOCK_TIME.store(chrono::Utc::now().timestamp() as u64, Ordering::Relaxed);
     let _ = EXTERNAL_RPC_CURRENT_BLOCK.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current_number| {
-        LATEST_FETCHED_BLOCK_TIME.store(chrono::Utc::now().timestamp() as u64, Ordering::Relaxed);
         if_else!(new_number_u64 >= current_number, Some(new_number_u64), None)
     });
 }


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Enhanced the importer to consider network failures in health checks:
  - Added tracking of the latest fetched block time
  - Implemented a timeout check in the `lag` function to detect communication issues with the leader
- Added a new end-to-end test to verify follower health based on leader miner status:
  - Checks follower health when leader miner is disabled
  - Verifies follower health recovery when leader miner is re-enabled
- These changes improve the system's ability to detect and respond to network issues between leader and follower nodes



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>importer.rs</strong><dd><code>Enhance importer with network failure detection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/follower/importer/importer.rs

<li>Added <code>LATEST_FETCHED_BLOCK_TIME</code> atomic variable to track the timestamp <br>of the last fetched block<br> <li> Modified <code>set_external_rpc_current_block</code> to update <br><code>LATEST_FETCHED_BLOCK_TIME</code><br> <li> Updated <code>lag</code> function to check for communication timeout with the <br>leader<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1930/files#diff-bd50f502f039aff8f75753bc780d281ae7d7936fadc9d53482084c647aec94ca">+13/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>leader-follower-change.test.ts</strong><dd><code>Add test for follower health based on leader miner status</code></dd></summary>
<hr>

e2e/cloudwalk-contracts/integration/test/leader-follower-change.test.ts

<li>Added new test case "Test follower health is based on leader miner <br>enabled"<br> <li> Test checks follower health when leader miner is disabled and <br>re-enabled<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1930/files#diff-7236d4b676b75ced96eb321337290326efe4e91a261edc4e83b688c4da09dd7c">+20/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information