### PR TITLE
chore: remove outdated ignores

### DIFF
--- a/.github/workflows/merge-gatekeeper.yml
+++ b/.github/workflows/merge-gatekeeper.yml
@@ -20,4 +20,4 @@ jobs:
           self: Merge Gatekeeper
           interval: 5
           timeout: 1800
-          ignored: PR Agent,E2E Rocks on pixv3,E2E InMemory on pixv3,E2E Rocks on cppv2,E2E InMemory on cppv2,eof_test
+          ignored: PR Agent,eof_test

--- a/.github/workflows/merge-gatekeeper.yml
+++ b/.github/workflows/merge-gatekeeper.yml
@@ -20,4 +20,4 @@ jobs:
           self: Merge Gatekeeper
           interval: 5
           timeout: 1800
-          ignored: Codacy Static Code Analysis
+          ignored: PR Agent

--- a/.github/workflows/merge-gatekeeper.yml
+++ b/.github/workflows/merge-gatekeeper.yml
@@ -20,4 +20,4 @@ jobs:
           self: Merge Gatekeeper
           interval: 5
           timeout: 1800
-          ignored: PR Agent
+          ignored: Codacy Static Code Analysis


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Updated merge-gatekeeper configuration

- Removed outdated ignored checks


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>merge-gatekeeper.yml</strong><dd><code>Remove outdated E2E checks from ignored list</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/merge-gatekeeper.yml

<li>Removed 'E2E Rocks on pixv3', 'E2E InMemory on pixv3', 'E2E Rocks on <br>cppv2', and 'E2E InMemory on cppv2' from the ignored list


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/1993/files#diff-81bfd69063f188ba06a94835cf828b1dd5e4fc28f39531b69e246c3cd7e190e1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>