### PR TITLE
fix: stratus-test-coverage recipe shebang

### DIFF
--- a/justfile
+++ b/justfile
@@ -525,7 +525,7 @@ _coverage-run-stratus-recipe *recipe="":
     -rm -r e2e_logs
 
 stratus-test-coverage *args="":
-    #!/opt/homebrew/bin/bash
+    #!/bin/bash
     # setup
     cargo llvm-cov clean --workspace
     just build


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Modified the shebang in the `stratus-test-coverage` recipe from `#!/opt/homebrew/bin/bash` to `#!/bin/bash`
- This change improves portability by using the system's default Bash interpreter instead of a specific path
- Ensures the script can run on different systems without relying on Homebrew's Bash installation



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>justfile</strong><dd><code>Update shebang for broader compatibility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

justfile

<li>Changed shebang from <code>#!/opt/homebrew/bin/bash</code> to <code>#!/bin/bash</code> in the <br><code>stratus-test-coverage</code> recipe<br>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1934/files#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information