### PR TITLE
test 10: distribute cache

### DIFF
--- a/src/eth/storage/permanent/rocks/rocks_state.rs
+++ b/src/eth/storage/permanent/rocks/rocks_state.rs
@@ -83,13 +83,13 @@ pub fn generate_cf_options_map(cache_multiplier: Option<f32>) -> HashMap<&'stati
     };
 
     hmap! {
-        "accounts" => DbConfig::OptimizedPointLookUp.to_options(cached_in_gigs_and_multiplied(15), None),
-        "accounts_history" => DbConfig::Default.to_options(CacheSetting::Disabled, Some(20)),
-        "account_slots" => DbConfig::OptimizedPointLookUp.to_options(cached_in_gigs_and_multiplied(45), Some(20)),
-        "account_slots_history" => DbConfig::Default.to_options(CacheSetting::Disabled, Some(52)),
-        "transactions" => DbConfig::Default.to_options(CacheSetting::Disabled, None),
-        "blocks_by_number" => DbConfig::Default.to_options(CacheSetting::Disabled, None),
-        "blocks_by_hash" => DbConfig::Default.to_options(CacheSetting::Disabled, None)
+        "accounts" => DbConfig::OptimizedPointLookUp.to_options(cached_in_gigs_and_multiplied(2), None),
+        "accounts_history" => DbConfig::Default.to_options(cached_in_gigs_and_multiplied(2), Some(20)),
+        "account_slots" => DbConfig::OptimizedPointLookUp.to_options(cached_in_gigs_and_multiplied(15), Some(20)),
+        "account_slots_history" => DbConfig::Default.to_options(cached_in_gigs_and_multiplied(25), Some(52)),
+        "transactions" => DbConfig::Default.to_options(cached_in_gigs_and_multiplied(5), None),
+        "blocks_by_number" => DbConfig::Default.to_options(cached_in_gigs_and_multiplied(10), None),
+        "blocks_by_hash" => DbConfig::Default.to_options(cached_in_gigs_and_multiplied(1), None)
     }
 }
 


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Adjusted cache settings for multiple database columns

- Enabled caching for previously disabled columns

- Reduced cache size for some columns

- Increased cache size for other columns


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rocks_state.rs</strong><dd><code>Redistribute and optimize database column cache settings</code>&nbsp; </dd></summary>
<hr>

src/eth/storage/permanent/rocks/rocks_state.rs

<li>Modified cache settings for all database columns<br> <li> Enabled caching for previously disabled columns (accounts_history, <br>transactions, blocks_by_number, blocks_by_hash)<br> <li> Reduced cache size for accounts and account_slots<br> <li> Increased cache size for account_slots_history


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2111/files#diff-9d38c98aa2d77c1665d2e2e11a0abc4787424d1b41a610d2fc1c4ea0311014a9">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>