### PR TITLE
enha: add major_error_code attribute to the ErrorCode derive macro

### DIFF
--- a/crates/stratus_macros/src/lib.rs
+++ b/crates/stratus_macros/src/lib.rs
@@ -23,23 +23,23 @@ fn derive_error_code_impl(input: DeriveInput) -> proc_macro2::TokenStream {
     };
 
     let mut match_arms = Vec::new();
-        // Get the major error code if specified
-        let major_error_code = input
-            .attrs
-            .iter()
-            .find(|attr| attr.path().is_ident("major_error_code"))
-            .and_then(|attr| {
-                if let Meta::NameValue(meta) = &attr.meta {
-                    if let Expr::Lit(ExprLit { lit: Lit::Int(lit_int), .. }) = &meta.value {
-                        lit_int.base10_parse::<i32>().ok()
-                    } else {
-                        None
-                    }
+    // Get the major error code if specified
+    let major_error_code = input
+        .attrs
+        .iter()
+        .find(|attr| attr.path().is_ident("major_error_code"))
+        .and_then(|attr| {
+            if let Meta::NameValue(meta) = &attr.meta {
+                if let Expr::Lit(ExprLit { lit: Lit::Int(lit_int), .. }) = &meta.value {
+                    lit_int.base10_parse::<i32>().ok()
                 } else {
                     None
                 }
-            })
-            .unwrap_or(0);
+            } else {
+                None
+            }
+        })
+        .unwrap_or(0);
     let mut reverse_match_arms = Vec::new();
 
     // Process each variant
@@ -62,7 +62,8 @@ fn derive_error_code_impl(input: DeriveInput) -> proc_macro2::TokenStream {
                     None
                 }
             })
-            .expect(&format!("Missing error_code attribute for variant {}", variant_name)) + major_error_code;
+            .expect(&format!("Missing error_code attribute for variant {}", variant_name))
+            + major_error_code;
 
         // Handle different field types
         match &variant.fields {

--- a/crates/stratus_macros/src/lib.rs
+++ b/crates/stratus_macros/src/lib.rs
@@ -23,6 +23,23 @@ fn derive_error_code_impl(input: DeriveInput) -> proc_macro2::TokenStream {
     };
 
     let mut match_arms = Vec::new();
+        // Get the major error code if specified
+        let major_error_code = input
+            .attrs
+            .iter()
+            .find(|attr| attr.path().is_ident("major_error_code"))
+            .and_then(|attr| {
+                if let Meta::NameValue(meta) = &attr.meta {
+                    if let Expr::Lit(ExprLit { lit: Lit::Int(lit_int), .. }) = &meta.value {
+                        lit_int.base10_parse::<i32>().ok()
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            })
+            .unwrap_or(0);
     let mut reverse_match_arms = Vec::new();
 
     // Process each variant
@@ -45,7 +62,7 @@ fn derive_error_code_impl(input: DeriveInput) -> proc_macro2::TokenStream {
                     None
                 }
             })
-            .expect(&format!("Missing error_code attribute for variant {}", variant_name));
+            .expect(&format!("Missing error_code attribute for variant {}", variant_name)) + major_error_code;
 
         // Handle different field types
         match &variant.fields {
@@ -103,6 +120,7 @@ mod tests {
     fn test_derive_error_code() {
         let input = TokenStream::from(quote! {
             #[derive(ErrorCode)]
+            #[major_error_code = 100]
             pub enum TestError {
                 #[error_code = 3]
                 First,
@@ -119,17 +137,17 @@ mod tests {
             impl ErrorCode for TestError {
                 fn error_code(&self) -> i32 {
                     match self {
-                        TestError::First => 3i32,
-                        TestError::Second { .. } => 4i32,
-                        TestError::Third(..) => 0i32
+                        TestError::First => 103i32,
+                        TestError::Second { .. } => 104i32,
+                        TestError::Third(..) => 100i32
                     }
                 }
 
                 fn str_repr_from_err_code(code: i32) -> &'static str {
                     match code {
-                        3i32 => stringify ! (First),
-                        4i32 => stringify ! (Second),
-                        0i32 => stringify ! (Third),
+                        103i32 => stringify ! (First),
+                        104i32 => stringify ! (Second),
+                        100i32 => stringify ! (Third),
                         _ => "Unknown"
                     }
                 }


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add major_error_code attribute to ErrorCode derive macro

- Implement major error code offset for enum variants

- Update error code calculation in derive implementation

- Adjust test case to include major error code


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Implement major error code attribute for ErrorCode derive macro</code></dd></summary>
<hr>

crates/stratus_macros/src/lib.rs

<li>Added major_error_code attribute parsing<br> <li> Implemented major error code offset for enum variants<br> <li> Updated error code calculation in derive implementation<br> <li> Adjusted test case to include major error code attribute


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1941/files#diff-aa54e2be264adf5d6c46d60aae8c43a6e73f438bbd1425de7653afb7e907ba1c">+25/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information