### PR TITLE
fix: client metrics being wrongly populated

### DIFF
--- a/src/eth/rpc/rpc_middleware.rs
+++ b/src/eth/rpc/rpc_middleware.rs
@@ -97,7 +97,7 @@ impl<'a> RpcServiceT<'a> for RpcMiddleware {
                 let decoded_tx_result = parse_rpc_rlp::<TransactionInput>(&tx_data);
 
                 if let Ok(decoded_tx) = decoded_tx_result {
-                    tx = TransactionTracingIdentifiers::from_raw_transaction(params_clone.clone(), &decoded_tx).ok();
+                    tx = TransactionTracingIdentifiers::from_raw_transaction(&decoded_tx).ok();
 
                     request.extensions_mut().insert(tx_data);
                     request.extensions_mut().insert(decoded_tx);
@@ -306,11 +306,9 @@ struct TransactionTracingIdentifiers {
 
 impl TransactionTracingIdentifiers {
     /// eth_sendRawTransaction
-    fn from_raw_transaction(params: Params, decoded_tx: &TransactionInput) -> anyhow::Result<Self> {
-        let client_opt = next_rpc_param::<RpcClientApp>(params.sequence()).map(|(_, client)| client).ok();
-
+    fn from_raw_transaction(decoded_tx: &TransactionInput) -> anyhow::Result<Self> {
         Ok(Self {
-            client: client_opt,
+            client: None,
             hash: Some(decoded_tx.hash),
             contract: codegen::contract_name(&decoded_tx.to),
             function: codegen::function_sig(&decoded_tx.input),


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Simplified transaction tracing in RPC middleware

- Removed unnecessary parameters from `from_raw_transaction` method

- Eliminated redundant client extraction logic

- Improved code clarity and efficiency


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rpc_middleware.rs</strong><dd><code>Simplify transaction tracing and improve RPC middleware efficiency</code></dd></summary>
<hr>

src/eth/rpc/rpc_middleware.rs

<li>Updated <code>from_raw_transaction</code> method to accept only decoded transaction <br>input<br> <li> Removed client extraction logic from <code>TransactionTracingIdentifiers</code><br> <li> Simplified <code>RpcMiddleware</code> implementation for transaction handling<br> <li> Set <code>client</code> field to <code>None</code> directly in <code>TransactionTracingIdentifiers</code>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2054/files#diff-31b7182aec4416845e60ec9ec16720ae97d31260e1a9c50d601d542dee8776f5">+3/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>