### PR TITLE
chore: remove/allow panics, expects and unwraps

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,7 @@
+#![allow(clippy::unwrap_used)]
+#![allow(clippy::expect_used)]
+#![allow(clippy::panic)]
+
 use std::collections::HashSet;
 use std::env;
 use std::fs;

--- a/src/eth/external_rpc/postgres.rs
+++ b/src/eth/external_rpc/postgres.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::panic)]
+
 use std::time::Duration;
 
 use async_trait::async_trait;

--- a/src/eth/follower/importer/importer.rs
+++ b/src/eth/follower/importer/importer.rs
@@ -522,6 +522,7 @@ async fn fetch_block_and_receipts(chain: Arc<BlockchainClient>, block_number: Bl
     (block, receipts)
 }
 
+#[allow(clippy::expect_used)]
 #[tracing::instrument(name = "importer::fetch_block", skip_all, fields(block_number))]
 async fn fetch_block(chain: Arc<BlockchainClient>, block_number: BlockNumber) -> ExternalBlock {
     const RETRY_DELAY: Duration = Duration::from_millis(10);

--- a/src/eth/miner/miner.rs
+++ b/src/eth/miner/miner.rs
@@ -508,6 +508,7 @@ mod interval_miner_ticker {
         const TASK_NAME: &str = "interval-miner-ticker";
 
         // sync to next second
+        #[allow(clippy::expect_used)]
         let next_second = (Utc::now() + Duration::from_secs(1))
             .with_nanosecond(0)
             .expect("nanosecond above is set to `0`, which is always less than 2 billion");

--- a/src/eth/primitives/address.rs
+++ b/src/eth/primitives/address.rs
@@ -99,7 +99,7 @@ impl From<LogTopic> for Address {
 impl From<NameOrAddress> for Address {
     fn from(value: NameOrAddress) -> Self {
         match value {
-            NameOrAddress::Name(_) => panic!("TODO"),
+            NameOrAddress::Name(_) => todo!(),
             NameOrAddress::Address(value) => Self(value),
         }
     }

--- a/src/eth/primitives/execution.rs
+++ b/src/eth/primitives/execution.rs
@@ -66,7 +66,7 @@ impl EvmExecution {
         let sender_next_nonce = sender_changes
             .nonce
             .take_original_ref()
-            .expect("from_original_values populates original values, so taking original ref here will succeed")
+            .ok_or_else(|| anyhow!("original nonce value not found when it should have been populated by from_original_values"))?
             .next_nonce();
         sender_changes.nonce.set_modified(sender_next_nonce);
 
@@ -197,7 +197,7 @@ impl EvmExecution {
             };
 
             // subtract execution cost from sender balance
-            let sender_balance = *sender_changes.balance.take_ref().expect("balance is never None");
+            let sender_balance = *sender_changes.balance.take_ref().ok_or(anyhow!("sender balance was None"))?;
             let sender_new_balance = if sender_balance > execution_cost {
                 sender_balance - execution_cost
             } else {

--- a/src/eth/primitives/external_block.rs
+++ b/src/eth/primitives/external_block.rs
@@ -18,11 +18,13 @@ pub struct ExternalBlock(#[deref] pub EthersBlockExternalTransaction);
 
 impl ExternalBlock {
     /// Returns the block hash.
+    #[allow(clippy::expect_used)]
     pub fn hash(&self) -> Hash {
         self.0.hash.expect("external block must have hash").into()
     }
 
     /// Returns the block number.
+    #[allow(clippy::expect_used)]
     pub fn number(&self) -> BlockNumber {
         self.0.number.expect("external block must have number").into()
     }

--- a/src/eth/primitives/external_receipt.rs
+++ b/src/eth/primitives/external_receipt.rs
@@ -21,11 +21,13 @@ impl ExternalReceipt {
     }
 
     /// Returns the block number.
+    #[allow(clippy::expect_used)]
     pub fn block_number(&self) -> BlockNumber {
         self.0.block_number.expect("external receipt must have block number").into()
     }
 
     /// Returns the block hash.
+    #[allow(clippy::expect_used)]
     pub fn block_hash(&self) -> Hash {
         self.0.block_hash.expect("external receipt must have block hash").into()
     }

--- a/src/eth/primitives/log_mined.rs
+++ b/src/eth/primitives/log_mined.rs
@@ -58,12 +58,21 @@ impl LogMined {
 impl TryFrom<EthersLog> for LogMined {
     type Error = anyhow::Error;
     fn try_from(value: EthersLog) -> Result<Self, Self::Error> {
+        let transaction_hash = value.transaction_hash.ok_or_else(|| anyhow::anyhow!("log must have transaction_hash"))?.into();
+        let transaction_index = value
+            .transaction_index
+            .ok_or_else(|| anyhow::anyhow!("log must have transaction_index"))?
+            .into();
+        let log_index = value.log_index.ok_or_else(|| anyhow::anyhow!("log must have log_index"))?.try_into()?;
+        let block_number = value.block_number.ok_or_else(|| anyhow::anyhow!("log must have block_number"))?.into();
+        let block_hash = value.block_hash.ok_or_else(|| anyhow::anyhow!("log must have block_hash"))?.into();
+
         Ok(Self {
-            transaction_hash: value.transaction_hash.expect("log must have transaction_hash").into(),
-            transaction_index: value.transaction_index.expect("log must have transaction_index").into(),
-            log_index: value.log_index.expect("log must have log_index").try_into()?,
-            block_number: value.block_number.expect("log must have block_number").into(),
-            block_hash: value.block_hash.expect("log must have block_hash").into(),
+            transaction_hash,
+            transaction_index,
+            log_index,
+            block_number,
+            block_hash,
             log: value.into(),
         })
     }

--- a/src/eth/storage/temporary/inmemory.rs
+++ b/src/eth/storage/temporary/inmemory.rs
@@ -209,7 +209,11 @@ impl TemporaryStorage for InMemoryTemporaryStorage {
         #[cfg(not(feature = "dev"))]
         let finished_block = {
             let latest = RwLockWriteGuard::<Option<InMemoryTemporaryStorageState>>::downgrade(latest);
-            latest.as_ref().expect("latest should be Some after finishing the pending block").block.clone()
+            latest
+                .as_ref()
+                .ok_or_else(|| anyhow::anyhow!("latest should be Some after finishing the pending block"))?
+                .block
+                .clone()
         };
 
         Ok(finished_block)

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -135,6 +135,7 @@ impl<T> InfallibleExt<T, serde_json::Error> for Result<T, serde_json::Error>
 where
     T: Sized,
 {
+    #[allow(clippy::expect_used)]
     fn expect_infallible(self) -> T {
         if let Err(ref e) = self {
             tracing::error!(reason = ?e, "expected infallible serde serialization/deserialization");
@@ -144,6 +145,7 @@ where
 }
 
 impl InfallibleExt<Decimal, ()> for Option<Decimal> {
+    #[allow(clippy::expect_used)]
     fn expect_infallible(self) -> Decimal {
         if self.is_none() {
             tracing::error!("expected infallible decimal conversion");
@@ -153,6 +155,7 @@ impl InfallibleExt<Decimal, ()> for Option<Decimal> {
 }
 
 impl InfallibleExt<DateTime<Utc>, ()> for Option<DateTime<Utc>> {
+    #[allow(clippy::expect_used)]
     fn expect_infallible(self) -> DateTime<Utc> {
         if self.is_none() {
             tracing::error!("expected infallible datetime conversion");
@@ -238,6 +241,7 @@ pub async fn traced_sleep(duration: Duration, _: SleepReason) {
 
 /// Spawns an async Tokio task with a name to be displayed in tokio-console.
 #[track_caller]
+#[allow(clippy::expect_used)]
 pub fn spawn_named<T>(name: &str, task: impl std::future::Future<Output = T> + Send + 'static) -> tokio::task::JoinHandle<T>
 where
     T: Send + 'static,
@@ -252,6 +256,7 @@ where
 
 /// Spawns a blocking Tokio task with a name to be displayed in tokio-console.
 #[track_caller]
+#[allow(clippy::expect_used)]
 pub fn spawn_blocking_named<T>(name: &str, task: impl FnOnce() -> T + Send + 'static) -> tokio::task::JoinHandle<T>
 where
     T: Send + 'static,
@@ -265,6 +270,7 @@ where
 }
 
 /// Spawns a thread with the given name. Thread has access to Tokio current runtime.
+#[allow(clippy::expect_used)]
 #[track_caller]
 pub fn spawn_thread<T>(name: &str, task: impl FnOnce() -> T + Send + 'static) -> std::thread::JoinHandle<T>
 where

--- a/src/globals.rs
+++ b/src/globals.rs
@@ -41,6 +41,7 @@ impl<T> GlobalServices<T>
 where
     T: clap::Parser + WithCommonConfig + Debug,
 {
+    #[allow(clippy::expect_used)]
     /// Executes global services initialization.
     pub fn init() -> Self
     where

--- a/src/infra/kafka/kafka.rs
+++ b/src/infra/kafka/kafka.rs
@@ -92,6 +92,7 @@ impl std::fmt::Display for KafkaSecurityProtocol {
 }
 
 impl KafkaConnector {
+    #[allow(clippy::expect_used)]
     pub fn new(config: &KafkaConfig) -> Result<Self> {
         tracing::info!(
             topic = %config.topic,


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Improved error handling across multiple modules by replacing `expect` and `panic` calls with more robust error handling mechanisms using `Result`, `ok_or_else`, and `anyhow!`.
- Added `#[allow(clippy::expect_used)]`, `#[allow(clippy::unwrap_used)]`, and `#[allow(clippy::panic)]` attributes to specific functions and modules where these operations are deemed necessary or safe.
- Refactored `parse_revm_execution` and `parse_revm_state` functions in the EVM executor to return `Result` types for better error propagation.
- Updated various primitive types and conversions to use `anyhow::Error` for more informative error messages.
- Replaced a `panic!` call with `todo!()` in the `Address` conversion from `NameOrAddress`.
- Made minor adjustments to improve code quality and maintainability across multiple files.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><details><summary>9 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>build.rs</strong><dd><code>Allow specific clippy lints in build script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

build.rs

<li>Added allow attributes for clippy lints: unwrap_used, expect_used, and <br>panic<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1933/files#diff-d0d98998092552a1d3259338c2c71e118a5b8343dd4703c0c7f552ada7f9cb42">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>postgres.rs</strong><dd><code>Allow panic lint in postgres module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/external_rpc/postgres.rs

- Added allow attribute for clippy::panic lint



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1933/files#diff-31cc1e306fa118997f1f04ed3603fd41c26624a702b6e45d569d5849c8f2a361">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>importer.rs</strong><dd><code>Allow expect usage in block fetching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/follower/importer/importer.rs

<li>Added allow attribute for clippy::expect_used lint in fetch_block <br>function<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1933/files#diff-bd50f502f039aff8f75753bc780d281ae7d7936fadc9d53482084c647aec94ca">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>miner.rs</strong><dd><code>Allow expect usage in miner ticker</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/miner/miner.rs

<li>Added allow attribute for clippy::expect_used lint in <br>interval_miner_ticker module<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1933/files#diff-16f448afc7dae3e8e802f676a86dbd7051e19f6c17cbbeb53eb730d726372629">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>external_block.rs</strong><dd><code>Allow expect usage in external block methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/external_block.rs

<li>Added allow attributes for clippy::expect_used lint in hash and number <br>methods<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1933/files#diff-a9f4dfb1768eeb5161bd375436af42b8fbb82726916dd9c4cc1e7a08edd54388">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>external_receipt.rs</strong><dd><code>Allow expect usage in external receipt methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/external_receipt.rs

<li>Added allow attributes for clippy::expect_used lint in block_number <br>and block_hash methods<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1933/files#diff-861198f134c8476294e25bf5d885dcf2229eeca24af73506e223ca2f0cc13dd5">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ext.rs</strong><dd><code>Allow expect usage in extension traits</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/ext.rs

<li>Added allow attributes for clippy::expect_used lint in various <br>implementations<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1933/files#diff-4ff673578dd06edb71da19750f05cb48bbbd3c78ded3dbeda59409354c35cef6">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>globals.rs</strong><dd><code>Allow expect usage in global services initialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/globals.rs

<li>Added allow attribute for clippy::expect_used lint in GlobalServices <br>implementation<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1933/files#diff-48d6fbc3a4ed67100952dcccfada858623c931e73d6de32984d4d1457e68d3a9">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>kafka.rs</strong><dd><code>Allow expect usage in Kafka connector creation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/infra/kafka/kafka.rs

<li>Added allow attribute for clippy::expect_used lint in <br>KafkaConnector::new method<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1933/files#diff-516e87c7aa8eb8e7908ce3727257a1f4ee49127c5e0e7dcd60fac65c3afcafef">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Error handling</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>evm.rs</strong><dd><code>Improve error handling in EVM execution parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/executor/evm.rs

<li>Modified parse_revm_execution to return Result instead of EvmExecution<br> <li> Changed parse_revm_state to return Result instead of ExecutionChanges<br> <li> Replaced panic with StratusError in parse_revm_state<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1933/files#diff-7fabd204a68cff51c55ee1391074463fa8ac005dc8ba443218bc83a9dda96658">+11/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>execution.rs</strong><dd><code>Improve error handling in execution primitives</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/execution.rs

<li>Replaced expect with ok_or_else and anyhow! for better error handling<br> <li> Modified error handling in EvmExecution implementation<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1933/files#diff-cd13932ed3cbc97c18547275105d872a204eda4ad4bf0c2811b18553b48e9038">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>log_mined.rs</strong><dd><code>Improve error handling in log conversion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/log_mined.rs

<li>Replaced expect calls with ok_or_else and anyhow! for better error <br>handling in TryFrom<EthersLog> implementation<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1933/files#diff-0ce210a69394a14d9a6424cf5ddf8b84c10a535b9ecae1dd34c0dbcff4beaf07">+14/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>inmemory.rs</strong><dd><code>Enhance error handling in temporary storage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/temporary/inmemory.rs

<li>Replaced expect with ok_or_else and anyhow! for better error handling <br>in TemporaryStorage implementation<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1933/files#diff-e51089a92c2c949c8c776644af3cf760132d61d63ff745d676a76041be8e06e9">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>address.rs</strong><dd><code>Replace panic with todo in address conversion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/address.rs

- Replaced panic with todo! in From<NameOrAddress> implementation for Address



</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1933/files#diff-43c180e22a2858040d18def981f15acd2fbe7f76fe1b59b76121e9aceeead96d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information