### PR TITLE
fix: dev functions creating default values in temporary storage

### DIFF
--- a/src/eth/storage/stratus_storage.rs
+++ b/src/eth/storage/stratus_storage.rs
@@ -75,10 +75,8 @@ impl StratusStorage {
         // create genesis block and accounts if necessary
         #[cfg(feature = "dev")]
         {
-            if GlobalState::get_node_mode() == NodeMode::Leader || !this.rocksdb_replication_enabled() {
-                if !this.has_genesis()? {
-                    this.reset_to_genesis()?;
-                }
+            if (GlobalState::get_node_mode() == NodeMode::Leader || !this.rocksdb_replication_enabled()) && !this.has_genesis()? {
+                this.reset_to_genesis()?;
             }
         }
 

--- a/src/eth/storage/temporary/inmemory.rs
+++ b/src/eth/storage/temporary/inmemory.rs
@@ -242,11 +242,10 @@ impl InMemoryTemporaryStorage {
     pub fn save_slot(&self, address: Address, slot: Slot) -> anyhow::Result<(), StorageError> {
         let mut pending_block = self.pending_block.write();
 
-        // Get or create the account
-        let account = pending_block.accounts.entry(address).or_insert_with(|| AccountWithSlots::new(address));
-
-        // Insert the slot
-        account.slots.insert(slot.index, slot);
+        // Only update if the account exists
+        if let Some(account) = pending_block.accounts.get_mut(&address) {
+            account.slots.insert(slot.index, slot);
+        }
 
         Ok(())
     }
@@ -255,11 +254,10 @@ impl InMemoryTemporaryStorage {
     pub fn save_account_nonce(&self, address: Address, nonce: Nonce) -> anyhow::Result<(), StorageError> {
         let mut pending_block = self.pending_block.write();
 
-        // Get or create the account
-        let account = pending_block.accounts.entry(address).or_insert_with(|| AccountWithSlots::new(address));
-
-        // Update the nonce
-        account.info.nonce = nonce;
+        // Only update if the account exists
+        if let Some(account) = pending_block.accounts.get_mut(&address) {
+            account.info.nonce = nonce;
+        }
 
         Ok(())
     }
@@ -268,11 +266,10 @@ impl InMemoryTemporaryStorage {
     pub fn save_account_balance(&self, address: Address, balance: Wei) -> anyhow::Result<(), StorageError> {
         let mut pending_block = self.pending_block.write();
 
-        // Get or create the account
-        let account = pending_block.accounts.entry(address).or_insert_with(|| AccountWithSlots::new(address));
-
-        // Update the balance
-        account.info.balance = balance;
+        // Only update if the account exists
+        if let Some(account) = pending_block.accounts.get_mut(&address) {
+            account.info.balance = balance;
+        }
 
         Ok(())
     }
@@ -283,15 +280,14 @@ impl InMemoryTemporaryStorage {
 
         let mut pending_block = self.pending_block.write();
 
-        // Get or create the account
-        let account = pending_block.accounts.entry(address).or_insert_with(|| AccountWithSlots::new(address));
-
-        // Update the bytecode
-        account.info.bytecode = if code.0.is_empty() {
-            None
-        } else {
-            Some(RevmBytecode::new_raw(code.0.into()))
-        };
+        // Only update if the account exists
+        if let Some(account) = pending_block.accounts.get_mut(&address) {
+            account.info.bytecode = if code.0.is_empty() {
+                None
+            } else {
+                Some(RevmBytecode::new_raw(code.0.into()))
+            };
+        }
 
         Ok(())
     }


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Prevent creation of default accounts in temporary storage

- Update only existing accounts in dev functions

- Modify save_slot, save_account_nonce, save_account_balance, save_account_code


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Dev Functions"] --> B["Check Account Existence"]
  B --> C{"Account Exists?"}
  C -->|Yes| D["Update Account"]
  C -->|No| E["No Action"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>inmemory.rs</strong><dd><code>Refactor dev functions to prevent default account creation</code></dd></summary>
<hr>

src/eth/storage/temporary/inmemory.rs

<li>Removed account creation in dev functions<br> <li> Added checks for existing accounts before updates<br> <li> Modified save_slot, save_account_nonce, save_account_balance, <br>save_account_code<br> <li> Ensured updates only occur for existing accounts


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2157/files#diff-e51089a92c2c949c8c776644af3cf760132d61d63ff745d676a76041be8e06e9">+20/-24</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>