### PR TITLE
chore: make noop tracer return early

### DIFF
--- a/src/eth/executor/evm.rs
+++ b/src/eth/executor/evm.rs
@@ -199,6 +199,10 @@ impl Evm {
 
         let InspectorInput { tx_hash, opts } = input;
 
+        if opts.as_ref().is_some_and(|opts| matches!(opts.tracer, Some(GethDebugTracerType::BuiltInTracer(GethDebugBuiltInTracerType::NoopTracer)))) {
+            return Ok(NoopFrame::default().into());
+        }
+
         let tx = self
             .evm
             .db()

--- a/src/eth/executor/evm.rs
+++ b/src/eth/executor/evm.rs
@@ -199,7 +199,10 @@ impl Evm {
 
         let InspectorInput { tx_hash, opts } = input;
 
-        if opts.as_ref().is_some_and(|opts| matches!(opts.tracer, Some(GethDebugTracerType::BuiltInTracer(GethDebugBuiltInTracerType::NoopTracer)))) {
+        if opts
+            .as_ref()
+            .is_some_and(|opts| matches!(opts.tracer, Some(GethDebugTracerType::BuiltInTracer(GethDebugBuiltInTracerType::NoopTracer))))
+        {
             return Ok(NoopFrame::default().into());
         }
 


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Early return for NoopTracer in EVM inspection

- Optimizes performance for NoopTracer scenarios

- Reduces unnecessary processing in EVM execution


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>evm.rs</strong><dd><code>Implement early return for NoopTracer in EVM inspection</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/eth/executor/evm.rs

<li>Added early return condition for NoopTracer<br> <li> Checks if tracer option is NoopTracer<br> <li> Returns default NoopFrame if condition is met


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1969/files#diff-7fabd204a68cff51c55ee1391074463fa8ac005dc8ba443218bc83a9dda96658">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>