### PR TITLE
test 11: sst and block size

### DIFF
--- a/src/eth/storage/permanent/rocks/rocks_config.rs
+++ b/src/eth/storage/permanent/rocks/rocks_config.rs
@@ -66,14 +66,12 @@ impl DbConfig {
                 
                 block_based_options.set_block_size(16 * 1024); // 16KB blocks
                 opts.set_target_file_size_base(128 * 1024 * 1024); // 128MB SST files
-                opts.set_max_bytes_for_level_base(256 * 1024 * 1024); // 256MB for L1
                 opts.set_level_compaction_dynamic_level_bytes(false);
             }
             
             DbConfig::OptimizedRangeScan => {
                 block_based_options.set_block_size(64 * 1024); // 64KB blocks
                 opts.set_target_file_size_base(512 * 1024 * 1024); // 512MB SST files
-                opts.set_max_bytes_for_level_base(1024 * 1024 * 1024); // 1GB for L1
                 
                 opts.set_compression_type(rocksdb::DBCompressionType::Lz4);
                 opts.set_bottommost_compression_type(rocksdb::DBCompressionType::Zstd);
@@ -91,7 +89,6 @@ impl DbConfig {
                 
                 block_based_options.set_block_size(32 * 1024); // 32KB blocks
                 opts.set_target_file_size_base(256 * 1024 * 1024); // 256MB SST files
-                opts.set_max_bytes_for_level_base(512 * 1024 * 1024); // 512MB for L1
                 opts.set_level_compaction_dynamic_level_bytes(true);
             }
         }

--- a/src/eth/storage/permanent/rocks/rocks_db.rs
+++ b/src/eth/storage/permanent/rocks/rocks_db.rs
@@ -25,7 +25,7 @@ pub fn create_or_open_db(path: impl AsRef<Path>, cf_configs: &HashMap<&'static s
     let cf_config_iter = cf_configs.iter().map(|(name, opts)| (*name, opts.clone()));
 
     tracing::debug!("generating options for column families");
-    let db_opts = DbConfig::Default.to_options(CacheSetting::Disabled, None);
+    let db_opts = DbConfig::MixedWorkload.to_options(CacheSetting::Disabled, None);
 
     if !path.exists() {
         tracing::warn!(?path, "RocksDB at path doesn't exist, creating a new one there instead");

--- a/src/eth/storage/permanent/rocks/rocks_state.rs
+++ b/src/eth/storage/permanent/rocks/rocks_state.rs
@@ -83,13 +83,18 @@ pub fn generate_cf_options_map(cache_multiplier: Option<f32>) -> HashMap<&'stati
     };
 
     hmap! {
+        // Point lookup optimized CFs
         "accounts" => DbConfig::OptimizedPointLookUp.to_options(cached_in_gigs_and_multiplied(2), None),
-        "accounts_history" => DbConfig::Default.to_options(cached_in_gigs_and_multiplied(2), Some(20)),
         "account_slots" => DbConfig::OptimizedPointLookUp.to_options(cached_in_gigs_and_multiplied(15), Some(20)),
-        "account_slots_history" => DbConfig::Default.to_options(cached_in_gigs_and_multiplied(25), Some(52)),
-        "transactions" => DbConfig::Default.to_options(cached_in_gigs_and_multiplied(5), None),
-        "blocks_by_number" => DbConfig::Default.to_options(cached_in_gigs_and_multiplied(10), None),
-        "blocks_by_hash" => DbConfig::Default.to_options(cached_in_gigs_and_multiplied(1), None)
+        "blocks_by_hash" => DbConfig::OptimizedPointLookUp.to_options(cached_in_gigs_and_multiplied(1), None),
+        
+        // Range scan optimized CFs
+        "account_slots_history" => DbConfig::OptimizedRangeScan.to_options(cached_in_gigs_and_multiplied(25), Some(52)),
+        "accounts_history" => DbConfig::OptimizedRangeScan.to_options(cached_in_gigs_and_multiplied(2), Some(20)),
+        "blocks_by_number" => DbConfig::OptimizedRangeScan.to_options(cached_in_gigs_and_multiplied(10), None),
+        
+        // Mixed workload CFs
+        "transactions" => DbConfig::MixedWorkload.to_options(cached_in_gigs_and_multiplied(5), None)
     }
 }
 

