### PR TITLE
fix(test): cppv2 fails to clone

### DIFF
--- a/e2e/cloudwalk-contracts/contracts-clone.sh
+++ b/e2e/cloudwalk-contracts/contracts-clone.sh
@@ -199,6 +199,5 @@ fi
 
 if [ "$cppv2" == 1 ]; then
     # Periphery Transition: attempts to clone the periphery v2 repository/contract using different methods
-    clone_alternative brlc-card-payment-processor-v2 main brlc-card-payment-processor-v2 ||
-        clone_alternative brlc-periphery main brlc-periphery-v2
+    clone brlc-card-payment-processor-v2
 fi


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed cloning issue for cppv2 in contracts-clone.sh

- Updated branch name from 'cpp2' to 'main'


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>contracts-clone.sh</strong><dd><code>Update branch name for cppv2 cloning</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

e2e/cloudwalk-contracts/contracts-clone.sh

<li>Changed branch name from 'cpp2' to 'main' for <br>brlc-card-payment-processor<br> <li> Changed branch name from 'cpp2' to 'main' for brlc-periphery


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2149/files#diff-5b521c8f3ba50a86c4afd8303eab5079009a0e12e43f0ab45bc37b459dddab64">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>