### PR TITLE
chore: fix tokio and openssl security issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3291,9 +3291,9 @@ checksum = "e296cf87e61c9cfc1a61c3c63a0f7f286ed4554e0e22be84e8a38e1d264a2a29"
 
 [[package]]
 name = "openssl"
-version = "0.10.68"
+version = "0.10.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
+checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
 dependencies = [
  "bitflags 2.8.0",
  "cfg-if",
@@ -3323,9 +3323,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.104"
+version = "0.9.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
+checksum = "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07"
 dependencies = [
  "cc",
  "libc",
@@ -5286,6 +5286,7 @@ dependencies = [
  "nom",
  "nonempty",
  "oneshot",
+ "openssl",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
@@ -5648,9 +5649,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.38.0"
+version = "1.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
+checksum = "68722da18b0fc4a05fdc1120b302b82051265792a1e1b399086e9b204b10ad3d"
 dependencies = [
  "backtrace",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ uuid = { version = "=1.10.0", features = ["v7"]}
 stratus_macros = { path = "./crates/stratus_macros" }
 
 # async
-tokio = { version = "=1.38.0", features = [
+tokio = { version = "=1.38.2", features = [
     "rt-multi-thread",
     "macros",
     "signal",
@@ -95,6 +95,7 @@ http = "=1.1.0"
 http-body = "=1.0.1"
 http-body-util = "=0.1.2"
 bytes = "=1.9.0"
+openssl = "=0.10.72"
 
 # observability
 console-subscriber = "=0.2.0"


### PR DESCRIPTION
### **User description**
https://github.com/cloudwalk/stratus/security/dependabot/82
https://github.com/cloudwalk/stratus/security/dependabot/70
https://github.com/cloudwalk/stratus/security/dependabot/83


___

### **PR Type**
Enhancement


___

### **Description**
- Update Tokio to version 1.38.2 for security fixes

- Add OpenSSL dependency version 0.10.72


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Update Tokio and add OpenSSL dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Cargo.toml

<li>Updated Tokio version from 1.38.0 to 1.38.2<br> <li> Added OpenSSL dependency with version 0.10.72


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2092/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>