### PR TITLE
fix: populate missing field to default trace response

### DIFF
--- a/src/eth/executor/evm.rs
+++ b/src/eth/executor/evm.rs
@@ -609,15 +609,14 @@ pub fn default_trace(tracer_type: GethDebugTracerType, tx: TransactionStage) -> 
         GethDebugTracerType::BuiltInTracer(GethDebugBuiltInTracerType::FourByteTracer) => FourByteFrame::default().into(),
         // HACK: Spoof empty call frame to prevent Blockscout from retrying unnecessary trace calls
         GethDebugTracerType::BuiltInTracer(GethDebugBuiltInTracerType::CallTracer) => {
-            let typ = match tx.to() {
-                Some(_) => "CALL",
-                None => "CREATE",
-            }
-            .to_string();
+            let (typ, to) = match tx.to() {
+                Some(_) => ("CALL".to_string(), tx.to().map_into()),
+                None => ("CREATE".to_string(), tx.deployed_contract_address().map_into()),
+            };
 
             CallFrame {
                 from: tx.from().into(),
-                to: tx.to().map_into(),
+                to,
                 typ,
                 ..Default::default()
             }

--- a/src/eth/primitives/transaction_stage.rs
+++ b/src/eth/primitives/transaction_stage.rs
@@ -54,6 +54,14 @@ impl TransactionStage {
         }
     }
 
+    pub fn deployed_contract_address(&self) -> Option<Address> {
+        match self {
+            Self::Executed(TransactionExecution::Local(tx)) => tx.result.execution.deployed_contract_address,
+            Self::Executed(TransactionExecution::External(tx)) => tx.receipt.contract_address.map_into(),
+            Self::Mined(tx) => tx.execution.deployed_contract_address,
+        }
+    }
+
     pub fn result(&self) -> &ExecutionResult {
         match self {
             Self::Executed(tx) => &tx.result().execution.result,


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Add missing `to` field in default CallTracer response

- Implement `deployed_contract_address` method for TransactionStage

- Improve handling of CREATE transactions in default trace


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>evm.rs</strong><dd><code>Improve default trace response for CallTracer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/executor/evm.rs

<li>Refactor <code>default_trace</code> function for CallTracer<br> <li> Add handling for CREATE transactions<br> <li> Populate <code>to</code> field with deployed contract address for CREATE


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2013/files#diff-7fabd204a68cff51c55ee1391074463fa8ac005dc8ba443218bc83a9dda96658">+5/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>transaction_stage.rs</strong><dd><code>Add deployed contract address retrieval to TransactionStage</code></dd></summary>
<hr>

src/eth/primitives/transaction_stage.rs

<li>Add <code>deployed_contract_address</code> method to TransactionStage<br> <li> Handle different transaction types for contract address retrieval


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2013/files#diff-01decfef18b1279624031c329be1473400de3c0edad3e0b196a2acc3fbc73a30">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>