### PR TITLE
enha: improve rlp decoding in sendRawTransaction

### DIFF
--- a/src/eth/rpc/rpc_middleware.rs
+++ b/src/eth/rpc/rpc_middleware.rs
@@ -86,18 +86,47 @@ impl<'a> RpcServiceT<'a> for RpcMiddleware {
 
         // extract request data
         let method = request.method_name().to_owned();
-        let tx = match method.as_str() {
-            "eth_call" | "eth_estimateGas" => TransactionTracingIdentifiers::from_call(request.params()).ok(),
-            "eth_sendRawTransaction" => TransactionTracingIdentifiers::from_transaction(request.params()).ok(),
-            "eth_getTransactionByHash" | "eth_getTransactionReceipt" => TransactionTracingIdentifiers::from_transaction_query(request.params()).ok(),
-            _ => None,
-        };
+        let mut tx = None;
+
+        let params_clone = request.params().clone();
+
+        if method == "eth_sendRawTransaction" {
+            let tx_data_result = next_rpc_param::<Bytes>(params_clone.sequence());
+
+            if let Ok((params, tx_data)) = tx_data_result {
+                let decoded_tx_result = parse_rpc_rlp::<TransactionInput>(&tx_data);
+
+                if let Ok(decoded_tx) = decoded_tx_result {
+                    let client_opt = next_rpc_param::<RpcClientApp>(params).map(|(_, client)| client).ok();
+
+                    tx = Some(TransactionTracingIdentifiers {
+                        client: client_opt,
+                        hash: Some(decoded_tx.hash),
+                        contract: codegen::contract_name(&decoded_tx.to),
+                        function: codegen::function_sig(&decoded_tx.input),
+                        from: Some(decoded_tx.signer),
+                        to: decoded_tx.to,
+                        nonce: Some(decoded_tx.nonce),
+                    });
+
+                    request.extensions_mut().insert(tx_data);
+                    request.extensions_mut().insert(decoded_tx);
+                }
+            }
+        } else {
+            // Handle other methods normally
+            tx = match method.as_str() {
+                "eth_call" | "eth_estimateGas" => TransactionTracingIdentifiers::from_call(params_clone.clone()).ok(),
+                "eth_getTransactionByHash" | "eth_getTransactionReceipt" => TransactionTracingIdentifiers::from_transaction_query(params_clone.clone()).ok(),
+                _ => None,
+            };
+        }
 
         let is_admin = request.extensions.is_admin();
 
         let client = if let Some(tx_client) = tx.as_ref().and_then(|tx| tx.client.as_ref()) {
-            let val = tx_client.clone();
-            request.extensions_mut().insert(val);
+            // Insert the client directly into extensions
+            request.extensions_mut().insert(tx_client.clone());
             tx_client
         } else {
             request.extensions.rpc_client()
@@ -288,23 +317,6 @@ struct TransactionTracingIdentifiers {
 }
 
 impl TransactionTracingIdentifiers {
-    // eth_sendRawTransaction
-    fn from_transaction(params: Params) -> anyhow::Result<Self> {
-        let (params, tx_data) = next_rpc_param::<Bytes>(params.sequence())?;
-        let tx = parse_rpc_rlp::<TransactionInput>(&tx_data)?;
-        let client = next_rpc_param::<RpcClientApp>(params);
-
-        Ok(Self {
-            client: client.map(|(_, client)| client).ok(),
-            hash: Some(tx.hash),
-            contract: codegen::contract_name(&tx.to),
-            function: codegen::function_sig(&tx.input),
-            from: Some(tx.signer),
-            to: tx.to,
-            nonce: Some(tx.nonce),
-        })
-    }
-
     /// eth_call / eth_estimateGas
     fn from_call(params: Params) -> anyhow::Result<Self> {
         let (_, call) = next_rpc_param::<CallInput>(params.sequence())?;

--- a/src/eth/rpc/rpc_middleware.rs
+++ b/src/eth/rpc/rpc_middleware.rs
@@ -124,7 +124,6 @@ impl<'a> RpcServiceT<'a> for RpcMiddleware {
         let is_admin = request.extensions.is_admin();
 
         let client = if let Some(tx_client) = tx.as_ref().and_then(|tx| tx.client.as_ref()) {
-            // Insert the client directly into extensions
             request.extensions_mut().insert(tx_client.clone());
             tx_client
         } else {

--- a/src/eth/rpc/rpc_middleware.rs
+++ b/src/eth/rpc/rpc_middleware.rs
@@ -114,7 +114,6 @@ impl<'a> RpcServiceT<'a> for RpcMiddleware {
                 }
             }
         } else {
-            // Handle other methods normally
             tx = match method.as_str() {
                 "eth_call" | "eth_estimateGas" => TransactionTracingIdentifiers::from_call(params_clone.clone()).ok(),
                 "eth_getTransactionByHash" | "eth_getTransactionReceipt" => TransactionTracingIdentifiers::from_transaction_query(params_clone.clone()).ok(),


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Improved RLP decoding in eth_sendRawTransaction

- Removed redundant transaction parsing logic

- Enhanced transaction extraction in RPC middleware

- Updated error handling for missing transaction input


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rpc_middleware.rs</strong><dd><code>Optimize transaction extraction in RPC middleware</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/rpc/rpc_middleware.rs

<li>Implemented direct RLP decoding for eth_sendRawTransaction<br> <li> Added transaction data to request extensions<br> <li> Updated handling of other RPC methods<br> <li> Removed redundant TransactionTracingIdentifiers::from_transaction <br>method


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2052/files#diff-31b7182aec4416845e60ec9ec16720ae97d31260e1a9c50d601d542dee8776f5">+35/-25</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rpc_server.rs</strong><dd><code>Refactor eth_send_raw_transaction to use pre-decoded data</code></dd></summary>
<hr>

src/eth/rpc/rpc_server.rs

<li>Removed manual transaction parsing in eth_send_raw_transaction<br> <li> Added error handling for missing transaction input<br> <li> Updated function signature to ignore unused parameters


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2052/files#diff-835ba255c9a5c1fe0e13285bc39e058e1c74422e5e03ebba483c9d8a15c45405">+13/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>