### PR TITLE
enha: add configurable max request size for JSON-RPC

### DIFF
--- a/e2e/cloudwalk-contracts/integration/test/leader-follower-change.test.ts
+++ b/e2e/cloudwalk-contracts/integration/test/leader-follower-change.test.ts
@@ -48,6 +48,7 @@ describe("Leader & Follower change integration test", function () {
             "ws://0.0.0.0:3001/",
             "2s",
             "100ms",
+            "10485760",
         ]);
         expect(response.data.error.code).to.equal(7007);
         expect(response.data.error.message).to.equal("Can't change miner mode while transactions are enabled.");
@@ -61,6 +62,7 @@ describe("Leader & Follower change integration test", function () {
             "ws://0.0.0.0:3001/",
             "2s",
             "100ms",
+            "10485760",
         ]);
         expect(response.data.error.code).to.equal(6002);
         expect(response.data.error.message.split("\n")[0]).to.equal(
@@ -77,6 +79,7 @@ describe("Leader & Follower change integration test", function () {
             "ws://0.0.0.0:3001/",
             "2s",
             "100ms",
+            "10485760",
         ]);
         expect(response.data.result).to.equal(true);
     });
@@ -137,6 +140,7 @@ describe("Leader & Follower change integration test", function () {
             "ws://0.0.0.0:3000/",
             "2s",
             "100ms",
+            "10485760",
         ]);
         expect(response.data.result).to.equal(true);
     });

--- a/e2e/cloudwalk-contracts/integration/test/leader-follower-importer.test.ts
+++ b/e2e/cloudwalk-contracts/integration/test/leader-follower-importer.test.ts
@@ -108,6 +108,7 @@ describe("Leader & Follower importer integration test", function () {
             "ws://0.0.0.0:3000/",
             "2s",
             "100ms",
+            "10485760",
         ]);
         expect(responseLeader.data.error.code).to.equal(7003);
         expect(responseLeader.data.error.message).to.equal("Stratus node is not a follower.");
@@ -126,6 +127,7 @@ describe("Leader & Follower importer integration test", function () {
             "ws://0.0.0.0:9999/",
             "2s",
             "100ms",
+            "10485760",
         ]);
         expect(responseInvalidAddressFollower.data.error.code).to.equal(4004);
         expect(responseInvalidAddressFollower.data.error.message).to.equal("Failed to initialize importer.");
@@ -137,6 +139,7 @@ describe("Leader & Follower importer integration test", function () {
             "ws://0.0.0.0:3000/",
             "2s",
             "100ms",
+            "10485760",
         ]);
         expect(responseValidFollower.data.result).to.equal(true);
     });
@@ -147,6 +150,7 @@ describe("Leader & Follower importer integration test", function () {
             "ws://0.0.0.0:3000/",
             "2s",
             "100ms",
+            "10485760",
         ]);
         expect(responseSecondInitFollower.data.error.code).to.equal(4001);
         expect(responseSecondInitFollower.data.error.message).to.equal("Importer is already running.");

--- a/src/bin/rpc_downloader.rs
+++ b/src/bin/rpc_downloader.rs
@@ -46,7 +46,7 @@ async fn run(config: RpcDownloaderConfig) -> anyhow::Result<()> {
     }
 
     let rpc_storage = config.rpc_storage.init().await?;
-    let chain = Arc::new(BlockchainClient::new_http(&config.external_rpc, config.external_rpc_timeout).await?);
+    let chain = Arc::new(BlockchainClient::new_http(&config.external_rpc, config.external_rpc_timeout, config.external_rpc_max_request_size_bytes).await?);
 
     let block_end = match config.block_end {
         Some(end) => BlockNumber::from(end),

--- a/src/config.rs
+++ b/src/config.rs
@@ -245,6 +245,14 @@ pub struct RpcDownloaderConfig {
     #[arg(long = "external-rpc-timeout", value_parser=parse_duration, env = "EXTERNAL_RPC_TIMEOUT", default_value = "2s")]
     pub external_rpc_timeout: Duration,
 
+    /// Maximum request size in bytes for external RPC requests
+    #[arg(
+        long = "external-rpc-max-request-size-bytes",
+        env = "EXTERNAL_RPC_MAX_REQUEST_SIZE_BYTES",
+        default_value = "10485760"
+    )]
+    pub external_rpc_max_request_size_bytes: u32,
+
     /// Number of parallel downloads.
     #[arg(short = 'p', long = "paralellism", env = "PARALELLISM", default_value = "1")]
     pub paralellism: usize,

