### PR TITLE
fix: add flag to skip coverage

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -57,6 +57,7 @@ jobs:
     with:
       justfile_recipe: "e2e-stratus"
       justfile_args: "10ms"
+      justfile_env: "SKIP_COVERAGE=1"
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     concurrency:

--- a/justfile
+++ b/justfile
@@ -98,7 +98,14 @@ stratus *args="":
 # Bin: Stratus main service as leader
 stratus-test *args="":
     #!/bin/bash
-    source <(cargo llvm-cov show-env --export-prefix)
+    
+    # Skip coverage if SKIP_COVERAGE is set to any non-empty value
+    if [ -n "${SKIP_COVERAGE}" ]; then
+        echo "Skipping coverage collection as SKIP_COVERAGE is set"
+    else
+        echo "Collecting coverage information"
+        source <(cargo llvm-cov show-env --export-prefix)
+    fi
     cargo build --features dev
     cargo run --bin stratus --features dev -- --leader {{args}} > stratus.log &
     just _wait_for_stratus


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Add SKIP_COVERAGE flag for e2e-interval-stratus workflow

- Implement conditional coverage collection in justfile

- Skip coverage generation when SKIP_COVERAGE is set

- Update e2e-test workflow to use SKIP_COVERAGE


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>e2e-test.yml</strong><dd><code>Add SKIP_COVERAGE flag to e2e-interval-stratus workflow</code>&nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/e2e-test.yml

- Add `justfile_env: "SKIP_COVERAGE=1"` to e2e-interval-stratus job


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2086/files#diff-5cc2c864012004f60ee3f9078fa1c4a8721c6b841e386c57f12bea58b692e6e2">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>justfile</strong><dd><code>Implement conditional coverage collection and reporting</code>&nbsp; &nbsp; </dd></summary>
<hr>

justfile

<li>Add conditional logic to skip coverage collection<br> <li> Implement checks for SKIP_COVERAGE environment variable<br> <li> Skip coverage report generation when SKIP_COVERAGE is set<br> <li> Maintain existing functionality when SKIP_COVERAGE is not set


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2086/files#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1">+19/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>