### PR TITLE
fix(justfile,deploy.py): add test command in e2e stratus rocks recipes and add raise

### DIFF
--- a/justfile
+++ b/justfile
@@ -231,6 +231,11 @@ e2e-stratus-rocks block-mode="automine" test="":
     just _wait_for_stratus
 
     just _log "Running E2E tests"
+    if [[ {{block-mode}} =~ ^[0-9]+(ms|s)$ ]]; then
+        just e2e stratus interval "{{test}}"
+    else
+        just e2e stratus {{block-mode}} "{{test}}"
+    fi
     result_code=$?
 
     just _log "Killing Stratus"

--- a/utils/deploy/deploy.py
+++ b/utils/deploy/deploy.py
@@ -297,6 +297,7 @@ def main() -> None:
                 log(message=f"Process completed in {elapsed_time:.2f} seconds.")
             except DeploymentError as e:
                 log(message=f"Process failed: {str(e)}", error=True)
+                raise DeploymentError(f"Process failed: {str(e)}", error_type="DeploymentError")
 
     except IOError as e:
         log(message=f"Error opening log file: {e}")


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add conditional logic for E2E test execution

- Support different block modes in Stratus E2E tests

- Improve test command flexibility in e2e-stratus-rocks recipe


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>justfile</strong><dd><code>Add conditional E2E test execution based on block mode</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

justfile

<li>Added conditional logic to handle different block modes<br> <li> Introduced support for interval-based and block-mode-based E2E tests<br> <li> Improved flexibility in test command execution


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1957/files#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information