### PR TITLE
enha: reject unknown clients in the middleware

### DIFF
--- a/e2e/hardhat.config.ts
+++ b/e2e/hardhat.config.ts
@@ -57,7 +57,7 @@ const config: HardhatUserConfig = {
             },
         },
         stratus: {
-            url: `http://localhost:${STRATUS_PORT}?app=e2e`,
+            url: `http://localhost:${STRATUS_PORT}`,
             accounts: {
                 mnemonic: ACCOUNTS_MNEMONIC,
             },

--- a/e2e/test/automine/e2e-json-rpc.test.ts
+++ b/e2e/test/automine/e2e-json-rpc.test.ts
@@ -1,6 +1,7 @@
 import { expect } from "chai";
 import { keccak256 } from "ethers";
-import { Block, Bytes, TransactionReceipt } from "web3-types";
+import { JsonRpcProvider } from "ethers";
+import { Block, Bytes } from "web3-types";
 
 import { ALICE, BOB } from "../helpers/account";
 import { isStratus } from "../helpers/network";
@@ -36,6 +37,64 @@ describe("JSON-RPC", () => {
             } else {
                 (await sendExpect("hardhat_reset")).eq(true);
             }
+        });
+    });
+
+    describe("Unknown Clients", () => {
+        before(async () => {
+            if (isStratus) {
+                // Ensure clean state
+                await send("stratus_enableUnknownClients");
+            }
+        });
+
+        it("disabling unknown clients blocks requests without client identification", async function () {
+            if (!isStratus) {
+                this.skip();
+                return;
+            }
+
+            await send("stratus_disableUnknownClients");
+
+            // Request without client identification should fail
+            const error = await sendAndGetError("eth_blockNumber");
+            expect(error.code).eq(1003);
+
+            // Requests with client identification should succeed
+            const validHeaders = {
+                "x-app": "test-client",
+                "x-stratus-app": "test-client",
+                "x-client": "test-client",
+                "x-stratus-client": "test-client",
+            };
+
+            for (const [header, value] of Object.entries(validHeaders)) {
+                const headers = { [header]: value };
+                const result = await send("eth_blockNumber", [], headers);
+                expect(result).to.match(/^0x[0-9a-f]+$/);
+            }
+
+            // URL parameters should also work
+            const validUrlParams = ["app=test-client", "client=test-client"];
+            for (const param of validUrlParams) {
+                const providerWithParam = new JsonRpcProvider(`http://localhost:3000?${param}`);
+                const blockNumber = await providerWithParam.getBlockNumber();
+                expect(blockNumber).to.be.a("number");
+            }
+        });
+
+        it("enabling unknown clients allows all requests", async function () {
+            if (!isStratus) {
+                this.skip();
+                return;
+            }
+
+            await send("stratus_disableUnknownClients");
+            await send("stratus_enableUnknownClients");
+
+            // Request without client identification should now succeed
+            const blockNumber = await send("eth_blockNumber");
+            expect(blockNumber).to.match(/^0x[0-9a-f]+$/);
         });
     });
 
@@ -291,7 +350,7 @@ describe("JSON-RPC", () => {
 
                 // Record timestamp in contract
                 const tx = await contract.recordTimestamp();
-                const receipt = await tx.wait();
+                const receipt: TransactionReceipt = await tx.wait();
 
                 // Get the timestamp from contract event
                 const event = receipt.logs[0];

--- a/justfile
+++ b/justfile
@@ -201,7 +201,7 @@ e2e-stratus block-mode="automine" test="":
     just build
 
     just _log "Starting Stratus"
-    just run -a 0.0.0.0:3000 --block-mode {{block-mode}} > stratus.log &
+    RUST_LOG=debug just run -a 0.0.0.0:3000 --block-mode {{block-mode}} > stratus.log &
 
     just _wait_for_stratus
 

--- a/src/eth/primitives/stratus_error.rs
+++ b/src/eth/primitives/stratus_error.rs
@@ -1,4 +1,9 @@
+use futures::future::BoxFuture;
+use jsonrpsee::server::middleware::rpc::layer::ResponseFuture;
 use jsonrpsee::types::ErrorObjectOwned;
+use jsonrpsee::types::Id;
+use jsonrpsee::MethodResponse;
+use jsonrpsee::ResponsePayload;
 use stratus_macros::ErrorCode;
 
 use crate::alias::JsonValue;
@@ -270,6 +275,12 @@ impl StratusError {
 
             _ => JsonValue::Null,
         }
+    }
+
+    pub fn to_response_future<'a>(self, id: Id<'_>) -> ResponseFuture<BoxFuture<'a, MethodResponse>> {
+        let response = ResponsePayload::<()>::error(StratusError::RPC(RpcError::ClientMissing));
+        let method_response = MethodResponse::response(id, response, u32::MAX as usize);
+        ResponseFuture::ready(method_response)
     }
 }
 

