### PR TITLE
chore: don't log false-positive "failed to send subscription notification"

### DIFF
--- a/src/eth/rpc/rpc_subscriptions.rs
+++ b/src/eth/rpc/rpc_subscriptions.rs
@@ -344,9 +344,8 @@ impl RpcSubscriptions {
                 if let Err(e) = sink.send_timeout(msg_clone, NOTIFICATION_TIMEOUT).await {
                     match e {
                         jsonrpsee::SendTimeoutError::Timeout(msg) => tracing::error!(reason = ?msg, "failed to send subscription notification"),
-                        jsonrpsee::SendTimeoutError::Closed(msg) => {
-                            tracing::info!(reason = ?msg, "failed to send subscription notification because the connection was closed")
-                        }
+                        jsonrpsee::SendTimeoutError::Closed(msg) =>
+                            tracing::info!(reason = ?msg, "failed to send subscription notification because the connection was closed"),
                     }
                 }
             });

--- a/src/eth/rpc/rpc_subscriptions.rs
+++ b/src/eth/rpc/rpc_subscriptions.rs
@@ -342,7 +342,12 @@ impl RpcSubscriptions {
             let msg_clone = msg.clone();
             spawn_named("rpc::sub::notify", async move {
                 if let Err(e) = sink.send_timeout(msg_clone, NOTIFICATION_TIMEOUT).await {
-                    tracing::error!(reason = ?e, "failed to send subscription notification");
+                    match e {
+                        jsonrpsee::SendTimeoutError::Timeout(msg) => tracing::error!(reason = ?msg, "failed to send subscription notification"),
+                        jsonrpsee::SendTimeoutError::Closed(msg) => {
+                            tracing::info!(reason = ?msg, "failed to send subscription notification because the connection was closed")
+                        }
+                    }
                 }
             });
         }


### PR DESCRIPTION
### **User description**
closes #1864


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Improve error handling for subscription notifications

- Differentiate between timeout and closed connection errors

- Log closed connection errors as info instead of error

- Enhance observability of subscription notification process


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rpc_subscriptions.rs</strong><dd><code>Enhance subscription notification error handling and logging</code></dd></summary>
<hr>

src/eth/rpc/rpc_subscriptions.rs

<li>Replace generic error logging with specific error type handling<br> <li> Implement separate logging for timeout and closed connection errors<br> <li> Change log level for closed connection errors from error to info<br> <li> Provide more detailed error information in log messages


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2048/files#diff-a07ba1157cec6586a0520b8dfb11e9d073359af24471ac286ff5eaa2669d355c">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>