### PR TITLE
feat: add matrix-based coverage testing strategy

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -97,4 +97,3 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: ${{ matrix.group }}
           name: ${{ matrix.group }}
-          verbose: true

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -93,7 +93,8 @@ jobs:
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@v5
         with:
-          directory: target/llvm-cov/codecov
+          files: target/llvm-cov/codecov/${{ matrix.group }}.json
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: ${{ matrix.group }}
           name: ${{ matrix.group }}
+          verbose: true

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -83,6 +83,13 @@ jobs:
           echo "Listing coverage directory contents:"
           ls -la target/llvm-cov/codecov/
 
+      - name: Upload coverage report artifact
+        uses: actions/upload-artifact@v4
+        with:
+            name: coverage-${{ matrix.group }}
+            path: target/llvm-cov/codecov/
+            retention-days: 90
+
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@v5
         with:
@@ -90,10 +97,3 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: ${{ matrix.group }}
           name: ${{ matrix.group }}
-
-      - name: Upload coverage report artifact
-        uses: actions/upload-artifact@v4
-        with:
-            name: coverage-${{ matrix.group }}
-            path: target/llvm-cov/codecov/
-            retention-days: 90

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -40,6 +40,9 @@ jobs:
         with:
           node-version-file: .tool-versions
 
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
         id: cache-cargo
@@ -77,6 +80,8 @@ jobs:
         run: |
           mkdir -p target/llvm-cov/codecov
           just stratus-test-coverage-group ${{ matrix.group }} "--codecov --output-path target/llvm-cov/codecov/${{ matrix.group }}.json"
+          echo "Listing coverage directory contents:"
+          ls -la target/llvm-cov/codecov/
 
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@v5

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,9 +13,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  coverage-build:
+  coverage-matrix:
     runs-on: ubuntu-22.04
-    timeout-minutes: 300
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        group: [unit, inmemory, rocksdb, leader-follower, admin-password, rpc-downloader, importer-offline]
 
     steps:
       - name: Checkout
@@ -69,20 +73,22 @@ jobs:
         with:
           tool: cargo-llvm-cov@0.6.14
 
-      - name: Generate coverage
+      - name: Generate coverage for ${{ matrix.group }}
         run: |
           mkdir -p target/llvm-cov/codecov
-          just stratus-test-coverage "--codecov --output-path target/llvm-cov/codecov/codecov.json"
+          just stratus-test-coverage-group ${{ matrix.group }} "--codecov --output-path target/llvm-cov/codecov/${{ matrix.group }}.json"
 
-      - name: Upload coverage report artifact
-        uses: actions/upload-artifact@v4
-        with:
-            name: coverage-report
-            path: target/llvm-cov/codecov/
-            retention-days: 90
-
-      - name: Upload coverage reports to Codecov
+      - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@v5
         with:
           directory: target/llvm-cov/codecov
           token: ${{ secrets.CODECOV_TOKEN }}
+          flags: ${{ matrix.group }}
+          name: ${{ matrix.group }}
+
+      - name: Upload coverage report artifact
+        uses: actions/upload-artifact@v4
+        with:
+            name: coverage-${{ matrix.group }}
+            path: target/llvm-cov/codecov/
+            retention-days: 90

--- a/justfile
+++ b/justfile
@@ -145,7 +145,6 @@ stratus-test-coverage-group group="unit" *args="":
     rm -rf data/importer-offline-database-rocksdb
     rm -rf e2e_logs
     
-    just build
     source <(cargo llvm-cov show-env --export-prefix)
     export RUST_LOG=error
     export TRACING_LOG_FORMAT=json

--- a/justfile
+++ b/justfile
@@ -189,12 +189,6 @@ stratus-test-coverage-group group="unit" *args="":
             done
             
             rm -rf data/rocksdb
-            just _coverage-run-stratus-recipe e2e-eof rocks
-            rm -rf e2e_logs
-            rm -rf temp_*
-            rm -rf data/rocksdb
-            
-            rm -rf data/rocksdb
             just _coverage-run-stratus-recipe e2e-clock-stratus-rocks
             rm -rf e2e_logs
             rm -rf temp_*
@@ -202,6 +196,12 @@ stratus-test-coverage-group group="unit" *args="":
             
             rm -rf data/rocksdb
             just _coverage-run-stratus-recipe contracts-test-stratus-rocks
+            rm -rf e2e_logs
+            rm -rf temp_*
+            rm -rf data/rocksdb
+
+            rm -rf data/rocksdb
+            just _coverage-run-stratus-recipe e2e-eof rocks
             rm -rf e2e_logs
             rm -rf temp_*
             rm -rf data/rocksdb

