### PR TITLE
fix: evm_input.test incorrect assertion

### DIFF
--- a/e2e/test/interval/evm-input.test.ts
+++ b/e2e/test/interval/evm-input.test.ts
@@ -19,7 +19,7 @@ describe("Evm Input", () => {
             })?.args as Result;
 
             expect(receipt.blockNumber).to.eq(logs.blockNumber);
-            expect(logs.blockNumber).gt(1000);
+            expect(logs.blockNumber).gte(1000);
             expect(logs.isSlow).to.be.false;
             expect(await contract.getExecutions()).to.eq(1);
         });


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix incorrect assertion in EVM input test

- Change comparison operator from 'gt' to 'gte'


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>evm-input.test.ts</strong><dd><code>Update block number assertion to include 1000</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

e2e/test/interval/evm-input.test.ts

<li>Changed assertion from <code>expect(logs.blockNumber).gt(1000)</code> to <br><code>expect(logs.blockNumber).gte(1000)</code>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1981/files#diff-ba990cc0eef69250fb66927f6717fd8e1405ad5089621b1137cc47603ac75689">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>