### PR TITLE
feat(rpc): add configurable max response size for JSON-RPC server

### DIFF
--- a/src/eth/rpc/rpc_config.rs
+++ b/src/eth/rpc/rpc_config.rs
@@ -16,6 +16,10 @@ pub struct RpcServerConfig {
     #[arg(long = "max-connections", env = "MAX_CONNECTIONS", default_value = "400")]
     pub rpc_max_connections: u32,
 
+    /// JSON-RPC server max response size limit in bytes
+    #[arg(long = "max-response-size-bytes", env = "MAX_RESPONSE_SIZE_BYTES", default_value = "10485760")]
+    pub rpc_max_response_size_bytes: u32,
+
     /// JSON-RPC server max active subscriptions per client.
     #[arg(long = "max-subscriptions", env = "MAX_SUBSCRIPTIONS", default_value = "30")]
     pub rpc_max_subscriptions: u32,

--- a/src/eth/rpc/rpc_server.rs
+++ b/src/eth/rpc/rpc_server.rs
@@ -150,6 +150,7 @@ pub async fn serve_rpc(
         .set_http_middleware(http_middleware)
         .set_id_provider(RandomStringIdProvider::new(8))
         .max_connections(rpc_config.rpc_max_connections)
+        .max_response_body_size(rpc_config.rpc_max_response_size_bytes)
         .build(rpc_config.rpc_address)
         .await?;
 


### PR DESCRIPTION
Add a new configuration parameter `rpc_max_response_size_bytes` to control the maximum response size for JSON-RPC server connections. This allows more granular control over server resource limits and prevents potential large response-related issues.