### PR TITLE
enha: include error signature in logs when transactions revert

### DIFF
--- a/e2e/contracts/TestRevertReason.sol
+++ b/e2e/contracts/TestRevertReason.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract TestRevertReason {
+    error KnownError();
+    error UnknownError();
+
+    function revertWithKnownError() public pure {
+        revert KnownError();
+    }
+
+    function revertWithUnknownError() public pure {
+        revert UnknownError();
+    }
+
+    function revertWithString() public pure {
+        revert("Custom error message");
+    }
+}

--- a/e2e/test/helpers/rpc.ts
+++ b/e2e/test/helpers/rpc.ts
@@ -201,6 +201,13 @@ export async function deployTestContractDenseStorage(): Promise<TestContractDens
     return await testContractFactory.connect(CHARLIE.signer()).deploy();
 }
 
+// Deploys the "TestRevertReason" contract.
+export async function deployTestRevertReason() {
+    const testContractFactory = await ethers.getContractFactory("TestRevertReason");
+    return await testContractFactory.connect(CHARLIE.signer()).deploy();
+}
+
+
 // Converts a number to Blockchain hex representation (prefixed with 0x).
 export function toHex(number: number | bigint): string {
     return "0x" + number.toString(16);

--- a/e2e/test/helpers/rpc.ts
+++ b/e2e/test/helpers/rpc.ts
@@ -207,7 +207,6 @@ export async function deployTestRevertReason() {
     return await testContractFactory.connect(CHARLIE.signer()).deploy();
 }
 
-
 // Converts a number to Blockchain hex representation (prefixed with 0x).
 export function toHex(number: number | bigint): string {
     return "0x" + number.toString(16);

--- a/src/eth/codegen.rs
+++ b/src/eth/codegen.rs
@@ -21,9 +21,16 @@ pub fn contract_name_for_o11y(address: &Option<Address>) -> ContractName {
 
 /// Returns the function name to be used in observability tasks.
 pub fn function_sig_for_o11y(bytes: impl AsRef<[u8]>) -> SoliditySignature {
-    let Some(id) = bytes.as_ref().get(..4) else { return metrics::LABEL_MISSING };
-    match SIGNATURES_4_BYTES.get(id) {
+    match function_sig_for_o11y_opt(bytes) {
         Some(signature) => signature,
         None => metrics::LABEL_UNKNOWN,
     }
+}
+
+/// Returns the function name to be used in observability tasks.
+pub fn function_sig_for_o11y_opt(bytes: impl AsRef<[u8]>) -> Option<SoliditySignature> {
+    let Some(id) = bytes.as_ref().get(..4) else {
+        return Some(metrics::LABEL_MISSING);
+    };
+    SIGNATURES_4_BYTES.get(id).copied()
 }

--- a/src/eth/codegen.rs
+++ b/src/eth/codegen.rs
@@ -1,5 +1,7 @@
 //! Auto-generated code.
 
+use std::borrow::Cow;
+
 use crate::eth::primitives::Address;
 use crate::infra::metrics;
 
@@ -11,7 +13,7 @@ pub type SoliditySignature = &'static str;
 pub type ContractName = &'static str;
 
 /// Returns the contract name to be used in observability tasks.
-pub fn contract_name_for_o11y(address: &Option<Address>) -> ContractName {
+pub fn contract_name(address: &Option<Address>) -> ContractName {
     let Some(address) = address else { return metrics::LABEL_MISSING };
     match CONTRACTS.get(address.as_bytes()) {
         Some(contract_name) => contract_name,
@@ -20,17 +22,36 @@ pub fn contract_name_for_o11y(address: &Option<Address>) -> ContractName {
 }
 
 /// Returns the function name to be used in observability tasks.
-pub fn function_sig_for_o11y(bytes: impl AsRef<[u8]>) -> SoliditySignature {
-    match function_sig_for_o11y_opt(bytes) {
+pub fn function_sig(bytes: impl AsRef<[u8]>) -> SoliditySignature {
+    match function_sig_opt(bytes) {
         Some(signature) => signature,
         None => metrics::LABEL_UNKNOWN,
     }
 }
 
 /// Returns the function name to be used in observability tasks.
-pub fn function_sig_for_o11y_opt(bytes: impl AsRef<[u8]>) -> Option<SoliditySignature> {
+pub fn function_sig_opt(bytes: impl AsRef<[u8]>) -> Option<SoliditySignature> {
     let Some(id) = bytes.as_ref().get(..4) else {
         return Some(metrics::LABEL_MISSING);
     };
     SIGNATURES_4_BYTES.get(id).copied()
+}
+
+/// Returns the error name or string.
+pub fn error_sig_opt(bytes: impl AsRef<[u8]>) -> Option<Cow<'static, str>> {
+    bytes
+        .as_ref()
+        .get(..4)
+        .and_then(|id| SIGNATURES_4_BYTES.get(id))
+        .copied()
+        .map(Cow::Borrowed)
+        .or_else(|| {
+            bytes.as_ref().get(4..).and_then(|bytes| {
+                ethabi::decode(&[ethabi::ParamType::String], bytes)
+                    .ok()
+                    .and_then(|res| res.first().cloned())
+                    .and_then(|token| token.into_string())
+                    .map(Cow::Owned)
+            })
+        })
 }

--- a/src/eth/executor/evm.rs
+++ b/src/eth/executor/evm.rs
@@ -338,8 +338,8 @@ fn parse_revm_result(result: RevmExecutionResult) -> (ExecutionResult, Bytes, Ve
             (result, output, logs, gas)
         }
         RevmExecutionResult::Revert { output, gas_used } => {
-            let result = ExecutionResult::Reverted;
             let output = Bytes::from(output);
+            let result = ExecutionResult::Reverted { reason: (&output).into() };
             let gas = Gas::from(gas_used);
             (result, output, Vec::new(), gas)
         }

--- a/src/eth/primitives/execution.rs
+++ b/src/eth/primitives/execution.rs
@@ -74,8 +74,8 @@ impl EvmExecution {
         let mut execution = Self {
             block_timestamp,
             receipt_applied: false,
-            result: ExecutionResult::new_reverted(), // assume it reverted
-            output: Bytes::default(),                // we cannot really know without performing an eth_call to the external system
+            result: ExecutionResult::new_reverted("reverted externally".into()), // assume it reverted
+            output: Bytes::default(),                                            // we cannot really know without performing an eth_call to the external system
             logs: Vec::new(),
             gas: receipt.gas_used.unwrap_or_default().try_into()?,
             changes: HashMap::from([(sender_changes.address, sender_changes)]),

--- a/src/eth/primitives/execution_result.rs
+++ b/src/eth/primitives/execution_result.rs
@@ -1,4 +1,10 @@
+use std::borrow::Cow;
+
 use display_json::DebugAsJson;
+use fake::Faker;
+
+use crate::eth::codegen::error_sig_opt;
+use crate::eth::primitives::Bytes;
 
 /// Indicates how a transaction execution was finished.
 #[derive(DebugAsJson, strum::Display, Clone, PartialEq, Eq, fake::Dummy, derive_new::new, serde::Serialize, serde::Deserialize, strum::EnumString)]
@@ -10,9 +16,69 @@ pub enum ExecutionResult {
 
     /// Transaction execution finished with a reversion (REVERT opcode).
     #[strum(to_string = "reverted")]
-    Reverted,
+    Reverted { reason: RevertReason },
 
     /// Transaction execution did not finish.
     #[strum(to_string = "halted")]
     Halted { reason: String },
+}
+
+#[derive(Debug, thiserror::Error, serde::Serialize, serde::Deserialize, Default, Clone, PartialEq, Eq)]
+pub struct RevertReason(pub Cow<'static, str>);
+
+impl fake::Dummy<Faker> for RevertReason {
+    fn dummy_with_rng<R: ethers_core::rand::prelude::Rng + ?Sized>(_: &Faker, _rng: &mut R) -> Self {
+        RevertReason(Cow::Borrowed("reverted"))
+    }
+}
+
+impl From<&'static str> for RevertReason {
+    fn from(value: &'static str) -> Self {
+        RevertReason(Cow::Borrowed(value))
+    }
+}
+
+impl From<&Bytes> for RevertReason {
+    fn from(value: &Bytes) -> Self {
+        let sig: Cow<str> = error_sig_opt(value).unwrap_or_else(|| Cow::Owned(value.to_string()));
+        Self(sig)
+    }
+}
+
+impl std::fmt::Display for RevertReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ethers_core::utils::hex;
+
+    use super::*;
+
+    #[test]
+    fn test_revert_reason_from_bytes() {
+        // Test string revert
+        let input = hex::decode(
+            "08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000\
+0000000000014437573746f6d206572726f72206d657373616765000000000000000000000000",
+        )
+        .unwrap();
+        let bytes = Bytes::from(input);
+        let revert = RevertReason::from(&bytes);
+        assert_eq!(revert.0, "Custom error message");
+
+        // Test known error
+        let input = hex::decode("22aa4404").unwrap();
+        let bytes = Bytes::from(input);
+        let revert = RevertReason::from(&bytes);
+        assert_eq!(revert.0, "KnownError()");
+
+        // Test unknown error
+        let input = hex::decode("c39a0557").unwrap();
+        let bytes = Bytes::from(input);
+        let revert = RevertReason::from(&bytes);
+        assert_eq!(revert.0, "0xc39a0557");
+    }
 }

--- a/src/eth/primitives/stratus_error.rs
+++ b/src/eth/primitives/stratus_error.rs
@@ -86,7 +86,7 @@ pub enum TransactionError {
 
     #[error("Transaction reverted during execution.")]
     #[error_code = 6]
-    Reverted { output: Bytes },
+    RevertedCall { output: Bytes },
 
     #[error("Transaction from zero address is not allowed.")]
     #[error_code = 7]
@@ -281,7 +281,7 @@ impl StratusError {
             // Transaction
             Self::RPC(RpcError::TransactionInvalid { decode_error }) => to_json_value(decode_error),
             Self::Transaction(TransactionError::EvmFailed(e)) => JsonValue::String(e.to_string()),
-            Self::Transaction(TransactionError::Reverted { output }) => to_json_value(output),
+            Self::Transaction(TransactionError::RevertedCall { output }) => to_json_value(output),
 
             // Unexpected
             Self::Unexpected(UnexpectedError::Unexpected(e)) => JsonValue::String(e.to_string()),

--- a/src/eth/rpc/rpc_middleware.rs
+++ b/src/eth/rpc/rpc_middleware.rs
@@ -296,8 +296,8 @@ impl TransactionTracingIdentifiers {
         Ok(Self {
             client: client.map(|(_, client)| client).ok(),
             hash: Some(tx.hash),
-            contract: codegen::contract_name_for_o11y(&tx.to),
-            function: codegen::function_sig_for_o11y(&tx.input),
+            contract: codegen::contract_name(&tx.to),
+            function: codegen::function_sig(&tx.input),
             from: Some(tx.signer),
             to: tx.to,
             nonce: Some(tx.nonce),
@@ -310,8 +310,8 @@ impl TransactionTracingIdentifiers {
         Ok(Self {
             client: None,
             hash: None,
-            contract: codegen::contract_name_for_o11y(&call.to),
-            function: codegen::function_sig_for_o11y(&call.data),
+            contract: codegen::contract_name(&call.to),
+            function: codegen::function_sig(&call.data),
             from: call.from,
             to: call.to,
             nonce: None,

--- a/src/eth/rpc/rpc_server.rs
+++ b/src/eth/rpc/rpc_server.rs
@@ -1,5 +1,6 @@
 //! RPC server for HTTP and WS.
 
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::ops::Deref;
 use std::str::FromStr;
@@ -34,6 +35,7 @@ use tracing::Span;
 
 use crate::alias::EthersReceipt;
 use crate::alias::JsonValue;
+use crate::eth::codegen::function_sig_for_o11y_opt;
 use crate::eth::executor::Executor;
 use crate::eth::follower::consensus::Consensus;
 use crate::eth::follower::importer::ImporterConfig;
@@ -914,7 +916,17 @@ fn eth_send_raw_transaction(params: Params<'_>, ctx: Arc<RpcContext>, ext: Exten
         NodeMode::Leader | NodeMode::FakeLeader => match ctx.executor.execute_local_transaction(tx) {
             Ok(_) => Ok(hex_data(tx_hash)),
             Err(e) => {
-                tracing::warn!(reason = ?e, "failed to execute eth_sendRawTransaction");
+                match &e {
+                    StratusError::Transaction(TransactionError::Reverted { output }) => {
+                        let sig: Cow<str> = function_sig_for_o11y_opt(output)
+                            .map(Cow::Borrowed)
+                            .unwrap_or_else(|| Cow::Owned(output.to_string()));
+                        tracing::warn!(error = ?sig, "transaction reverted with");
+                    }
+                    e => {
+                        tracing::warn!(reason = ?e, "failed to execute eth_sendRawTransaction");
+                    }
+                }
                 Err(e)
             }
         },

--- a/src/eth/rpc/rpc_server.rs
+++ b/src/eth/rpc/rpc_server.rs
@@ -921,10 +921,10 @@ fn eth_send_raw_transaction(params: Params<'_>, ctx: Arc<RpcContext>, ext: Exten
                         let sig: Cow<str> = function_sig_for_o11y_opt(output)
                             .map(Cow::Borrowed)
                             .unwrap_or_else(|| Cow::Owned(output.to_string()));
-                        tracing::warn!(error = ?sig, "transaction reverted with");
+                        tracing::warn!(error = ?sig, ?tx_hash, "transaction reverted");
                     }
                     e => {
-                        tracing::warn!(reason = ?e, "failed to execute eth_sendRawTransaction");
+                        tracing::warn!(reason = ?e, ?tx_hash, "failed to execute eth_sendRawTransaction");
                     }
                 }
                 Err(e)

--- a/src/eth/storage/permanent/rocks/types/execution_result.rs
+++ b/src/eth/storage/permanent/rocks/types/execution_result.rs
@@ -11,7 +11,7 @@ impl From<ExecutionResult> for ExecutionResultRocksdb {
     fn from(item: ExecutionResult) -> Self {
         match item {
             ExecutionResult::Success => ExecutionResultRocksdb::Success,
-            ExecutionResult::Reverted => ExecutionResultRocksdb::Reverted,
+            ExecutionResult::Reverted { .. } => ExecutionResultRocksdb::Reverted,
             ExecutionResult::Halted { reason } => ExecutionResultRocksdb::Halted { reason },
         }
     }
@@ -21,7 +21,8 @@ impl From<ExecutionResultRocksdb> for ExecutionResult {
     fn from(item: ExecutionResultRocksdb) -> Self {
         match item {
             ExecutionResultRocksdb::Success => ExecutionResult::Success,
-            ExecutionResultRocksdb::Reverted => ExecutionResult::Reverted,
+            // TODO: can use the output to derive this information
+            ExecutionResultRocksdb::Reverted => ExecutionResult::Reverted { reason: "unknown".into() },
             ExecutionResultRocksdb::Halted { reason } => ExecutionResult::Halted { reason },
         }
     }

--- a/src/infra/metrics/metrics_definitions.rs
+++ b/src/infra/metrics/metrics_definitions.rs
@@ -111,6 +111,9 @@ metrics! {
     "Time executing a local transaction."
     histogram_duration executor_local_transaction{success, contract, function},
 
+    "Time executing a local transaction."
+    counter executor_local_transaction_reverts{contract, function, reason},
+
     "Number of account reads when executing a local transaction."
     histogram_counter executor_local_transaction_account_reads{contract, function},
 

--- a/static/contracts-signatures/TestRevertReason.signatures
+++ b/static/contracts-signatures/TestRevertReason.signatures
@@ -1,0 +1,7 @@
+Function signatures:
+2b3d7bd2: revertWithKnownError()
+0323d234: revertWithString()
+2e6b10d2: revertWithUnknownError()
+
+Error signatures:
+22aa4404: KnownError()


### PR DESCRIPTION
### **User description**
TODO: handle revert reasons with encoded strings (DONE)


___

### **PR Type**
Enhancement


___

### **Description**
- Include error signature in logs for reverted transactions

- Add function_sig_for_o11y_opt for optional signature lookup

- Improve error logging in eth_send_raw_transaction

- Use Cow for efficient string handling


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>codegen.rs</strong><dd><code>Add optional function signature lookup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/codegen.rs

<li>Added function_sig_for_o11y_opt for optional signature lookup<br> <li> Modified function_sig_for_o11y to use new optional function<br> <li> Improved error handling for missing byte data


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1945/files#diff-9a9594a9fd77f6026138025d08f653526526ef6b1c9c30eb6a95f5ebfc9035b6">+9/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rpc_server.rs</strong><dd><code>Improve transaction revert error logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/rpc/rpc_server.rs

<li>Added Cow import for efficient string handling<br> <li> Imported function_sig_for_o11y_opt from codegen module<br> <li> Enhanced error logging in eth_send_raw_transaction with error <br>signatures<br> <li> Improved transaction revert error handling


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1945/files#diff-835ba255c9a5c1fe0e13285bc39e058e1c74422e5e03ebba483c9d8a15c45405">+13/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information