### PR TITLE
test 9: bloom ratio 0.08

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![codecov](https://codecov.io/github/cloudwalk/stratus/graph/badge.svg?token=D1795GHLG6)](https://codecov.io/github/cloudwalk/stratus)
-
+a
 # Stratus ☁️
 
 Welcome to Stratus, the cutting-edge EVM executor and JSON-RPC server with custom storage that scales horizontally. Built in Rust 🦀 for speed and reliability, Stratus is here to take your blockchain projects to the next level!

--- a/src/eth/storage/permanent/rocks/rocks_config.rs
+++ b/src/eth/storage/permanent/rocks/rocks_config.rs
@@ -43,7 +43,7 @@ impl DbConfig {
         if let Some(prefix_len) = prefix_len {
             let transform = rocksdb::SliceTransform::create_fixed_prefix(prefix_len);
             block_based_options.set_index_type(rocksdb::BlockBasedIndexType::HashSearch);
-            opts.set_memtable_prefix_bloom_ratio(0.02);
+            opts.set_memtable_prefix_bloom_ratio(0.08);
             opts.set_prefix_extractor(transform);
         }
 

--- a/src/eth/storage/permanent/rocks/rocks_config.rs
+++ b/src/eth/storage/permanent/rocks/rocks_config.rs
@@ -43,7 +43,7 @@ impl DbConfig {
         if let Some(prefix_len) = prefix_len {
             let transform = rocksdb::SliceTransform::create_fixed_prefix(prefix_len);
             block_based_options.set_index_type(rocksdb::BlockBasedIndexType::HashSearch);
-            opts.set_memtable_prefix_bloom_ratio(0.15);
+            opts.set_memtable_prefix_bloom_ratio(0.02);
             opts.set_prefix_extractor(transform);
         }
 


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Adjusted memtable prefix bloom ratio to 0.08

- Minor change to README.md


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rocks_config.rs</strong><dd><code>Adjust RocksDB memtable prefix bloom ratio</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/permanent/rocks/rocks_config.rs

- Changed memtable prefix bloom ratio from 0.15 to 0.08


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2109/files#diff-8f09ddf1ee290769ad87d67b994627ad2357a63824fa23b8275d1e766a28a777">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Minor addition to README.md</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

- Added a single character 'a' to the second line


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2109/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>