### PR TITLE
feat: implement stratus_getTransactionResult

### DIFF
--- a/e2e/test/automine/e2e-json-rpc.test.ts
+++ b/e2e/test/automine/e2e-json-rpc.test.ts
@@ -433,7 +433,7 @@ describe("JSON-RPC", () => {
 
                 // Record timestamp in contract
                 const tx = await contract.recordTimestamp();
-                const receipt = await tx.wait() as TransactionReceipt;
+                const receipt = (await tx.wait()) as TransactionReceipt;
 
                 // Get the timestamp from contract event
                 const event = receipt.logs[0];

--- a/e2e/test/automine/e2e-json-rpc.test.ts
+++ b/e2e/test/automine/e2e-json-rpc.test.ts
@@ -248,7 +248,7 @@ describe("JSON-RPC", () => {
                 expect(actualTxHash).eq(expectedTxHash);
             });
         });
-        describe("stratus_getTransactionStatus", () => {
+        describe("stratus_getTransactionResult", () => {
             it("Returns decoded error message when transaction is reverted", async function () {
                 if (!isStratus) {
                     this.skip();
@@ -433,7 +433,7 @@ describe("JSON-RPC", () => {
 
                 // Record timestamp in contract
                 const tx = await contract.recordTimestamp();
-                const receipt: TransactionReceipt = (await tx.wait()) as any;
+                const receipt = await tx.wait() as TransactionReceipt;
 
                 // Get the timestamp from contract event
                 const event = receipt.logs[0];

--- a/e2e/test/automine/e2e-json-rpc.test.ts
+++ b/e2e/test/automine/e2e-json-rpc.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { keccak256, TransactionReceipt } from "ethers";
+import { TransactionReceipt, keccak256 } from "ethers";
 import { JsonRpcProvider } from "ethers";
 import { Block, Bytes } from "web3-types";
 
@@ -433,7 +433,7 @@ describe("JSON-RPC", () => {
 
                 // Record timestamp in contract
                 const tx = await contract.recordTimestamp();
-                const receipt: TransactionReceipt = await tx.wait() as any;
+                const receipt: TransactionReceipt = (await tx.wait()) as any;
 
                 // Get the timestamp from contract event
                 const event = receipt.logs[0];

--- a/src/eth/primitives/transaction_stage.rs
+++ b/src/eth/primitives/transaction_stage.rs
@@ -1,3 +1,4 @@
+use super::ExecutionResult;
 use crate::alias::EthersReceipt;
 use crate::alias::EthersTransaction;
 use crate::alias::JsonValue;
@@ -46,6 +47,13 @@ impl TransactionStage {
                 let json_rpc_format: EthersReceipt = tx.into();
                 to_json_value(json_rpc_format)
             }
+        }
+    }
+
+    pub fn result(&self) -> &ExecutionResult {
+        match self {
+            Self::Executed(tx) => &tx.result().execution.result,
+            Self::Mined(tx) => &tx.execution.result,
         }
     }
 }

--- a/src/eth/storage/permanent/rocks/types/execution.rs
+++ b/src/eth/storage/permanent/rocks/types/execution.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use super::address::AddressRocksdb;
 use super::bytes::BytesRocksdb;
+use super::execution_result::ExecutionResultBuilder;
 use super::execution_result::ExecutionResultRocksdb;
 use super::gas::GasRocksdb;
 use super::log::LogRocksdb;
@@ -37,11 +38,12 @@ impl From<EvmExecution> for ExecutionRocksdb {
 
 impl From<ExecutionRocksdb> for EvmExecution {
     fn from(item: ExecutionRocksdb) -> Self {
+        let (result, output) = ExecutionResultBuilder((item.result, item.output)).build();
         Self {
             block_timestamp: item.block_timestamp.into(),
             receipt_applied: item.execution_costs_applied,
-            result: item.result.into(),
-            output: item.output.into(),
+            result,
+            output,
             logs: item.logs.into_iter().map(Log::from).collect(),
             gas: item.gas.into(),
             changes: HashMap::default(),


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Implement stratus_getTransactionResult RPC method

- Add result() method to TransactionStage

- Refactor ExecutionResult handling in storage

- Add e2e tests for new RPC method


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>transaction_stage.rs</strong><dd><code>Add result() method to TransactionStage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/transaction_stage.rs

- Import ExecutionResult
- Add result() method to TransactionStage


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1959/files#diff-01decfef18b1279624031c329be1473400de3c0edad3e0b196a2acc3fbc73a30">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>rpc_server.rs</strong><dd><code>Implement stratus_getTransactionResult RPC method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/rpc/rpc_server.rs

<li>Register stratus_getTransactionResult RPC method<br> <li> Implement stratus_get_transaction_result function<br> <li> Refactor eth_get_transaction_receipt to use common logic


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1959/files#diff-835ba255c9a5c1fe0e13285bc39e058e1c74422e5e03ebba483c9d8a15c45405">+32/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>execution.rs</strong><dd><code>Refactor ExecutionRocksdb conversion using ExecutionResultBuilder</code></dd></summary>
<hr>

src/eth/storage/permanent/rocks/types/execution.rs

<li>Use ExecutionResultBuilder for conversion<br> <li> Update From implementation for ExecutionRocksdb


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1959/files#diff-157f259e44224a5b1350a0b2743bd737d685b9b5380fa2143a4daa44fe531dc9">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>execution_result.rs</strong><dd><code>Implement ExecutionResultBuilder for improved result handling</code></dd></summary>
<hr>

src/eth/storage/permanent/rocks/types/execution_result.rs

<li>Add ExecutionResultBuilder struct<br> <li> Implement From trait for ExecutionResultBuilder<br> <li> Remove direct From implementation for ExecutionResultRocksdb


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1959/files#diff-70b1a8cb3b627b206b7e4fcf1b7fd822ac75824704e7a12209871f54fa21c254">+18/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>e2e-json-rpc.test.ts</strong><dd><code>Add e2e tests for stratus_getTransactionStatus</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

e2e/test/automine/e2e-json-rpc.test.ts

<li>Add tests for stratus_getTransactionStatus<br> <li> Test success and revert scenarios<br> <li> Minor type adjustment for TransactionReceipt


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1959/files#diff-3d74b20bca5732bd9d71f766b668d339a52e53e6b7fd18ff8f9000c077184439">+51/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information