### PR TITLE
chore: remove outdated permanent storage URL parameter

### DIFF
--- a/src/eth/storage/permanent/mod.rs
+++ b/src/eth/storage/permanent/mod.rs
@@ -93,10 +93,6 @@ pub struct PermanentStorageConfig {
     #[arg(long = "perm-storage", env = "PERM_STORAGE")]
     pub perm_storage_kind: PermanentStorageKind,
 
-    /// Storage connection URL.
-    #[arg(long = "perm-storage-url", env = "PERM_STORAGE_URL", required_if_eq_any([("perm_storage_kind", "redis")]))]
-    pub perm_storage_url: Option<String>,
-
     /// RocksDB storage path prefix to execute multiple local Stratus instances.
     #[arg(long = "rocks-path-prefix", env = "ROCKS_PATH_PREFIX")]
     pub rocks_path_prefix: Option<String>,


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Remove optional permanent storage URL parameter

- Simplify PermanentStorageConfig struct

- Update CLI arguments and environment variables


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Remove permanent storage URL configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/permanent/mod.rs

<li>Removed <code>perm_storage_url</code> field from <code>PermanentStorageConfig</code> struct<br> <li> Deleted associated CLI argument and environment variable


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2038/files#diff-5c1d69109eb8f0c1ff647aac434f8d48db626a5e159ca8a106ece3e402aef28a">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>