--- a/src/eth/storage/permanent/rocks/rocks_state.rs
+++ b/src/eth/storage/permanent/rocks/rocks_state.rs
@@ -83,13 +83,13 @@ pub fn generate_cf_options_map(cache_multiplier: Option<f32>) -> HashMap<&'stati
     };
 
     hmap! {
-        "accounts" => DbConfig::OptimizedPointLookUp.to_options(cached_in_gigs_and_multiplied(15), None),
-        "accounts_history" => DbConfig::Default.to_options(CacheSetting::Disabled, Some(20)),
-        "account_slots" => DbConfig::OptimizedPointLookUp.to_options(cached_in_gigs_and_multiplied(45), Some(20)),
-        "account_slots_history" => DbConfig::Default.to_options(CacheSetting::Disabled, Some(52)),
-        "transactions" => DbConfig::Default.to_options(CacheSetting::Disabled, None),
-        "blocks_by_number" => DbConfig::Default.to_options(CacheSetting::Disabled, None),
-        "blocks_by_hash" => DbConfig::Default.to_options(CacheSetting::Disabled, None)
+        "accounts" => DbConfig::OptimizedPointLookUp.to_options(cached_in_gigs_and_multiplied(2), None),
+        "accounts_history" => DbConfig::Default.to_options(cached_in_gigs_and_multiplied(2), Some(20)),
+        "account_slots" => DbConfig::OptimizedPointLookUp.to_options(cached_in_gigs_and_multiplied(15), Some(20)),
+        "account_slots_history" => DbConfig::Default.to_options(cached_in_gigs_and_multiplied(25), Some(52)),
+        "transactions" => DbConfig::Default.to_options(cached_in_gigs_and_multiplied(5), None),
+        "blocks_by_number" => DbConfig::Default.to_options(cached_in_gigs_and_multiplied(10), None),
+        "blocks_by_hash" => DbConfig::Default.to_options(cached_in_gigs_and_multiplied(1), None)
     }
 }
 


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Optimize RocksDB configurations for different workloads

- Introduce new DbConfig variant: OptimizedRangeScan

- Adjust block sizes, SST file sizes, and compression

- Fine-tune column family settings for performance


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rocks_config.rs</strong><dd><code>Enhance RocksDB configuration options and defaults</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/permanent/rocks/rocks_config.rs

<li>Added OptimizedRangeScan and MixedWorkload DbConfig variants<br> <li> Implemented specific configurations for each DbConfig type<br> <li> Adjusted block sizes, SST file sizes, and compression settings<br> <li> Set default DbConfig to MixedWorkload


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2112/files#diff-8f09ddf1ee290769ad87d67b994627ad2357a63824fa23b8275d1e766a28a777">+29/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>rocks_state.rs</strong><dd><code>Optimize column family configurations for different access patterns</code></dd></summary>
<hr>

src/eth/storage/permanent/rocks/rocks_state.rs

<li>Reorganized column family configurations<br> <li> Optimized settings for point lookup, range scan, and mixed workloads<br> <li> Adjusted cache sizes and compression settings


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2112/files#diff-9d38c98aa2d77c1665d2e2e11a0abc4787424d1b41a610d2fc1c4ea0311014a9">+12/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rocks_db.rs</strong><dd><code>Update default RocksDB configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/permanent/rocks/rocks_db.rs

- Changed default DbConfig from Default to MixedWorkload


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2112/files#diff-dbfbd37776a9fa0a5c4dcc69c520cdfd65bd7206ab3fdd06351a54fdfd3657f5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>