--- a/justfile
+++ b/justfile
@@ -250,54 +250,6 @@ stratus-test-coverage-group group="unit" *args="":
         cargo llvm-cov report --codecov --output-path target/llvm-cov/codecov/{{group}}.json {{args}}
     fi
 
-# Test: Execute coverage for leader-follower tests
-stratus-test-coverage-leader-follower *args="":
-    #!/bin/bash
-    # setup
-    rm -rf temp_*
-    rm -rf e2e_logs
-    
-    just build
-    source <(cargo llvm-cov show-env --export-prefix)
-    export RUST_LOG=error
-    export TRACING_LOG_FORMAT=json
-    just contracts-clone
-    just contracts-flatten
-    
-    # other
-    for test in kafka deploy brlc change miner importer health; do
-        just _e2e-leader-follower-up-coverage $test
-        rm -rf e2e_logs
-        rm -rf temp_*
-        rm -rf utils/deploy/deploy_*.log
-    done
-    
-    cargo llvm-cov report {{args}}
-
-# Test: Execute coverage for misc tests
-stratus-test-coverage-misc *args="":
-    #!/bin/bash
-    # setup
-    rm -rf temp_*
-    rm -rf e2e_logs
-    rm -rf data/importer-offline-database-rocksdb
-    
-    just build
-    source <(cargo llvm-cov show-env --export-prefix)
-    export RUST_LOG=error
-    export TRACING_LOG_FORMAT=json
-    
-    just _coverage-run-stratus-recipe e2e-rpc-downloader
-    rm -rf e2e_logs
-    rm -rf temp_*
-
-    just _coverage-run-stratus-recipe e2e-importer-offline
-    rm -rf e2e_logs
-    rm -rf temp_*
-    rm -rf data/importer-offline-database-rocksdb
-    
-    cargo llvm-cov report {{args}}
-
 # ------------------------------------------------------------------------------
 # E2E tasks
 # ------------------------------------------------------------------------------

--- a/justfile
+++ b/justfile
@@ -287,10 +287,6 @@ stratus-test-coverage-misc *args="":
     export RUST_LOG=error
     export TRACING_LOG_FORMAT=json
     
-    just _coverage-run-stratus-recipe e2e-admin-password
-    rm -rf e2e_logs
-    rm -rf temp_*
-
     just _coverage-run-stratus-recipe e2e-rpc-downloader
     rm -rf e2e_logs
     rm -rf temp_*

--- a/justfile_helpers
+++ b/justfile_helpers
@@ -12,8 +12,8 @@ _log message:
 # Wait for Stratus to start.
 _wait_for_stratus port="3000":
     #!/bin/bash
-    just _log "Waiting 300 seconds for Stratus on port {{port}} to start"
-    wait-service --tcp 0.0.0.0:{{port}} -t 300 -- echo
+    just _log "Waiting 600 seconds for Stratus on port {{port}} to start"
+    wait-service --tcp 0.0.0.0:{{port}} -t 600 -- echo
     if [ $? -eq 0 ]; then
         just _log "Stratus on port {{port}} started"
     else


### PR DESCRIPTION
### **User description**
Enhance the coverage testing workflow by:
- Introducing a matrix strategy to parallelize coverage tests across different groups
- Adding support for individual group-based coverage generation
- Improving Codecov integration with group-specific flags
- Reducing overall workflow timeout

The changes allow more granular and efficient coverage testing by running different test groups in parallel, such as unit, inmemory, rocksdb, and others.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Implement matrix-based coverage testing strategy

- Parallelize tests across different groups

- Improve Codecov integration with group-specific flags

- Refactor justfile for granular coverage testing


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>coverage.yml</strong><dd><code>Implement matrix-based coverage workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/coverage.yml

<li>Introduce matrix strategy for parallel coverage tests<br> <li> Add Foundry installation step<br> <li> Modify coverage generation for group-specific output<br> <li> Update artifact upload and Codecov reporting


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2033/files#diff-a2115d277b5ca5a2f09a999e53440839cf332b94da177f3d1766334555b0f7c6">+18/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>justfile</strong><dd><code>Refactor justfile for granular coverage testing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

justfile

<li>Add <code>stratus-test-coverage-group</code> recipe for group-specific testing<br> <li> Implement case-based coverage execution for different test groups<br> <li> Refactor <code>stratus-test-coverage</code> to use new group-based approach<br> <li> Add helper recipes for leader-follower and misc tests


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2033/files#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1">+183/-51</a></td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>justfile_helpers</strong><dd><code>Extend Stratus startup timeout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

justfile_helpers

- Increase Stratus startup timeout from 300 to 600 seconds


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2033/files#diff-ceafeefe0a05bcfb7f2605021b3a6023e055ac359102cb979fbb80fee7a2e2cd">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>