--- a/src/eth/rpc/mod.rs
+++ b/src/eth/rpc/mod.rs
@@ -18,6 +18,5 @@ use rpc_middleware::RpcMiddleware;
 use rpc_parser::next_rpc_param;
 use rpc_parser::next_rpc_param_or_default;
 use rpc_parser::parse_rpc_rlp;
-use rpc_server::reject_unknown_client;
 pub use rpc_server::serve_rpc;
 pub use rpc_subscriptions::RpcSubscriptions;

--- a/src/eth/rpc/rpc_method_wrapper.rs
+++ b/src/eth/rpc/rpc_method_wrapper.rs
@@ -5,7 +5,6 @@ use jsonrpsee::types::Params;
 use jsonrpsee::Extensions;
 
 use crate::eth::primitives::StratusError;
-use crate::eth::rpc::reject_unknown_client;
 use crate::eth::rpc::rpc_parser::RpcExtensionsExt;
 use crate::eth::rpc::RpcContext;
 
@@ -24,7 +23,6 @@ cfg_if! {
             F: Fn(Params<'_>, Arc<RpcContext>, &Extensions) -> Result<T, StratusError> + Clone,
         {
             move |params, ctx, extensions| {
-                reject_unknown_client(extensions.rpc_client())?;
                 function(params, ctx, &extensions).inspect_err(|e| metrify_stratus_error(e, &extensions, method_name))
             }
         }
@@ -34,7 +32,6 @@ cfg_if! {
             F: Fn(Params<'_>, Arc<RpcContext>, &Extensions) -> Result<T, StratusError> + Clone,
         {
             move |params, ctx, extensions| {
-                reject_unknown_client(extensions.rpc_client())?;
                 function(params, ctx, &extensions)
             }
         }

--- a/src/eth/rpc/rpc_middleware.rs
+++ b/src/eth/rpc/rpc_middleware.rs
@@ -11,6 +11,7 @@ use jsonrpsee::server::middleware::rpc::RpcServiceT;
 #[cfg(feature = "metrics")]
 use jsonrpsee::server::ConnectionGuard;
 use jsonrpsee::types::error::INTERNAL_ERROR_CODE;
+use jsonrpsee::types::Id;
 use jsonrpsee::types::Params;
 use jsonrpsee::MethodResponse;
 use pin_project::pin_project;
@@ -28,6 +29,8 @@ use crate::eth::primitives::Bytes;
 use crate::eth::primitives::CallInput;
 use crate::eth::primitives::Hash;
 use crate::eth::primitives::Nonce;
+use crate::eth::primitives::RpcError;
+use crate::eth::primitives::StratusError;
 use crate::eth::primitives::TransactionInput;
 use crate::eth::rpc::next_rpc_param;
 use crate::eth::rpc::parse_rpc_rlp;
@@ -42,6 +45,7 @@ use crate::infra::metrics;
 use crate::infra::tracing::new_cid;
 use crate::infra::tracing::SpanExt;
 use crate::infra::tracing::TracingExt;
+use crate::GlobalState;
 
 // -----------------------------------------------------------------------------
 // Request handling
@@ -139,15 +143,25 @@ impl<'a> RpcServiceT<'a> for RpcMiddleware {
         drop(middleware_enter);
         request.extensions_mut().insert(span);
 
+        let id = request.id.to_string();
+        let future_response = reject_unknown_client(&client, request.id.clone()).unwrap_or(self.service.call(request));
         RpcResponse {
             client,
-            id: request.id.to_string(),
+            id,
             method: method.to_string(),
             tx,
             start: Instant::now(),
-            future_response: self.service.call(request),
+            future_response,
         }
     }
+}
+
+/// Returns an error JSON-RPC response if the client is not allowed to perform the current operation.
+fn reject_unknown_client<'a>(client: &RpcClientApp, id: Id<'_>) -> Option<ResponseFuture<BoxFuture<'a, MethodResponse>>> {
+    if client.is_unknown() && !GlobalState::is_unknown_client_enabled() {
+        return Some(StratusError::RPC(RpcError::ClientMissing).to_response_future(id));
+    }
+    None
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
### **User description**
This is the first step towards removing the method wrapper.


___

### **PR Type**
Enhancement


___

### **Description**
- Reject unknown clients in middleware

- Remove method wrapper for client rejection

- Implement client identification via headers/URL

- Update E2E tests for unknown client handling


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>stratus_error.rs</strong><dd><code>Add response future conversion for StratusError</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/stratus_error.rs

<li>Added imports for futures and jsonrpsee<br> <li> Implemented <code>to_response_future</code> method for StratusError


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1939/files#diff-301cded01d772388e3e5c08ede093b91c3e4478c08e11a48f70e3d44351385fb">+11/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>rpc_method_wrapper.rs</strong><dd><code>Remove client rejection from metrics wrapper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/rpc/rpc_method_wrapper.rs

- Removed `reject_unknown_client` call from metrics wrapper


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1939/files#diff-0bbd6e729eb4e018401d1475a5dd64871ecb654be7b3d125c48c204fbddc9545">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>rpc_middleware.rs</strong><dd><code>Implement client rejection in RPC middleware</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/rpc/rpc_middleware.rs

<li>Implemented <code>reject_unknown_client</code> function in middleware<br> <li> Updated <code>call</code> method to use new rejection logic


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1939/files#diff-31b7182aec4416845e60ec9ec16720ae97d31260e1a9c50d601d542dee8776f5">+16/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>rpc_server.rs</strong><dd><code>Remove client rejection from RPC server methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/rpc/rpc_server.rs

<li>Removed <code>reject_unknown_client</code> function and its usage<br> <li> Removed client rejection from <code>stratus_get_subscriptions</code> and <br><code>eth_subscribe</code>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1939/files#diff-835ba255c9a5c1fe0e13285bc39e058e1c74422e5e03ebba483c9d8a15c45405">+1/-18</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Remove unused import for client rejection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/rpc/mod.rs

- Removed import of `reject_unknown_client` function


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1939/files#diff-0a0c2af8f16ac3beb803893d128781f7a3a203e12dcd6738e7ac439cd78493cd">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>hardhat.config.ts</strong><dd><code>Update Stratus URL in Hardhat config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

e2e/hardhat.config.ts

- Removed `?app=e2e` from Stratus URL in config


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1939/files#diff-3e084564f2c060c8fb691130bd011c22ac7469b6e534fb27ec1edc12c9fc7dae">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>justfile</strong><dd><code>Enable debug logging for Stratus in E2E tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

justfile

- Added RUST_LOG=debug to Stratus startup command


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1939/files#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>e2e-json-rpc.test.ts</strong><dd><code>Add E2E tests for unknown client handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

e2e/test/automine/e2e-json-rpc.test.ts

<li>Added new tests for unknown client handling<br> <li> Implemented tests for enabling/disabling unknown clients<br> <li> Added checks for various client identification methods


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1939/files#diff-3d74b20bca5732bd9d71f766b668d339a52e53e6b7fd18ff8f9000c077184439">+61/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information