### PR TITLE
fix: use a bounded channel for the importer block fetcher

### DIFF
--- a/.github/workflows/merge-gatekeeper.yml
+++ b/.github/workflows/merge-gatekeeper.yml
@@ -20,4 +20,4 @@ jobs:
           self: Merge Gatekeeper
           interval: 5
           timeout: 1800
-          ignored: PR Agent
+          ignored: PR Agent,E2E Rocks on periphery,E2E InMemory on periphery


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Replace unbounded channel with bounded channel (10,000 capacity)

- Modify block fetcher to use bounded channel

- Update block executor to use bounded channel

- Change send operation to asynchronous in block fetcher


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>importer.rs</strong><dd><code>Replace unbounded channel with bounded channel in importer</code></dd></summary>
<hr>

src/eth/follower/importer/importer.rs

<li>Replace <code>mpsc::unbounded_channel()</code> with <code>mpsc::channel(10_000)</code><br> <li> Update <code>backlog_rx</code> type from <code>UnboundedReceiver</code> to <code>Receiver</code><br> <li> Change <code>backlog_tx</code> type from <code>UnboundedSender</code> to <code>Sender</code><br> <li> Modify <code>backlog_tx.send()</code> to be asynchronous with <code>.await</code>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2059/files#diff-bd50f502f039aff8f75753bc780d281ae7d7936fadc9d53482084c647aec94ca">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>