### PR TITLE
test: replace non-existent BRLC token functions

### DIFF
--- a/e2e/cloudwalk-contracts/integration/test/helpers/rpc.ts
+++ b/e2e/cloudwalk-contracts/integration/test/helpers/rpc.ts
@@ -91,16 +91,11 @@ export async function deployBRLC() {
 }
 
 export async function configureBRLC() {
-    await waitReceipt(brlcToken.grantRole(
-      await brlcToken.GRANTOR_ROLE(),
-      await deployer.getAddress(),
-      { gasLimit: GAS_LIMIT_OVERRIDE }
-    ));
-    await waitReceipt(brlcToken.grantRole(
-      await brlcToken.MINTER_ROLE(),
-      await deployer.getAddress(),
-      { gasLimit: GAS_LIMIT_OVERRIDE })
-    );
+    const deployerAddress = await deployer.getAddress();
+    const grantorRole = await brlcToken.GRANTOR_ROLE();
+    const minterRole = await brlcToken.MINTER_ROLE();
+    await waitReceipt(brlcToken.grantRole(grantorRole, deployerAddress, { gasLimit: GAS_LIMIT_OVERRIDE }));
+    await waitReceipt(brlcToken.grantRole(minterRole, deployerAddress, { gasLimit: GAS_LIMIT_OVERRIDE }));
 }
 
 export async function deployCashier() {

--- a/e2e/cloudwalk-contracts/integration/test/helpers/rpc.ts
+++ b/e2e/cloudwalk-contracts/integration/test/helpers/rpc.ts
@@ -91,9 +91,15 @@ export async function deployBRLC() {
 }
 
 export async function configureBRLC() {
-    await waitReceipt(brlcToken.updateMainMinter(await deployer.getAddress(), { gasLimit: GAS_LIMIT_OVERRIDE }));
-    await waitReceipt(
-        brlcToken.configureMinter(await deployer.getAddress(), 1000000000, { gasLimit: GAS_LIMIT_OVERRIDE }),
+    await waitReceipt(brlcToken.grantRole(
+      await brlcToken.GRANTOR_ROLE(),
+      await deployer.getAddress(),
+      { gasLimit: GAS_LIMIT_OVERRIDE }
+    ));
+    await waitReceipt(brlcToken.grantRole(
+      await brlcToken.MINTER_ROLE(),
+      await deployer.getAddress(),
+      { gasLimit: GAS_LIMIT_OVERRIDE })
     );
 }
 
@@ -105,7 +111,7 @@ export async function deployCashier() {
 }
 
 export async function configureCashier() {
-    brlcToken.connect(deployer).configureMinter(await cashier.getAddress(), 1000000000);
+    waitReceipt(brlcToken.connect(deployer).grantRole(await brlcToken.MINTER_ROLE(), await cashier.getAddress()));
     waitReceipt(cashier.grantRole(await cashier.CASHIER_ROLE(), await deployer.getAddress()));
 }
 

--- a/e2e/cloudwalk-contracts/integration/test/leader-follower-brlc.test.ts
+++ b/e2e/cloudwalk-contracts/integration/test/leader-follower-brlc.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { Block, Transaction, TransactionReceipt, TransactionResponse } from "ethers";
+import { TransactionReceipt, TransactionResponse } from "ethers";
 import { ethers } from "hardhat";
 
 import {
@@ -41,14 +41,13 @@ describe("Leader & Follower BRLC integration test", function () {
     });
 
     describe("Deploy and configure BRLC contract using transaction forwarding from follower to leader", function () {
-        it("Validate deployer is main minter", async function () {
+        it("Validate deployer is minter", async function () {
             updateProviderUrl("stratus-follower");
 
             await deployBRLC();
             await configureBRLC();
 
-            expect(deployer.address).to.equal(await brlcToken.mainMinter());
-            expect(await brlcToken.isMinter(deployer.address)).to.be.true;
+            expect(await brlcToken.hasRole(await brlcToken.MINTER_ROLE(), deployer.address)).to.equal(true);
 
             updateProviderUrl("stratus");
         });

--- a/e2e/cloudwalk-contracts/integration/test/leader-follower-kafka.test.ts
+++ b/e2e/cloudwalk-contracts/integration/test/leader-follower-kafka.test.ts
@@ -24,12 +24,11 @@ describe("Leader & Follower Kafka integration test", function () {
             await setDeployer();
         });
 
-        it("Validate deployer is main minter", async function () {
+        it("Validate deployer is minter", async function () {
             await deployBRLC();
             await new Promise((resolve) => setTimeout(resolve, 5000));
             await configureBRLC();
-            expect(deployer.address).to.equal(await brlcToken.mainMinter());
-            expect(await brlcToken.isMinter(deployer.address)).to.be.true;
+            expect(await brlcToken.hasRole(await brlcToken.MINTER_ROLE(), deployer.address)).to.equal(true);
         });
     });
 

--- a/e2e/cloudwalk-contracts/integration/test/leader-follower-replication.test.ts
+++ b/e2e/cloudwalk-contracts/integration/test/leader-follower-replication.test.ts
@@ -41,14 +41,13 @@ describe("Leader & Follower replication integration test", function () {
     });
 
     describe("Deploy and configure BRLC contract using transaction forwarding from follower to leader", function () {
-        it("Validate deployer is main minter", async function () {
+        it("Validate deployer is minter", async function () {
             updateProviderUrl("stratus-follower");
 
             await deployBRLC();
             await configureBRLC();
 
-            expect(deployer.address).to.equal(await brlcToken.mainMinter());
-            expect(await brlcToken.isMinter(deployer.address)).to.be.true;
+            expect(await brlcToken.hasRole(await brlcToken.MINTER_ROLE(), deployer.address)).to.equal(true);
 
             updateProviderUrl("stratus");
         });


### PR DESCRIPTION
### **User description**
Some functions of the BRLC token smart contract have been replaced as part of the integration tests as they no longer exist after [recent changes](https://github.com/cloudwalk/brlc-token/pull/109).


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Update BRLC token integration tests

- Replace deprecated minter functions with role-based access

- Modify deployer validation in test cases

- Update Cashier configuration process


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rpc.ts</strong><dd><code>Update BRLC token configuration to use role-based access</code>&nbsp; </dd></summary>
<hr>

e2e/cloudwalk-contracts/integration/test/helpers/rpc.ts

<li>Replace <code>updateMainMinter</code> and <code>configureMinter</code> with <code>grantRole</code><br> <li> Update <code>configureCashier</code> to use <code>grantRole</code> for MINTER_ROLE<br> <li> Add GRANTOR_ROLE assignment to deployer


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2121/files#diff-bfbd0a045ec4243ba68015b78cb7fb7cb485ff47e44bc3c22e3e155fc3ddf003">+10/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>leader-follower-brlc.test.ts</strong><dd><code>Update BRLC token minter validation in tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

e2e/cloudwalk-contracts/integration/test/leader-follower-brlc.test.ts

<li>Remove unused imports<br> <li> Update test case to validate deployer as minter<br> <li> Replace <code>mainMinter</code> and <code>isMinter</code> checks with <code>hasRole</code>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2121/files#diff-9c6d7de0f652c0d9179b3a178bc7626eccf0bc0a5bc3402b2dd4d910f9fc359a">+3/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>leader-follower-kafka.test.ts</strong><dd><code>Update BRLC token minter validation in Kafka tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

e2e/cloudwalk-contracts/integration/test/leader-follower-kafka.test.ts

<li>Update test case to validate deployer as minter<br> <li> Replace <code>mainMinter</code> and <code>isMinter</code> checks with <code>hasRole</code>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2121/files#diff-36b9289f58e9e3911bd2c5c9fa3e72f2aef1dcea9c9d59769988b56091cf8211">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>leader-follower-replication.test.ts</strong><dd><code>Update BRLC token minter validation in replication tests</code>&nbsp; </dd></summary>
<hr>

e2e/cloudwalk-contracts/integration/test/leader-follower-replication.test.ts

<li>Update test case to validate deployer as minter<br> <li> Replace <code>mainMinter</code> and <code>isMinter</code> checks with <code>hasRole</code>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2121/files#diff-ad863ba39ecadff6c0f24538c3bbabada650f3b8cfaec8657787acbbb365f34c">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>