### PR TITLE
enha: cache pending slots found in permanent or not found in any storage

### DIFF
--- a/src/eth/storage/stratus_storage.rs
+++ b/src/eth/storage/stratus_storage.rs
@@ -337,6 +337,7 @@ impl StratusStorage {
 
         match (point_in_time, found_in_perm) {
             // Pending slots found in the permanent storage (or not found in any storage) are always mined already
+            #[cfg(not(feature = "replication"))]
             (PointInTime::Pending, true) => {
                 self.cache.cache_account(account.clone());
                 self.cache.cache_account_latest(address, account.clone());


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Cache pending slots found in permanent storage

- Optimize caching for accounts and slots

- Improve handling of default values

- Enhance tracing and error logging


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Read Request"] --> B{"Check Point in Time"}
  B -->|"Pending"| C{"Check Storage"}
  C -->|"Found in Permanent"| D["Cache as Latest"]
  C -->|"Not Found"| E["Cache as Pending"]
  B -->|"Mined"| F["Cache as Latest"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>stratus_storage.rs</strong><dd><code>Refactor account and slot reading with improved caching</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/stratus_storage.rs

<li>Modified <code>read_account</code> and <code>read_slot</code> functions<br> <li> Added logic to differentiate between permanent and temporary storage<br> <li> Implemented caching strategy based on storage source and point in time<br> <li> Enhanced error logging and tracing


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2167/files#diff-3b2e36e47959decdfe26b2c4fab90b41f9242bfdad29cc43b2377ee851f4f40a">+47/-30</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>