### PR TITLE
perf: rocks slots baseline

### DIFF
--- a/src/eth/storage/cache.rs
+++ b/src/eth/storage/cache.rs
@@ -21,11 +21,11 @@ pub struct StorageCache {
 #[derive(DebugAsJson, Clone, Parser, serde::Serialize)]
 pub struct CacheConfig {
     /// Capacity of slot cache
-    #[arg(long = "slot-cache-capacity", env = "SLOT_CACHE_CAPACITY", default_value = "100000")]
+    #[arg(long = "slot-cache-capacity", env = "SLOT_CACHE_CAPACITY", default_value = "0")]
     pub slot_cache_capacity: usize,
 
     /// Capacity of account cache
-    #[arg(long = "account-cache-capacity", env = "ACCOUNT_CACHE_CAPACITY", default_value = "20000")]
+    #[arg(long = "account-cache-capacity", env = "ACCOUNT_CACHE_CAPACITY", default_value = "0")]
     pub account_cache_capacity: usize,
 }
 

--- a/src/eth/storage/permanent/rocks/rocks_state.rs
+++ b/src/eth/storage/permanent/rocks/rocks_state.rs
@@ -83,9 +83,9 @@ pub fn generate_cf_options_map(cache_multiplier: Option<f32>) -> HashMap<&'stati
     };
 
     hmap! {
-        "accounts" => DbConfig::OptimizedPointLookUp.to_options(cached_in_gigs_and_multiplied(15), None),
+        "accounts" => DbConfig::OptimizedPointLookUp.to_options(CacheSetting::Disabled, None),
         "accounts_history" => DbConfig::Default.to_options(CacheSetting::Disabled, Some(20)),
-        "account_slots" => DbConfig::OptimizedPointLookUp.to_options(cached_in_gigs_and_multiplied(45), Some(20)),
+        "account_slots" => DbConfig::OptimizedPointLookUp.to_options(CacheSetting::Disabled, Some(20)),
         "account_slots_history" => DbConfig::Default.to_options(CacheSetting::Disabled, Some(52)),
         "transactions" => DbConfig::Default.to_options(CacheSetting::Disabled, None),
         "blocks_by_number" => DbConfig::Default.to_options(CacheSetting::Disabled, None),


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Disable slot and account cache by default

- Disable RocksDB caching for accounts and account slots


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cache.rs</strong><dd><code>Disable in-memory slot and account caches by default</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/cache.rs

<li>Changed default value of <code>slot_cache_capacity</code> to 0<br> <li> Changed default value of <code>account_cache_capacity</code> to 0


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2100/files#diff-b8200ddbedbd8dab58d6c980baad75e39c70b818c009a4d556ee71b13f046307">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>rocks_state.rs</strong><dd><code>Disable RocksDB caching for accounts and account slots</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/permanent/rocks/rocks_state.rs

<li>Disabled RocksDB caching for 'accounts' column family<br> <li> Disabled RocksDB caching for 'account_slots' column family


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2100/files#diff-9d38c98aa2d77c1665d2e2e11a0abc4787424d1b41a610d2fc1c4ea0311014a9">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>