### PR TITLE
coverage: fix: add codecov.yaml with allow_coverage_offsets set to True

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,0 +1,2 @@
+codecov:
+  allow_coverage_offsets: True


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add codecov.yaml configuration file

- Enable allow_coverage_offsets setting in Codecov


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>codecov.yaml</strong><dd><code>Configure Codecov to allow coverage offsets</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codecov.yaml

- Add new codecov.yaml file
- Set `allow_coverage_offsets` to `True`


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2066/files#diff-dd0aaed42efd4c8adb46abdee691cfb7a3f4a56cfb45caef82da9b3e9b5469b2">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>