### PR TITLE
fix: infer missing type field for transactions where v is 0x0 or 0x1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4789,16 +4789,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_path_to_error"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
-dependencies = [
- "itoa",
- "serde",
-]
-
-[[package]]
 name = "serde_plain"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5322,7 +5312,6 @@ dependencies = [
  "sentry-tracing",
  "serde",
  "serde_json",
- "serde_path_to_error",
  "serde_plain",
  "serde_urlencoded",
  "serde_with",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,7 +133,6 @@ sasl2-sys = { version = "=0.1.22", features = ["vendored"] }
 
 # Historic events processor
 indicatif = "=0.17.8"
-serde_path_to_error = "0.1.17"
 
 # ------------------------------------------------------------------------------
 # Platform specific dependencies


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Infer missing type field for transactions

- Add type 2 inference for v values 0x0/0x1

- Implement new test cases for type inference

- Add serde_path_to_error dependency


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>external_transaction.rs</strong><dd><code>Enhance transaction type inference and add tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/external_transaction.rs

<li>Infer type 2 transactions when v is 0x0 or 0x1<br> <li> Add logic to insert "type" field if missing<br> <li> Implement new test cases for type 2 inference<br> <li> Test both v=0x0 and v=0x1 scenarios


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2044/files#diff-a5bcf577600cee6a4844b4015797a92684df8ec490f06f66b4a556881a66032d">+51/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Add new dependency for error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Cargo.toml

- Add serde_path_to_error dependency version 0.1.17


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2044/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>