### PR TITLE
fix: ignore nonce errors in fake leader

### DIFF
--- a/src/eth/follower/importer/importer.rs
+++ b/src/eth/follower/importer/importer.rs
@@ -24,6 +24,8 @@ use crate::eth::primitives::BlockNumber;
 use crate::eth::primitives::ExternalBlock;
 use crate::eth::primitives::ExternalReceipt;
 use crate::eth::primitives::ExternalReceipts;
+use crate::eth::primitives::StratusError;
+use crate::eth::primitives::TransactionError;
 use crate::eth::storage::permanent::rocks::types::ReplicationLogRocksdb;
 use crate::eth::storage::StratusStorage;
 use crate::ext::spawn_named;
@@ -245,9 +247,16 @@ impl Importer {
                 for tx in block.0.transactions.into_transactions() {
                     tracing::info!(?tx, "executing tx as fake miner");
                     if let Err(e) = executor.execute_local_transaction(tx.try_into()?) {
-                        tracing::error!(reason = ?e, "transaction failed");
-                        GlobalState::shutdown_from("Importer (FakeMiner)", "Transaction Failed");
-                        return Err(anyhow!(e));
+                        match e {
+                            StratusError::Transaction(TransactionError::Nonce { transaction: _, account: _ }) => {
+                                tracing::warn!(reason = ?e, "transaction failed, was this node restarted?");
+                            }
+                            _ => {
+                                tracing::error!(reason = ?e, "transaction failed");
+                                GlobalState::shutdown_from("Importer (FakeMiner)", "Transaction Failed");
+                                return Err(anyhow!(e));
+                            }
+                        }
                     }
                 }
                 mine_and_commit(&miner);


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Ignore nonce errors in fake leader mode

- Improve error handling for transaction execution

- Add new imports for error types

- Enhance logging for transaction failures


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>importer.rs</strong><dd><code>Improve error handling in fake leader transaction execution</code></dd></summary>
<hr>

src/eth/follower/importer/importer.rs

<li>Added imports for <code>StratusError</code> and <code>TransactionError</code><br> <li> Implemented error handling for transaction execution in fake leader <br>mode<br> <li> Ignore nonce errors, logging a warning instead of shutting down<br> <li> Maintain existing behavior for other error types


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2126/files#diff-bd50f502f039aff8f75753bc780d281ae7d7936fadc9d53482084c647aec94ca">+12/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>