### PR TITLE
feat: add hostname to build info

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ derive-new = "=0.6.0"
 hash_hasher = "=2.0.3"
 hex_fmt = "=0.3.0"
 hex-literal = "=0.4.1"
+hostname = "0.4.0"
 humantime = "=2.1.0"
 indexmap = { version = "=2.7.1", features = ["serde"] }
 itertools = "=0.13.0"

--- a/src/infra/build_info.rs
+++ b/src/infra/build_info.rs
@@ -1,5 +1,5 @@
 use serde_json::json;
-
+use hostname;
 use crate::alias::JsonValue;
 
 // -----------------------------------------------------------------------------
@@ -57,6 +57,14 @@ pub fn version() -> &'static str {
     }
 }
 
+// returns the hostname
+fn get_hostname() -> String {
+    hostname::get()
+        .unwrap_or_default()
+        .to_string_lossy()
+        .into_owned()
+}
+
 /// Returns build info as JSON.
 pub fn as_json() -> JsonValue {
     json!(
@@ -67,6 +75,7 @@ pub fn as_json() -> JsonValue {
                 "version": version(),
                 "service_name_with_version": service_name_with_version(),
                 "timestamp": BUILD_TIMESTAMP,
+                "hostname": get_hostname(),
             },
             "cargo": {
                 "debug": CARGO_DEBUG,


### PR DESCRIPTION
Add hostname retrieval to build information JSON output using the 'hostname' crate. This provides additional context about the machine running the service in the build metadata.