--- a/src/eth/rpc/rpc_server.rs
+++ b/src/eth/rpc/rpc_server.rs
@@ -428,7 +428,8 @@ async fn stratus_init_importer(params: Params<'_>, ctx: Arc<RpcContext>, ext: Ex
     let (params, external_rpc) = next_rpc_param::<String>(params.sequence())?;
     let (params, external_rpc_ws) = next_rpc_param::<String>(params)?;
     let (params, raw_external_rpc_timeout) = next_rpc_param::<String>(params)?;
-    let (_, raw_sync_interval) = next_rpc_param::<String>(params)?;
+    let (params, raw_sync_interval) = next_rpc_param::<String>(params)?;
+    let (_, raw_external_rpc_max_request_size_bytes) = next_rpc_param::<String>(params)?;
 
     let external_rpc_timeout = parse_duration(&raw_external_rpc_timeout).map_err(|e| {
         tracing::error!(reason = ?e, "failed to parse external_rpc_timeout");
@@ -440,11 +441,17 @@ async fn stratus_init_importer(params: Params<'_>, ctx: Arc<RpcContext>, ext: Ex
         ImporterError::ConfigParseError
     })?;
 
+    let external_rpc_max_request_size_bytes = raw_external_rpc_max_request_size_bytes.parse::<u32>().map_err(|e| {
+        tracing::error!(reason = ?e, "failed to parse external_rpc_max_request_size_bytes");
+        ImporterError::ConfigParseError
+    })?;
+
     let importer_config = ImporterConfig {
         external_rpc,
         external_rpc_ws: Some(external_rpc_ws),
         external_rpc_timeout,
         sync_interval,
+        external_rpc_max_request_size_bytes,
     };
 
     importer_config.init_follower_importer(ctx).await

--- a/src/infra/blockchain_client/blockchain_client.rs
+++ b/src/infra/blockchain_client/blockchain_client.rs
@@ -38,20 +38,22 @@ pub struct BlockchainClient {
     ws: Option<RwLock<WsClient>>,
     ws_url: Option<String>,
     timeout: Duration,
+    #[allow(dead_code)]
+    max_request_size_bytes: u32,
 }
 
 impl BlockchainClient {
     /// Creates a new RPC client connected only to HTTP.
-    pub async fn new_http(http_url: &str, timeout: Duration) -> anyhow::Result<Self> {
-        Self::new_http_ws(http_url, None, timeout).await
+    pub async fn new_http(http_url: &str, timeout: Duration, max_request_size_bytes: u32) -> anyhow::Result<Self> {
+        Self::new_http_ws(http_url, None, timeout, max_request_size_bytes).await
     }
 
     /// Creates a new RPC client connected to HTTP and optionally to WS.
-    pub async fn new_http_ws(http_url: &str, ws_url: Option<&str>, timeout: Duration) -> anyhow::Result<Self> {
+    pub async fn new_http_ws(http_url: &str, ws_url: Option<&str>, timeout: Duration, max_request_size_bytes: u32) -> anyhow::Result<Self> {
         tracing::info!(%http_url, "creating blockchain client");
 
         // build http provider
-        let http = Self::build_http_client(http_url, timeout)?;
+        let http = Self::build_http_client(http_url, timeout, max_request_size_bytes)?;
 
         // build ws provider
         let ws = if let Some(ws_url) = ws_url {
@@ -66,6 +68,7 @@ impl BlockchainClient {
             ws,
             ws_url: ws_url.map(|x| x.to_owned()),
             timeout,
+            max_request_size_bytes,
         };
 
         // check health before assuming it is ok
@@ -74,9 +77,13 @@ impl BlockchainClient {
         Ok(client)
     }
 
-    fn build_http_client(url: &str, timeout: Duration) -> anyhow::Result<HttpClient> {
+    fn build_http_client(url: &str, timeout: Duration, max_request_size_bytes: u32) -> anyhow::Result<HttpClient> {
         tracing::info!(%url, timeout = %timeout.to_string_ext(), "creating blockchain http client");
-        match HttpClientBuilder::default().request_timeout(timeout).build(url) {
+        match HttpClientBuilder::default()
+            .request_timeout(timeout)
+            .max_request_size(max_request_size_bytes)
+            .build(url)
+        {
             Ok(http) => {
                 tracing::info!(%url, timeout = %timeout.to_string_ext(), "created blockchain http client");
                 Ok(http)

--- a/utils/deploy/deploy.py
+++ b/utils/deploy/deploy.py
@@ -26,6 +26,7 @@ class Config:
     auto_approve: bool
     external_rpc_timeout: str = "2s"
     sync_interval: str = "100ms"
+    external_rpc_max_request_size_bytes: str = "10485760"
     total_check_attempts: int = 10
     required_consecutive_checks: int = 3
     sleep_interval: float = 0.5
@@ -265,7 +266,7 @@ def main() -> None:
                         return
 
                 # Change Leader to Follower
-                change_to_follower_params = [f"http://{config.follower_address}/", f"ws://{config.follower_address}/", config.external_rpc_timeout, config.sync_interval]
+                change_to_follower_params = [f"http://{config.follower_address}/", f"ws://{config.follower_address}/", config.external_rpc_timeout, config.sync_interval, config.external_rpc_max_request_size_bytes]
                 change_role(address=config.leader_address, method="stratus_changeToFollower", params=change_to_follower_params, role=NodeRole.FOLLOWER)
 
                 # Validate new Follower state


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add configurable max request size for external RPC

- Implement in RPC downloader, importer, and blockchain client

- Update integration tests with new parameter

- Modify deployment script to include new configuration


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rpc_downloader.rs</strong><dd><code>Update RPC downloader with max request size parameter</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/bin/rpc_downloader.rs

<li>Add <code>external_rpc_max_request_size_bytes</code> parameter to <br><code>BlockchainClient::new_http</code> call


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2043/files#diff-34137b2d44a1c2a35b30a2515f309e99ecd04277d9b2d681ff55c5bbe30ac5c1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>importer_config.rs</strong><dd><code>Implement max request size in ImporterConfig</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/follower/importer/importer_config.rs

<li>Add <code>external_rpc_max_request_size_bytes</code> field to <code>ImporterConfig</code> struct<br> <li> Update <code>init</code> method to pass max request size to <br><code>BlockchainClient::new_http_ws</code>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2043/files#diff-d6208b041b3fff7e5d6e8ed530417cc9ac4d6037a7a9737370e05322418d1d34">+17/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>rpc_server.rs</strong><dd><code>Update RPC server to handle max request size parameter</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/rpc/rpc_server.rs

<li>Add parsing for <code>external_rpc_max_request_size_bytes</code> in <br><code>stratus_init_importer</code> function<br> <li> Include new parameter in <code>ImporterConfig</code> initialization


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2043/files#diff-835ba255c9a5c1fe0e13285bc39e058e1c74422e5e03ebba483c9d8a15c45405">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>blockchain_client.rs</strong><dd><code>Implement max request size in BlockchainClient</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/infra/blockchain_client/blockchain_client.rs

<li>Add <code>max_request_size_bytes</code> field to <code>BlockchainClient</code> struct<br> <li> Update <code>new_http</code>, <code>new_http_ws</code>, and <code>build_http_client</code> methods to include <br>max request size<br> <li> Set max request size in <code>HttpClientBuilder</code>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2043/files#diff-05af32e93a38a2ab966d4c4c633284d19cada2fa11c1962fabf9c981ff7fd3e6">+13/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.rs</strong><dd><code>Add max request size configuration to RpcDownloaderConfig</code></dd></summary>
<hr>

src/config.rs

<li>Add <code>external_rpc_max_request_size_bytes</code> field to <code>RpcDownloaderConfig</code> <br>struct<br> <li> Set default value to 10485760 bytes (10MB)


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2043/files#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecd">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>deploy.py</strong><dd><code>Update deployment script with max request size parameter</code>&nbsp; </dd></summary>
<hr>

utils/deploy/deploy.py

<li>Add <code>external_rpc_max_request_size_bytes</code> to <code>Config</code> class with default <br>value of "10485760"<br> <li> Include new parameter in <code>change_to_follower_params</code> list


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2043/files#diff-5cac6ac4e8e56f48fc33e163636d79fde99b570d397107f1880d3d4a8c9aa940">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>leader-follower-change.test.ts</strong><dd><code>Update leader-follower change tests with max request size</code></dd></summary>
<hr>

e2e/cloudwalk-contracts/integration/test/leader-follower-change.test.ts

<li>Add max request size parameter (10485760) to <code>stratus_changeToFollower</code> <br>calls in tests


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2043/files#diff-7236d4b676b75ced96eb321337290326efe4e91a261edc4e83b688c4da09dd7c">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>leader-follower-importer.test.ts</strong><dd><code>Update leader-follower importer tests with max request size</code></dd></summary>
<hr>

e2e/cloudwalk-contracts/integration/test/leader-follower-importer.test.ts

<li>Add max request size parameter (10485760) to <code>stratus_initImporter</code> <br>calls in tests


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2043/files#diff-76e205db03980cadded8f3f9ff7be76d1f3d3af18d4d8bf2cc8fa09d74934b8d">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>