### PR TITLE
chore: put replication behind dev FF

### DIFF
--- a/.github/workflows/e2e-leader-follower.yml
+++ b/.github/workflows/e2e-leader-follower.yml
@@ -36,8 +36,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test: [brlc, importer, miner, change, deploy, kafka, health, replication]
-        use_rocksdb_replication: [false, true]
+        test: [brlc, importer, miner, change, deploy, kafka, health] # , replication]
+        use_rocksdb_replication: [false] # , true]
     name: "E2E Leader & Follower on ${{ matrix.test }} (RocksDB Replication: ${{ matrix.use_rocksdb_replication }})"
     runs-on: ubuntu-22.04
     timeout-minutes: 45

--- a/src/bin/data_migration.rs
+++ b/src/bin/data_migration.rs
@@ -250,7 +250,14 @@ fn main() -> Result<()> {
     let source_db = open_db(&args.source, &source_cf_options)?;
 
     // Create destination database
-    let state = RocksStorageState::new(args.destination, std::time::Duration::from_secs(240), Some(0.0), false, false)?;
+    let state = RocksStorageState::new(
+        args.destination,
+        std::time::Duration::from_secs(240),
+        Some(0.0),
+        false,
+        #[cfg(feature = "dev")]
+        false,
+    )?;
     let dest_db = Arc::clone(&state.db);
 
     // Get list of column families

--- a/src/bin/historic_events_processor.rs
+++ b/src/bin/historic_events_processor.rs
@@ -90,7 +90,15 @@ fn process_block_events(block: BlockRocksdb) -> Vec<String> {
 /// Main function that processes blockchain data and generates events
 fn main() -> Result<(), anyhow::Error> {
     tracing_subscriber::fmt::init();
-    let state = RocksStorageState::new("data/rocksdb".to_string(), TIMEOUT, Some(0.1), false, false).context("failed to create rocksdb state")?;
+    let state = RocksStorageState::new(
+        "data/rocksdb".to_string(),
+        TIMEOUT,
+        Some(0.1),
+        false,
+        #[cfg(feature = "dev")]
+        false,
+    )
+    .context("failed to create rocksdb state")?;
 
     let (b_pb, tx_pb) = create_progress_bar(&state);
 

--- a/src/eth/follower/importer/importer.rs
+++ b/src/eth/follower/importer/importer.rs
@@ -19,6 +19,7 @@ use crate::eth::follower::consensus::Consensus;
 use crate::eth::miner::miner::interval_miner::mine_and_commit;
 use crate::eth::miner::miner::CommitItem;
 use crate::eth::miner::Miner;
+#[cfg(feature = "dev")]
 use crate::eth::primitives::BlockFilter;
 use crate::eth::primitives::BlockNumber;
 use crate::eth::primitives::ExternalBlock;
@@ -26,6 +27,7 @@ use crate::eth::primitives::ExternalReceipt;
 use crate::eth::primitives::ExternalReceipts;
 use crate::eth::primitives::StratusError;
 use crate::eth::primitives::TransactionError;
+#[cfg(feature = "dev")]
 use crate::eth::storage::permanent::rocks::types::ReplicationLogRocksdb;
 use crate::eth::storage::StratusStorage;
 use crate::ext::spawn_named;
@@ -54,6 +56,7 @@ pub enum ImporterMode {
     /// Fake leader feches a block, re-executes its txs and then mines it's own block.
     FakeLeader,
     /// Import blocks using RocksDB replication logs.
+    #[cfg(feature = "dev")]
     RocksDbReplication,
 }
 
@@ -143,6 +146,7 @@ impl Importer {
         let number: BlockNumber = storage.read_block_number_to_resume_import()?;
 
         match self.importer_mode {
+            #[cfg(feature = "dev")]
             ImporterMode::RocksDbReplication => {
                 // Use RocksDB replication approach
                 let (log_tx, log_rx) = mpsc::channel(10_000);
@@ -515,6 +519,7 @@ impl Importer {
     // -----------------------------------------------------------------------------
 
     // Applies replication logs to storage
+    #[cfg(feature = "dev")]
     async fn start_log_applier(
         storage: Arc<StratusStorage>,
         mut log_rx: mpsc::Receiver<ReplicationLogRocksdb>,
@@ -599,6 +604,7 @@ impl Importer {
     // -----------------------------------------------------------------------------
 
     /// Retrieves replication logs.
+    #[cfg(feature = "dev")]
     async fn start_log_fetcher(
         chain: Arc<BlockchainClient>,
         log_tx: mpsc::Sender<ReplicationLogRocksdb>,
@@ -674,6 +680,8 @@ async fn fetch_block_and_receipts(chain: Arc<BlockchainClient>, block_number: Bl
         };
     }
 }
+
+#[cfg(feature = "dev")]
 async fn fetch_replication_log(chain: Arc<BlockchainClient>, block_number: BlockNumber) -> ReplicationLogRocksdb {
     const REPLICATION_RETRY_DELAY: Duration = Duration::from_millis(10);
     Span::with(|s| {

--- a/src/eth/follower/importer/importer_config.rs
+++ b/src/eth/follower/importer/importer_config.rs
@@ -78,6 +78,7 @@ impl ImporterConfig {
         const TASK_NAME: &str = "importer::init";
         tracing::info!("creating importer for follower node");
 
+        #[cfg(feature = "dev")]
         let importer_mode = if storage.rocksdb_replication_enabled() {
             ImporterMode::RocksDbReplication
         } else {

--- a/src/eth/rpc/rpc_server.rs
+++ b/src/eth/rpc/rpc_server.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 use std::sync::LazyLock;
 use std::time::Duration;
 
+#[cfg(feature = "dev")]
 use alloy_primitives::hex;
 use alloy_rpc_types_trace::geth::GethDebugTracingOptions;
 use alloy_rpc_types_trace::geth::GethTrace;
@@ -241,6 +242,8 @@ fn register_methods(mut module: RpcModule<RpcContext>) -> anyhow::Result<RpcModu
 
     // stratus importing helpers
     module.register_blocking_method("stratus_getBlockAndReceipts", stratus_get_block_and_receipts)?;
+
+    #[cfg(feature = "dev")]
     module.register_blocking_method("stratus_getReplicationLog", stratus_get_replication_log)?;
 
     // block
@@ -763,6 +766,7 @@ fn stratus_get_block_and_receipts(params: Params<'_>, ctx: Arc<RpcContext>, ext:
     }))
 }
 
+#[cfg(feature = "dev")]
 fn stratus_get_replication_log(params: Params<'_>, ctx: Arc<RpcContext>, ext: Extensions) -> Result<JsonValue, StratusError> {
     // enter span
     let _middleware_enter = ext.enter_middleware_span();

--- a/src/eth/storage/permanent/mod.rs
+++ b/src/eth/storage/permanent/mod.rs
@@ -60,6 +60,7 @@ impl PermanentStorageConfig {
             self.rocks_shutdown_timeout,
             self.rocks_cache_size_multiplier,
             !self.rocks_disable_sync_write,
+            #[cfg(feature = "dev")]
             self.use_rocksdb_replication,
             self.rocks_cf_size_metrics_interval,
         )

--- a/src/eth/storage/permanent/rocks/rocks_permanent.rs
+++ b/src/eth/storage/permanent/rocks/rocks_permanent.rs
@@ -44,7 +44,7 @@ impl RocksPermanentStorage {
         shutdown_timeout: Duration,
         cache_size_multiplier: Option<f32>,
         enable_sync_write: bool,
-        use_rocksdb_replication: bool,
+        #[cfg(feature = "dev")] use_rocksdb_replication: bool,
         cf_size_metrics_interval: Option<Duration>,
     ) -> anyhow::Result<Self> {
         tracing::info!("setting up rocksdb storage");
@@ -72,6 +72,7 @@ impl RocksPermanentStorage {
             shutdown_timeout,
             cache_size_multiplier,
             enable_sync_write,
+            #[cfg(feature = "dev")]
             use_rocksdb_replication,
         )?);
 
@@ -214,6 +215,7 @@ impl RocksPermanentStorage {
             })
     }
 
+    #[cfg(feature = "dev")]
     pub fn rocksdb_replication_enabled(&self) -> bool {
         self.state.use_rocksdb_replication
     }

--- a/src/eth/storage/permanent/rocks/rocks_state.rs
+++ b/src/eth/storage/permanent/rocks/rocks_state.rs
@@ -139,6 +139,8 @@ pub struct RocksStorageState {
     db_options: Options,
     shutdown_timeout: Duration,
     enable_sync_write: bool,
+
+    #[cfg(feature = "dev")]
     pub use_rocksdb_replication: bool,
 }
 
@@ -148,7 +150,8 @@ impl RocksStorageState {
         shutdown_timeout: Duration,
         cache_multiplier: Option<f32>,
         enable_sync_write: bool,
-        use_rocksdb_replication: bool,
+
+        #[cfg(feature = "dev")] use_rocksdb_replication: bool,
     ) -> Result<Self> {
         tracing::debug!("creating (or opening an existing) database with the specified column families");
 
@@ -181,6 +184,8 @@ impl RocksStorageState {
             db: Arc::clone(db),
             shutdown_timeout,
             enable_sync_write,
+
+            #[cfg(feature = "dev")]
             use_rocksdb_replication,
         };
 
@@ -193,7 +198,14 @@ impl RocksStorageState {
     pub fn new_in_testdir() -> anyhow::Result<(Self, tempfile::TempDir)> {
         let test_dir = tempfile::tempdir()?;
         let path = test_dir.as_ref().display().to_string();
-        let state = Self::new(path, Duration::ZERO, None, true, false)?;
+        let state = Self::new(
+            path,
+            Duration::ZERO,
+            None,
+            true,
+            #[cfg(feature = "dev")]
+            false,
+        )?;
         Ok((state, test_dir))
     }
 


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Put replication behind dev feature flag

- Update RocksStorageState and RocksPermanentStorage constructors

- Modify importer and RPC server for feature flag

- Adjust StratusStorage for conditional compilation


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Replication Code"] -- "Put behind" --> B["Dev Feature Flag"]
  C["RocksStorageState"] -- "Update" --> D["Constructor"]
  E["RPC Server"] -- "Modify" --> F["Conditional Compilation"]
  G["StratusStorage"] -- "Adjust" --> H["Feature-dependent Code"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>9 files</summary><table>
<tr>
  <td><strong>data_migration.rs</strong><dd><code>Update RocksStorageState constructor with feature flag</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2158/files#diff-4910bcf5232a67ecc7cd38a6149a5e2fef11e4754179cddc14955ff40a9d5e87">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>historic_events_processor.rs</strong><dd><code>Modify RocksStorageState initialization with feature flag</code></dd></td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2158/files#diff-783a0df733dbcaeda4ed1c0f489555965746b725684709eab41c3c5992832f79">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>importer.rs</strong><dd><code>Add feature flags for replication-related code</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2158/files#diff-bd50f502f039aff8f75753bc780d281ae7d7936fadc9d53482084c647aec94ca">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>importer_config.rs</strong><dd><code>Conditionally compile importer mode selection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2158/files#diff-d6208b041b3fff7e5d6e8ed530417cc9ac4d6037a7a9737370e05322418d1d34">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>rpc_server.rs</strong><dd><code>Add feature flags for replication-related RPC methods</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2158/files#diff-835ba255c9a5c1fe0e13285bc39e058e1c74422e5e03ebba483c9d8a15c45405">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong><dd><code>Update PermanentStorageConfig init method with feature flag</code></dd></td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2158/files#diff-5c1d69109eb8f0c1ff647aac434f8d48db626a5e159ca8a106ece3e402aef28a">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>rocks_permanent.rs</strong><dd><code>Modify RocksPermanentStorage constructor and methods with feature flag</code></dd></td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2158/files#diff-d582062cac05f2b057f597f872d3f0415f29f579876306b2d9289c278c3bd3fd">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>rocks_state.rs</strong><dd><code>Update RocksStorageState struct and constructor with feature flag</code></dd></td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2158/files#diff-9d38c98aa2d77c1665d2e2e11a0abc4787424d1b41a610d2fc1c4ea0311014a9">+14/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>stratus_storage.rs</strong><dd><code>Add feature flags for replication-related StratusStorage methods</code></dd></td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2158/files#diff-3b2e36e47959decdfe26b2c4fab90b41f9242bfdad29cc43b2377ee851f4f40a">+17/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>