### PR TITLE
feat(rpc): reduce verbosity in subscriber notification logs

### DIFF
--- a/src/eth/rpc/rpc_subscriptions.rs
+++ b/src/eth/rpc/rpc_subscriptions.rs
@@ -173,13 +173,42 @@ impl RpcSubscriptions {
                 let interested_subs = subs.pending_txs.read().await;
                 let subscribers = interested_subs.values().collect_vec();
 
-                if subscribers.len() > 0 {
-                    // Extrai apenas os nomes dos clientes
-                    let client_names: Vec<String> = subscribers.iter().map(|s| s.client.to_string()).collect();
+                if !subscribers.is_empty() {
+                    // Group clients by type and count how many of each type
+                    let mut client_type_counts = std::collections::HashMap::new();
+                    
+                    for sub in &subscribers {
+                        let client_str = sub.client.to_string();
+                        let client_type = if client_str.starts_with("banking::") {
+                            "banking"
+                        } else if client_str.starts_with("issuing::") {
+                            "issuing"
+                        } else if client_str.starts_with("stratus::") {
+                            "stratus"
+                        } else if client_str.starts_with("acquiring::") {
+                            "acquiring"
+                        } else if client_str.starts_with("lending::") {
+                            "lending"
+                        } else if client_str.starts_with("infra::") {
+                            "infra"
+                        } else if client_str.starts_with("user::") {
+                            "user"
+                        } else {
+                            "other"
+                        };
+                        
+                        *client_type_counts.entry(client_type.to_string()).or_insert(0) += 1;
+                    }
+                    
+                    // Format the log message
+                    let mut client_summary = Vec::new();
+                    for (client_type, count) in client_type_counts.iter() {
+                        client_summary.push(format!("{}: {}", client_type, count));
+                    }
 
                     tracing::info!(
                         tx_hash = ?tx_hash,
-                        clients = ?client_names,
+                        clients = ?client_summary.join(", "),
                         "notifying subscribers about new pending transaction"
                     );
                 }
@@ -209,14 +238,43 @@ impl RpcSubscriptions {
                 let interested_subs = subs.new_heads.read().await;
                 let subscribers = interested_subs.values().collect_vec();
 
-                if subscribers.len() > 0 {
-                    // Extrai apenas os nomes dos clientes
-                    let client_names: Vec<String> = subscribers.iter().map(|s| s.client.to_string()).collect();
+                if !subscribers.is_empty() {
+                    // Group clients by type and count how many of each type
+                    let mut client_type_counts = std::collections::HashMap::new();
+                    
+                    for sub in &subscribers {
+                        let client_str = sub.client.to_string();
+                        let client_type = if client_str.starts_with("banking::") {
+                            "banking"
+                        } else if client_str.starts_with("issuing::") {
+                            "issuing"
+                        } else if client_str.starts_with("stratus::") {
+                            "stratus"
+                        } else if client_str.starts_with("acquiring::") {
+                            "acquiring"
+                        } else if client_str.starts_with("lending::") {
+                            "lending"
+                        } else if client_str.starts_with("infra::") {
+                            "infra"
+                        } else if client_str.starts_with("user::") {
+                            "user"
+                        } else {
+                            "other"
+                        };
+                        
+                        *client_type_counts.entry(client_type.to_string()).or_insert(0) += 1;
+                    }
+                    
+                    // Format the log message
+                    let mut client_summary = Vec::new();
+                    for (client_type, count) in client_type_counts.iter() {
+                        client_summary.push(format!("{}: {}", client_type, count));
+                    }
 
                     tracing::info!(
                         block_number = ?block_header.number,
                         block_hash = ?block_header.hash,
-                        clients = ?client_names,
+                        clients = ?client_summary.join(", "),
                         "notifying subscribers about new block"
                     );
                 }
@@ -250,14 +308,43 @@ impl RpcSubscriptions {
                     .filter_map(|s| if_else!(s.filter.matches(&log), Some(&s.inner), None))
                     .collect_vec();
 
-                if matching_subscribers.len() > 0 {
-                    // Extrai apenas os nomes dos clientes
-                    let client_names: Vec<String> = matching_subscribers.iter().map(|s| s.client.to_string()).collect();
+                if !matching_subscribers.is_empty() {
+                    // Group clients by type and count how many of each type
+                    let mut client_type_counts = std::collections::HashMap::new();
+                    
+                    for sub in &matching_subscribers {
+                        let client_str = sub.client.to_string();
+                        let client_type = if client_str.starts_with("banking::") {
+                            "banking"
+                        } else if client_str.starts_with("issuing::") {
+                            "issuing"
+                        } else if client_str.starts_with("stratus::") {
+                            "stratus"
+                        } else if client_str.starts_with("acquiring::") {
+                            "acquiring"
+                        } else if client_str.starts_with("lending::") {
+                            "lending"
+                        } else if client_str.starts_with("infra::") {
+                            "infra"
+                        } else if client_str.starts_with("user::") {
+                            "user"
+                        } else {
+                            "other"
+                        };
+                        
+                        *client_type_counts.entry(client_type.to_string()).or_insert(0) += 1;
+                    }
+                    
+                    // Format the log message
+                    let mut client_summary = Vec::new();
+                    for (client_type, count) in client_type_counts.iter() {
+                        client_summary.push(format!("{}: {}", client_type, count));
+                    }
 
                     tracing::info!(
                         log_block_number = ?log.block_number,
                         log_tx_hash = ?log.transaction_hash,
-                        clients = ?client_names,
+                        clients = ?client_summary.join(", "),
                         "notifying subscribers about new logs"
                     );
                 }

--- a/src/eth/rpc/rpc_subscriptions.rs
+++ b/src/eth/rpc/rpc_subscriptions.rs
@@ -179,25 +179,9 @@ impl RpcSubscriptions {
 
                     for sub in &subscribers {
                         let client_str = sub.client.to_string();
-                        let client_type = if client_str.starts_with("banking::") {
-                            "banking"
-                        } else if client_str.starts_with("issuing::") {
-                            "issuing"
-                        } else if client_str.starts_with("stratus::") {
-                            "stratus"
-                        } else if client_str.starts_with("acquiring::") {
-                            "acquiring"
-                        } else if client_str.starts_with("lending::") {
-                            "lending"
-                        } else if client_str.starts_with("infra::") {
-                            "infra"
-                        } else if client_str.starts_with("user::") {
-                            "user"
-                        } else {
-                            "other"
-                        };
+                        let client_type = Self::get_client_type(&client_str);
 
-                        *client_type_counts.entry(client_type.to_string()).or_insert(0) += 1;
+                        *client_type_counts.entry(client_type).or_insert(0) += 1;
                     }
 
                     // Format the log message
@@ -244,25 +228,9 @@ impl RpcSubscriptions {
 
                     for sub in &subscribers {
                         let client_str = sub.client.to_string();
-                        let client_type = if client_str.starts_with("banking::") {
-                            "banking"
-                        } else if client_str.starts_with("issuing::") {
-                            "issuing"
-                        } else if client_str.starts_with("stratus::") {
-                            "stratus"
-                        } else if client_str.starts_with("acquiring::") {
-                            "acquiring"
-                        } else if client_str.starts_with("lending::") {
-                            "lending"
-                        } else if client_str.starts_with("infra::") {
-                            "infra"
-                        } else if client_str.starts_with("user::") {
-                            "user"
-                        } else {
-                            "other"
-                        };
+                        let client_type = Self::get_client_type(&client_str);
 
-                        *client_type_counts.entry(client_type.to_string()).or_insert(0) += 1;
+                        *client_type_counts.entry(client_type).or_insert(0) += 1;
                     }
 
                     // Format the log message
@@ -314,25 +282,9 @@ impl RpcSubscriptions {
 
                     for sub in &matching_subscribers {
                         let client_str = sub.client.to_string();
-                        let client_type = if client_str.starts_with("banking::") {
-                            "banking"
-                        } else if client_str.starts_with("issuing::") {
-                            "issuing"
-                        } else if client_str.starts_with("stratus::") {
-                            "stratus"
-                        } else if client_str.starts_with("acquiring::") {
-                            "acquiring"
-                        } else if client_str.starts_with("lending::") {
-                            "lending"
-                        } else if client_str.starts_with("infra::") {
-                            "infra"
-                        } else if client_str.starts_with("user::") {
-                            "user"
-                        } else {
-                            "other"
-                        };
+                        let client_type = Self::get_client_type(&client_str);
 
-                        *client_type_counts.entry(client_type.to_string()).or_insert(0) += 1;
+                        *client_type_counts.entry(client_type).or_insert(0) += 1;
                     }
 
                     // Format the log message
@@ -393,6 +345,17 @@ impl RpcSubscriptions {
                     tracing::error!(reason = ?e, "failed to send subscription notification");
                 }
             });
+        }
+    }
+
+    fn get_client_type(client_str: &str) -> String {
+        // Split the client string by "::" and take the first part
+        if let Some(index) = client_str.find("::") {
+            // Extract the type part (before the first "::")
+            client_str[..index].to_string()
+        } else {
+            // If there's no "::", return "other"
+            "other".to_string()
         }
     }
 }

--- a/src/eth/rpc/rpc_subscriptions.rs
+++ b/src/eth/rpc/rpc_subscriptions.rs
@@ -175,10 +175,8 @@ impl RpcSubscriptions {
 
                 if subscribers.len() > 0 {
                     // Extrai apenas os nomes dos clientes
-                    let client_names: Vec<String> = subscribers.iter()
-                        .map(|s| s.client.to_string())
-                        .collect();
-                    
+                    let client_names: Vec<String> = subscribers.iter().map(|s| s.client.to_string()).collect();
+
                     tracing::info!(
                         tx_hash = ?tx_hash,
                         clients = ?client_names,
@@ -213,10 +211,8 @@ impl RpcSubscriptions {
 
                 if subscribers.len() > 0 {
                     // Extrai apenas os nomes dos clientes
-                    let client_names: Vec<String> = subscribers.iter()
-                        .map(|s| s.client.to_string())
-                        .collect();
-                    
+                    let client_names: Vec<String> = subscribers.iter().map(|s| s.client.to_string()).collect();
+
                     tracing::info!(
                         block_number = ?block_header.number,
                         block_hash = ?block_header.hash,
@@ -253,13 +249,11 @@ impl RpcSubscriptions {
                     .flat_map(HashMap::values)
                     .filter_map(|s| if_else!(s.filter.matches(&log), Some(&s.inner), None))
                     .collect_vec();
-                
+
                 if matching_subscribers.len() > 0 {
                     // Extrai apenas os nomes dos clientes
-                    let client_names: Vec<String> = matching_subscribers.iter()
-                        .map(|s| s.client.to_string())
-                        .collect();
-                    
+                    let client_names: Vec<String> = matching_subscribers.iter().map(|s| s.client.to_string()).collect();
+
                     tracing::info!(
                         log_block_number = ?log.block_number,
                         log_tx_hash = ?log.transaction_hash,

--- a/src/eth/rpc/rpc_subscriptions.rs
+++ b/src/eth/rpc/rpc_subscriptions.rs
@@ -176,7 +176,7 @@ impl RpcSubscriptions {
                 if !subscribers.is_empty() {
                     // Group clients by type and count how many of each type
                     let mut client_type_counts = std::collections::HashMap::new();
-                    
+
                     for sub in &subscribers {
                         let client_str = sub.client.to_string();
                         let client_type = if client_str.starts_with("banking::") {
@@ -196,10 +196,10 @@ impl RpcSubscriptions {
                         } else {
                             "other"
                         };
-                        
+
                         *client_type_counts.entry(client_type.to_string()).or_insert(0) += 1;
                     }
-                    
+
                     // Format the log message
                     let mut client_summary = Vec::new();
                     for (client_type, count) in client_type_counts.iter() {
@@ -241,7 +241,7 @@ impl RpcSubscriptions {
                 if !subscribers.is_empty() {
                     // Group clients by type and count how many of each type
                     let mut client_type_counts = std::collections::HashMap::new();
-                    
+
                     for sub in &subscribers {
                         let client_str = sub.client.to_string();
                         let client_type = if client_str.starts_with("banking::") {
@@ -261,10 +261,10 @@ impl RpcSubscriptions {
                         } else {
                             "other"
                         };
-                        
+
                         *client_type_counts.entry(client_type.to_string()).or_insert(0) += 1;
                     }
-                    
+
                     // Format the log message
                     let mut client_summary = Vec::new();
                     for (client_type, count) in client_type_counts.iter() {
@@ -311,7 +311,7 @@ impl RpcSubscriptions {
                 if !matching_subscribers.is_empty() {
                     // Group clients by type and count how many of each type
                     let mut client_type_counts = std::collections::HashMap::new();
-                    
+
                     for sub in &matching_subscribers {
                         let client_str = sub.client.to_string();
                         let client_type = if client_str.starts_with("banking::") {
@@ -331,10 +331,10 @@ impl RpcSubscriptions {
                         } else {
                             "other"
                         };
-                        
+
                         *client_type_counts.entry(client_type.to_string()).or_insert(0) += 1;
                     }
-                    
+
                     // Format the log message
                     let mut client_summary = Vec::new();
                     for (client_type, count) in client_type_counts.iter() {


### PR DESCRIPTION
### **User description**
Replace detailed subscription object display with a simple list of client names in notification logs. This significantly reduces log verbosity while maintaining essential information such as block hash, block number, and client identifiers.

Before this change, logs were showing the entire internal structure of subscription objects, resulting in extremely verbose logs that were difficult to read and analyze. Now, logs only show the client names without any internal implementation details.

This change improves log readability and reduces resource consumption in production environments, addressing feedback that logs were excessively verbose.

Tested with multiple simultaneous clients to ensure essential information is preserved even with a large number of subscribers.


___

### **PR Type**
Enhancement


___

### **Description**
- Reduce log verbosity in subscriber notifications

- Replace subscription object display with client names

- Improve readability of logs for pending transactions

- Enhance logging for new blocks and logs


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rpc_subscriptions.rs</strong><dd><code>Refactor RPC subscription logging for improved clarity and reduced </code><br><code>verbosity</code></dd></summary>
<hr>

src/eth/rpc/rpc_subscriptions.rs

<li>Replace detailed subscription object with client names in logs<br> <li> Add conditional logging based on subscriber count<br> <li> Improve logging for pending transactions, new blocks, and logs<br> <li> Refactor variable names for clarity (e.g., <code>interested_subs</code> to <br><code>subscribers</code>)


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2028/files#diff-a07ba1157cec6586a0520b8dfb11e9d073359af24471ac286ff5eaa2669d355c">+47/-26</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>