### PR TITLE
feat: derive error codes using the ErrorCode trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4968,6 +4968,7 @@ dependencies = [
  "smallvec",
  "sqlx",
  "static_assertions",
+ "stratus_macros",
  "strum",
  "sugars",
  "tempfile",
@@ -4985,6 +4986,15 @@ dependencies = [
  "triehash",
  "uuid",
  "vergen",
+]
+
+[[package]]
+name = "stratus_macros"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.76",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ quick_cache = "=0.6.9"
 sugars = "=3.0.1"
 thiserror = "=1.0.61"
 uuid = { version = "=1.10.0", features = ["v7"]}
+stratus_macros = { path = "./crates/stratus_macros" }
 
 # async
 tokio = { version = "=1.38.0", features = [

--- a/crates/stratus_macros/src/lib.rs
+++ b/crates/stratus_macros/src/lib.rs
@@ -1,6 +1,13 @@
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{parse_macro_input, DeriveInput, Data, Fields, Meta, Expr, ExprLit, Lit};
+use syn::parse_macro_input;
+use syn::Data;
+use syn::DeriveInput;
+use syn::Expr;
+use syn::ExprLit;
+use syn::Fields;
+use syn::Lit;
+use syn::Meta;
 
 #[proc_macro_derive(ErrorCode, attributes(error_code))]
 pub fn derive_error_code(input: TokenStream) -> TokenStream {
@@ -87,9 +94,10 @@ fn derive_error_code_impl(input: DeriveInput) -> proc_macro2::TokenStream {
 
 #[cfg(test)]
 mod tests {
-    use crate::derive_error_code_impl;
     use proc_macro2::TokenStream;
     use quote::quote;
+
+    use crate::derive_error_code_impl;
 
     #[test]
     fn test_derive_error_code() {

--- a/e2e/cloudwalk-contracts/integration/test/leader-follower-change.test.ts
+++ b/e2e/cloudwalk-contracts/integration/test/leader-follower-change.test.ts
@@ -49,7 +49,7 @@ describe("Leader & Follower change integration test", function () {
             "2s",
             "100ms",
         ]);
-        expect(response.data.error.code).to.equal(-32009);
+        expect(response.data.error.code).to.equal(7007);
         expect(response.data.error.message).to.equal("Can't change miner mode while transactions are enabled.");
     });
 
@@ -62,7 +62,7 @@ describe("Leader & Follower change integration test", function () {
             "2s",
             "100ms",
         ]);
-        expect(response.data.error.code).to.equal(-32603);
+        expect(response.data.error.code).to.equal(6002);
         expect(response.data.error.message.split("\n")[0]).to.equal(
             "Unexpected error: can't change miner mode from Interval without pausing it first",
         );
@@ -103,7 +103,7 @@ describe("Leader & Follower change integration test", function () {
     it("Change Follower to Leader with transactions enabled should fail", async function () {
         updateProviderUrl("stratus-follower");
         const response = await sendAndGetFullResponse("stratus_changeToLeader", []);
-        expect(response.data.error.code).to.equal(-32009);
+        expect(response.data.error.code).to.equal(7007);
         expect(response.data.error.message).to.equal("Can't change miner mode while transactions are enabled.");
     });
 
@@ -196,7 +196,7 @@ describe("Leader & Follower change integration test", function () {
         let successCount = 0;
         let semaphoreFailureCount = 0;
 
-        const SEMAPHORE_ERROR_CODE = -32009;
+        const SEMAPHORE_ERROR_CODE = 7005;
         const SEMAPHORE_ERROR_MESSAGE = "Stratus node is already in the process of changing mode.";
 
         allResponses.forEach((response, index) => {

--- a/e2e/cloudwalk-contracts/integration/test/leader-follower-health.test.ts
+++ b/e2e/cloudwalk-contracts/integration/test/leader-follower-health.test.ts
@@ -12,7 +12,7 @@ it("Test follower health is based on getting new blocks", async function () {
     await new Promise((resolve) => setTimeout(resolve, 5000));
 
     const unhealthyResponse = await sendAndGetFullResponse("stratus_health", []);
-    expect(unhealthyResponse.data.error.code).to.equal(-32009);
+    expect(unhealthyResponse.data.error.code).to.equal(7001);
     expect(unhealthyResponse.data.error.message).to.equal("Stratus is not ready to start servicing requests.");
 
     // Start the leader again

--- a/e2e/cloudwalk-contracts/integration/test/leader-follower-importer.test.ts
+++ b/e2e/cloudwalk-contracts/integration/test/leader-follower-importer.test.ts
@@ -33,7 +33,7 @@ describe("Leader & Follower importer integration test", function () {
     it("Shutdown command to Leader should fail", async function () {
         updateProviderUrl("stratus");
         const responseLeader = await sendAndGetFullResponse("stratus_shutdownImporter", []);
-        expect(responseLeader.data.error.code).eq(-32009);
+        expect(responseLeader.data.error.code).eq(7003);
         expect(responseLeader.data.error.message).eq("Stratus node is not a follower.");
     });
 
@@ -46,7 +46,7 @@ describe("Leader & Follower importer integration test", function () {
     it("Shutdown command to Follower when Importer is already shutdown should fail", async function () {
         updateProviderUrl("stratus-follower");
         const responseFollower = await sendAndGetFullResponse("stratus_shutdownImporter", []);
-        expect(responseFollower.data.error.code).to.equal(-32603);
+        expect(responseFollower.data.error.code).to.equal(4002);
         expect(responseFollower.data.error.message).to.equal("Importer is already shutdown.");
     });
 
@@ -56,7 +56,7 @@ describe("Leader & Follower importer integration test", function () {
         expect(followerNode.is_leader).to.equal(false);
         expect(followerNode.is_importer_shutdown).to.equal(true);
         const followerHealth = await sendAndGetFullResponse("stratus_health", []);
-        expect(followerHealth.data.error.code).eq(-32009);
+        expect(followerHealth.data.error.code).eq(7001);
         expect(followerHealth.data.error.message).eq("Stratus is not ready to start servicing requests.");
     });
 
@@ -97,7 +97,7 @@ describe("Leader & Follower importer integration test", function () {
         const nonce = parseInt(nonceResponse.data.result, 16);
         const signedTx = await BOB.signWeiTransfer(ALICE.address, 1, nonce);
         const txResponse = await sendAndGetFullResponse("eth_sendRawTransaction", [signedTx]);
-        expect(txResponse.data.error.code).to.equal(-32603);
+        expect(txResponse.data.error.code).to.equal(5001);
         expect(txResponse.data.error.message).to.equal("Consensus is temporarily unavailable for follower node.");
     });
 
@@ -109,14 +109,14 @@ describe("Leader & Follower importer integration test", function () {
             "2s",
             "100ms",
         ]);
-        expect(responseLeader.data.error.code).to.equal(-32009);
+        expect(responseLeader.data.error.code).to.equal(7003);
         expect(responseLeader.data.error.message).to.equal("Stratus node is not a follower.");
     });
 
     it("Init command to Follower without addresses should fail", async function () {
         updateProviderUrl("stratus-follower");
         const responseInvalidFollower = await sendAndGetFullResponse("stratus_initImporter", []);
-        expect(responseInvalidFollower.data.error.code).to.equal(-32602);
+        expect(responseInvalidFollower.data.error.code).to.equal(1005);
         expect(responseInvalidFollower.data.error.message).to.equal("Expected String parameter, but received nothing.");
     });
 
@@ -127,7 +127,7 @@ describe("Leader & Follower importer integration test", function () {
             "2s",
             "100ms",
         ]);
-        expect(responseInvalidAddressFollower.data.error.code).to.equal(-32603);
+        expect(responseInvalidAddressFollower.data.error.code).to.equal(4004);
         expect(responseInvalidAddressFollower.data.error.message).to.equal("Failed to initialize importer.");
     });
 
@@ -148,7 +148,7 @@ describe("Leader & Follower importer integration test", function () {
             "2s",
             "100ms",
         ]);
-        expect(responseSecondInitFollower.data.error.code).to.equal(-32603);
+        expect(responseSecondInitFollower.data.error.code).to.equal(4001);
         expect(responseSecondInitFollower.data.error.message).to.equal("Importer is already running.");
     });
 

--- a/e2e/cloudwalk-contracts/integration/test/leader-follower-miner.test.ts
+++ b/e2e/cloudwalk-contracts/integration/test/leader-follower-miner.test.ts
@@ -74,7 +74,7 @@ describe("Miner mode change integration test", function () {
     it("Miner change to Interval on Follower should fail because importer wasn't stopped", async function () {
         updateProviderUrl("stratus-follower");
         const response = await sendAndGetFullResponse("stratus_changeMinerMode", ["1s"]);
-        expect(response.data.error.code).eq(6002);
+        expect(response.data.error.code).eq(5002);
         expect(response.data.error.message).eq("Consensus is set.");
     });
 
@@ -167,7 +167,7 @@ describe("Miner mode change integration test", function () {
 
         // Change Miner mode to External on Leader with Pending Transactions should fail
         const changeMinerModeResponse = await sendAndGetFullResponse("stratus_changeMinerMode", ["external"]);
-        expect(changeMinerModeResponse.data.error.code).eq(6002);
+        expect(changeMinerModeResponse.data.error.code).eq(3006);
         expect(changeMinerModeResponse.data.error.message).eq("There are (1) pending transactions.");
 
         // Clean up

--- a/e2e/cloudwalk-contracts/integration/test/leader-follower-miner.test.ts
+++ b/e2e/cloudwalk-contracts/integration/test/leader-follower-miner.test.ts
@@ -35,14 +35,14 @@ describe("Miner mode change integration test", function () {
     it("Miner change to External on Leader should fail because transactions are enabled", async function () {
         updateProviderUrl("stratus");
         const response = await sendAndGetFullResponse("stratus_changeMinerMode", ["external"]);
-        expect(response.data.error.code).eq(-32009);
+        expect(response.data.error.code).eq(7007);
         expect(response.data.error.message).eq("Can't change miner mode while transactions are enabled.");
     });
 
     it("Miner change to Interval on Follower should fail because transactions are enabled", async function () {
         updateProviderUrl("stratus-follower");
         const response = await sendAndGetFullResponse("stratus_changeMinerMode", ["1s"]);
-        expect(response.data.error.code).eq(-32009);
+        expect(response.data.error.code).eq(7007);
         expect(response.data.error.message).eq("Can't change miner mode while transactions are enabled.");
     });
 
@@ -65,7 +65,7 @@ describe("Miner mode change integration test", function () {
     it("Miner change to External on Leader should fail because miner is enabled", async function () {
         updateProviderUrl("stratus");
         const response = await sendAndGetFullResponse("stratus_changeMinerMode", ["external"]);
-        expect(response.data.error.code).eq(-32603);
+        expect(response.data.error.code).eq(6002);
         expect(response.data.error.message.split("\n")[0]).to.equal(
             "Unexpected error: can't change miner mode from Interval without pausing it first",
         );
@@ -74,7 +74,7 @@ describe("Miner mode change integration test", function () {
     it("Miner change to Interval on Follower should fail because importer wasn't stopped", async function () {
         updateProviderUrl("stratus-follower");
         const response = await sendAndGetFullResponse("stratus_changeMinerMode", ["1s"]);
-        expect(response.data.error.code).eq(-32603);
+        expect(response.data.error.code).eq(6002);
         expect(response.data.error.message).eq("Consensus is set.");
     });
 
@@ -97,14 +97,14 @@ describe("Miner mode change integration test", function () {
     it("Miner change on Leader without params should fail", async function () {
         updateProviderUrl("stratus");
         const response = await sendAndGetFullResponse("stratus_changeMinerMode", []);
-        expect(response.data.error.code).eq(-32602);
+        expect(response.data.error.code).eq(1005);
         expect(response.data.error.message).eq("Expected String parameter, but received nothing.");
     });
 
     it("Miner change on Leader with invalid params should fail", async function () {
         updateProviderUrl("stratus");
         const response = await sendAndGetFullResponse("stratus_changeMinerMode", ["invalidMode"]);
-        expect(response.data.error.code).eq(-32602);
+        expect(response.data.error.code).eq(1009);
         expect(response.data.error.message).eq("Miner mode param is invalid.");
     });
 
@@ -123,7 +123,7 @@ describe("Miner mode change integration test", function () {
     it("Miner change on Leader to Automine should fail because it is not supported", async function () {
         updateProviderUrl("stratus");
         const response = await sendAndGetFullResponse("stratus_changeMinerMode", ["automine"]);
-        expect(response.data.error.code).eq(-32603);
+        expect(response.data.error.code).eq(6002);
         expect(response.data.error.message.split("\n")[0]).eq(
             "Unexpected error: Miner mode change to 'automine' is unsupported.",
         );
@@ -167,7 +167,7 @@ describe("Miner mode change integration test", function () {
 
         // Change Miner mode to External on Leader with Pending Transactions should fail
         const changeMinerModeResponse = await sendAndGetFullResponse("stratus_changeMinerMode", ["external"]);
-        expect(changeMinerModeResponse.data.error.code).eq(-32603);
+        expect(changeMinerModeResponse.data.error.code).eq(6002);
         expect(changeMinerModeResponse.data.error.message).eq("There are (1) pending transactions.");
 
         // Clean up

--- a/e2e/test/admin/e2e-admin-password-enabled.test.ts
+++ b/e2e/test/admin/e2e-admin-password-enabled.test.ts
@@ -9,14 +9,14 @@ describe("Admin Password (with password set)", () => {
 
     it("should reject requests without password", async () => {
         const error = await sendAndGetError("stratus_enableTransactions", []);
-        expect(error.code).eq(-32009); // Internal error
+        expect(error.code).eq(7004); // Internal error
         expect(error.message).to.contain("Incorrect password");
     });
 
     it("should reject requests with wrong password", async () => {
         const headers = { Authorization: "Password wrong123" };
         const error = await sendAndGetError("stratus_enableTransactions", [], headers);
-        expect(error.code).eq(-32009); // Internal error
+        expect(error.code).eq(7004); // Internal error
         expect(error.message).to.contain("Incorrect password");
     });
 

--- a/e2e/test/automine/e2e-json-rpc.test.ts
+++ b/e2e/test/automine/e2e-json-rpc.test.ts
@@ -325,7 +325,7 @@ describe("JSON-RPC", () => {
             it("fails on HTTP", async () => {
                 const error = await sendAndGetError("eth_subscribe", ["newHeads"]);
                 expect(error).to.not.be.null;
-                expect(error.code).eq(6002); // Internal error
+                expect(error.code).eq(-32603); // Internal error
             });
             it("subscribes to newHeads receives success subscription event", async () => {
                 const waitTimeInMilliseconds = 40;

--- a/e2e/test/automine/e2e-json-rpc.test.ts
+++ b/e2e/test/automine/e2e-json-rpc.test.ts
@@ -325,7 +325,7 @@ describe("JSON-RPC", () => {
             it("fails on HTTP", async () => {
                 const error = await sendAndGetError("eth_subscribe", ["newHeads"]);
                 expect(error).to.not.be.null;
-                expect(error.code).eq(-32603); // Internal error
+                expect(error.code).eq(6002); // Internal error
             });
             it("subscribes to newHeads receives success subscription event", async () => {
                 const waitTimeInMilliseconds = 40;
@@ -359,7 +359,7 @@ describe("JSON-RPC", () => {
                 expect(response.error).to.not.be.undefined;
                 expect(response.error.code).to.not.be.undefined;
                 expect(response.error.code).to.be.a("number");
-                expect(response.error.code).eq(-32602);
+                expect(response.error.code).eq(1006);
             });
 
             it("validates newHeads event", async () => {

--- a/e2e/test/external/e2e-json-rpc.test.ts
+++ b/e2e/test/external/e2e-json-rpc.test.ts
@@ -483,7 +483,7 @@ describe("JSON-RPC", () => {
             it("fails on HTTP", async () => {
                 const error = await sendAndGetError("eth_subscribe", ["newHeads"]);
                 expect(error).to.not.be.null;
-                expect(error.code).eq(-32603); // Internal error
+                expect(error.code).eq(6002); // Internal error
             });
             it("subscribes to newHeads receives success subscription event", async () => {
                 const waitTimeInMilliseconds = 40;
@@ -517,7 +517,7 @@ describe("JSON-RPC", () => {
                 expect(response.error).to.not.be.undefined;
                 expect(response.error.code).to.not.be.undefined;
                 expect(response.error.code).to.be.a("number");
-                expect(response.error.code).eq(-32602);
+                expect(response.error.code).eq(1006);
             });
 
             it("validates newHeads event", async () => {

--- a/e2e/test/external/e2e-json-rpc.test.ts
+++ b/e2e/test/external/e2e-json-rpc.test.ts
@@ -483,7 +483,7 @@ describe("JSON-RPC", () => {
             it("fails on HTTP", async () => {
                 const error = await sendAndGetError("eth_subscribe", ["newHeads"]);
                 expect(error).to.not.be.null;
-                expect(error.code).eq(6002); // Internal error
+                expect(error.code).eq(-32603); // Internal error
             });
             it("subscribes to newHeads receives success subscription event", async () => {
                 const waitTimeInMilliseconds = 40;

--- a/src/eth/follower/importer/importer.rs
+++ b/src/eth/follower/importer/importer.rs
@@ -342,21 +342,18 @@ impl Importer {
                         set_external_rpc_current_block(block.number());
                         continue;
                     }
-                    Ok(None) => {
+                    Ok(None) =>
                         if !Self::should_shutdown(TASK_NAME) {
                             tracing::error!("{} newHeads subscription closed by the other side", TASK_NAME);
-                        }
-                    }
-                    Ok(Some(Err(e))) => {
+                        },
+                    Ok(Some(Err(e))) =>
                         if !Self::should_shutdown(TASK_NAME) {
                             tracing::error!(reason = ?e, "{} failed to read newHeads subscription event", TASK_NAME);
-                        }
-                    }
-                    Err(_) => {
+                        },
+                    Err(_) =>
                         if !Self::should_shutdown(TASK_NAME) {
                             tracing::error!("{} timed-out waiting for newHeads subscription event", TASK_NAME);
-                        }
-                    }
+                        },
                 }
 
                 if Self::should_shutdown(TASK_NAME) {
@@ -372,11 +369,10 @@ impl Importer {
                             tracing::info!("{} resubscribed to newHeads event", TASK_NAME);
                             sub_new_heads = Some(sub);
                         }
-                        Err(e) => {
+                        Err(e) =>
                             if !Self::should_shutdown(TASK_NAME) {
                                 tracing::error!(reason = ?e, "{} failed to resubscribe to newHeads event", TASK_NAME);
-                            }
-                        }
+                            },
                     }
                 }
             }
@@ -397,11 +393,10 @@ impl Importer {
                     set_external_rpc_current_block(block_number);
                     traced_sleep(sync_interval, SleepReason::SyncData).await;
                 }
-                Err(e) => {
+                Err(e) =>
                     if !Self::should_shutdown(TASK_NAME) {
                         tracing::error!(reason = ?e, "failed to retrieve block number. retrying now.");
-                    }
-                }
+                    },
             }
         }
     }

--- a/src/eth/follower/importer/importer.rs
+++ b/src/eth/follower/importer/importer.rs
@@ -229,11 +229,7 @@ impl Importer {
                     };
 
                     if let Err(e) = executor.execute_local_transaction(tx_input) {
-                        if e.is_internal() {
-                            tracing::error!(reason = ?e, "internal error while executing imported transaction");
-                        } else {
-                            tracing::error!(reason = ?e, "transaction failed");
-                        }
+                        tracing::error!(reason = ?e, "transaction failed");
                     }
                 }
 
@@ -346,18 +342,21 @@ impl Importer {
                         set_external_rpc_current_block(block.number());
                         continue;
                     }
-                    Ok(None) =>
+                    Ok(None) => {
                         if !Self::should_shutdown(TASK_NAME) {
                             tracing::error!("{} newHeads subscription closed by the other side", TASK_NAME);
-                        },
-                    Ok(Some(Err(e))) =>
+                        }
+                    }
+                    Ok(Some(Err(e))) => {
                         if !Self::should_shutdown(TASK_NAME) {
                             tracing::error!(reason = ?e, "{} failed to read newHeads subscription event", TASK_NAME);
-                        },
-                    Err(_) =>
+                        }
+                    }
+                    Err(_) => {
                         if !Self::should_shutdown(TASK_NAME) {
                             tracing::error!("{} timed-out waiting for newHeads subscription event", TASK_NAME);
-                        },
+                        }
+                    }
                 }
 
                 if Self::should_shutdown(TASK_NAME) {
@@ -373,10 +372,11 @@ impl Importer {
                             tracing::info!("{} resubscribed to newHeads event", TASK_NAME);
                             sub_new_heads = Some(sub);
                         }
-                        Err(e) =>
+                        Err(e) => {
                             if !Self::should_shutdown(TASK_NAME) {
                                 tracing::error!(reason = ?e, "{} failed to resubscribe to newHeads event", TASK_NAME);
-                            },
+                            }
+                        }
                     }
                 }
             }
@@ -397,10 +397,11 @@ impl Importer {
                     set_external_rpc_current_block(block_number);
                     traced_sleep(sync_interval, SleepReason::SyncData).await;
                 }
-                Err(e) =>
+                Err(e) => {
                     if !Self::should_shutdown(TASK_NAME) {
                         tracing::error!(reason = ?e, "failed to retrieve block number. retrying now.");
-                    },
+                    }
+                }
             }
         }
     }

--- a/src/eth/rpc/rpc_server.rs
+++ b/src/eth/rpc/rpc_server.rs
@@ -852,9 +852,7 @@ fn eth_estimate_gas(params: Params<'_>, ctx: Arc<RpcContext>, ext: &Extensions) 
 
         // internal error
         Err(e) => {
-            if e.is_internal() {
-                tracing::error!(reason = ?e, "failed to execute eth_estimateGas");
-            }
+            tracing::warn!(reason = ?e, "failed to execute eth_estimateGas");
             Err(e)
         }
     }
@@ -894,9 +892,7 @@ fn eth_call(params: Params<'_>, ctx: Arc<RpcContext>, ext: &Extensions) -> Resul
 
         // internal error
         Err(e) => {
-            if e.is_internal() {
-                tracing::error!(reason = ?e, "failed to execute eth_call");
-            }
+            tracing::warn!(reason = ?e, "failed to execute eth_call");
             Err(e)
         }
     }
@@ -937,9 +933,7 @@ fn eth_send_raw_transaction(params: Params<'_>, ctx: Arc<RpcContext>, ext: &Exte
         NodeMode::Leader | NodeMode::FakeLeader => match ctx.executor.execute_local_transaction(tx) {
             Ok(_) => Ok(hex_data(tx_hash)),
             Err(e) => {
-                if e.is_internal() {
-                    tracing::error!(reason = ?e, "failed to execute eth_sendRawTransaction");
-                }
+                tracing::warn!(reason = ?e, "failed to execute eth_sendRawTransaction");
                 Err(e)
             }
         },


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Derive error codes using ErrorCode trait

- Refactor error handling and logging

- Update error codes in e2e tests

- Improve code organization and imports


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>lib.rs</strong><dd><code>Implement ErrorCode derive macro</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1938/files#diff-aa54e2be264adf5d6c46d60aae8c43a6e73f438bbd1425de7653afb7e907ba1c">+10/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>stratus_error.rs</strong><dd><code>Implement ErrorCode trait for StratusError</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1938/files#diff-301cded01d772388e3e5c08ede093b91c3e4478c08e11a48f70e3d44351385fb">+74/-78</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Error handling</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>importer.rs</strong><dd><code>Refactor error handling in Importer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1938/files#diff-bd50f502f039aff8f75753bc780d281ae7d7936fadc9d53482084c647aec94ca">+16/-15</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>rpc_server.rs</strong><dd><code>Update error logging in RPC server</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1938/files#diff-835ba255c9a5c1fe0e13285bc39e058e1c74422e5e03ebba483c9d8a15c45405">+3/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>leader-follower-change.test.ts</strong><dd><code>Update error codes in leader-follower tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1938/files#diff-7236d4b676b75ced96eb321337290326efe4e91a261edc4e83b688c4da09dd7c">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>leader-follower-health.test.ts</strong><dd><code>Update error codes in health tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1938/files#diff-9d7eb44a4a7217dd3b8075ccec746e8c6ff4873124a29aa4e75555044cd481d1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>leader-follower-importer.test.ts</strong><dd><code>Update error codes in importer tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1938/files#diff-76e205db03980cadded8f3f9ff7be76d1f3d3af18d4d8bf2cc8fa09d74934b8d">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>leader-follower-miner.test.ts</strong><dd><code>Update error codes in miner tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1938/files#diff-4b1c5fc9f33c8088178dffe2234e70df03667bf90fa3a5663fd17c3dabfe13a5">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>e2e-admin-password-enabled.test.ts</strong><dd><code>Update error codes in admin password tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1938/files#diff-f5eb3e0fddaf4dfb49740a21d95efc9f96e200ebe53e2783aa29e6a357b94226">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>e2e-json-rpc.test.ts</strong><dd><code>Update error codes in JSON-RPC tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1938/files#diff-3d74b20bca5732bd9d71f766b668d339a52e53e6b7fd18ff8f9000c077184439">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>e2e-json-rpc.test.ts</strong><dd><code>Update error codes in external JSON-RPC tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1938/files#diff-f5d1f06c4777826f9cbdcb4372d15c42f354177c83df65f3324cfd607da16004">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>Cargo.toml</strong><dd><code>Add stratus_macros dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1938/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information