### PR TITLE
hotfix: point-in-time latest going to mined-past

### DIFF
--- a/src/eth/executor/evm_input.rs
+++ b/src/eth/executor/evm_input.rs
@@ -120,7 +120,7 @@ impl EvmInput {
     }
 
     /// Creates from a call that was sent directly to Stratus with `eth_call` or `eth_estimateGas` for a mined block.
-    pub fn from_mined_block(input: CallInput, block: Block) -> Self {
+    pub fn from_mined_block(input: CallInput, block: Block, point_in_time: PointInTime) -> Self {
         Self {
             from: input.from.unwrap_or(Address::ZERO),
             to: input.to.map_into(),
@@ -131,7 +131,7 @@ impl EvmInput {
             nonce: None,
             block_number: block.number(),
             block_timestamp: block.header.timestamp,
-            point_in_time: PointInTime::MinedPast(block.number()),
+            point_in_time,
             chain_id: None,
         }
     }

--- a/src/eth/executor/executor.rs
+++ b/src/eth/executor/executor.rs
@@ -627,7 +627,7 @@ impl Executor {
                 let Some(block) = self.storage.read_block(point_in_time.into())? else {
                     return Err(RpcError::BlockFilterInvalid { filter: point_in_time.into() }.into());
                 };
-                EvmInput::from_mined_block(call_input.clone(), block)
+                EvmInput::from_mined_block(call_input.clone(), block, point_in_time)
             }
         };
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix `EvmInput::from_mined_block` to use correct `point_in_time`

- Ensure `PointInTime::Latest` is properly handled

- Modify function signature to include `point_in_time` parameter


___

### **Changes diagram**

```mermaid
flowchart LR
  A["EvmInput::from_mined_block"] -- "Add parameter" --> B["point_in_time"]
  B -- "Use instead of" --> C["PointInTime::MinedPast"]
  D["Executor"] -- "Pass correct point_in_time" --> A
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>evm_input.rs</strong><dd><code>Update EvmInput to use correct point-in-time for mined blocks</code></dd></summary>
<hr>

src/eth/executor/evm_input.rs

<li>Modified <code>EvmInput::from_mined_block</code> signature to include <code>point_in_time</code> <br>parameter<br> <li> Replaced hardcoded <code>PointInTime::MinedPast(block.number())</code> with <br><code>point_in_time</code> parameter


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2161/files#diff-9dbdf7472d01464e439067cbd23dfe3648c7fb38a307bee0cf8642ad16a1a252">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>executor.rs</strong><dd><code>Adjust Executor to pass correct point-in-time to EvmInput</code></dd></summary>
<hr>

src/eth/executor/executor.rs

<li>Updated call to <code>EvmInput::from_mined_block</code> to pass <code>point_in_time</code> <br>parameter


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2161/files#diff-6b460d7dee8280c0287e8d9d9d59cf66a57ec9fed1bc003c6ede6fef60c7376b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>