### PR TITLE
fix: typo in action that was causing only one type of e2e to run

### DIFF
--- a/.github/workflows/_setup-e2e.yml
+++ b/.github/workflows/_setup-e2e.yml
@@ -86,7 +86,7 @@ jobs:
           tool: cargo-llvm-cov@0.6.14
 
       - name: Run e2e tests
-        run: ${{ inputs.justfile_env }} just run-test ${{ inputs.justfile_recipe }} ${{ inputs.jusftile_args }}
+        run: ${{ inputs.justfile_env }} just run-test ${{ inputs.justfile_recipe }} ${{ inputs.justfile_args }}
         env:
           CARGO_PROFILE_RELEASE_DEBUG: 0
           RUST_LOG: error


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix typo in GitHub Actions workflow file

- Correct argument passing in e2e test execution


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>_setup-e2e.yml</strong><dd><code>Fix typo in e2e test execution command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/_setup-e2e.yml

- Corrected typo in `run` command: `jusftile_args` to `justfile_args`


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2064/files#diff-41e89a8381754cea161274f93967da9d766868c2ee6083c52bf19d5f554ec332">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>