### PR TITLE
enha: upgrade evm spec to Cancun

### DIFF
--- a/src/eth/executor/evm.rs
+++ b/src/eth/executor/evm.rs
@@ -86,7 +86,7 @@ impl Evm {
         tracing::info!(?config, "creating revm");
 
         // configure handler
-        let mut handler = Handler::mainnet_with_spec(SpecId::LONDON);
+        let mut handler = Handler::mainnet_with_spec(SpecId::CANCUN);
 
         // handler custom validators
         let validate_tx_against_state = handler.validation.tx_against_state;


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Upgrade EVM specification from London to Cancun


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>evm.rs</strong><dd><code>Update EVM handler to use Cancun specification</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/executor/evm.rs

<li>Updated <code>Handler::mainnet_with_spec()</code> to use <code>SpecId::CANCUN</code> instead of <br><code>SpecId::LONDON</code>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1982/files#diff-7fabd204a68cff51c55ee1391074463fa8ac005dc8ba443218bc83a9dda96658">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>