### PR TITLE
fix: cf size metric fields

### DIFF
--- a/src/eth/storage/permanent/rocks/rocks_state.rs
+++ b/src/eth/storage/permanent/rocks/rocks_state.rs
@@ -662,7 +662,7 @@ impl RocksStorageState {
 
         for (cf_name, cf_handle) in column_families {
             if let Ok(Some(size)) = self.db.property_int_value_cf(&cf_handle, "rocksdb.total-sst-files-size") {
-                metrics::set_rocks_cf_size(size, cf_name, db_name);
+                metrics::set_rocks_cf_size(size, db_name, cf_name);
             }
         }
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed incorrect parameter order in `set_rocks_cf_size` call


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rocks_state.rs</strong><dd><code>Correct parameter order for RocksDB metrics</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/permanent/rocks/rocks_state.rs

<li>Swapped <code>cf_name</code> and <code>db_name</code> parameters in <code>metrics::set_rocks_cf_size</code> <br>call


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2097/files#diff-9d38c98aa2d77c1665d2e2e11a0abc4787424d1b41a610d2fc1c4ea0311014a9">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>