### PR TITLE
chore: allow multiple build binaries to run concurrently

### DIFF
--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -34,7 +34,7 @@ jobs:
 
     concurrency:
       group: ${{ github.workflow }}-{{ github.run_id }}
-      cancel-in-progress: true
+      cancel-in-progress: false
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
### **User description**
When running benchmark sometimes multiple runs are executed at the same time. Having the workflow cancel any in-progress workflow increases the wait time unnecessarily.


___

### **PR Type**
Enhancement


___

### **Description**
- Modify GitHub Actions workflow to allow concurrent builds

- Change `cancel-in-progress` from true to false

- Improve efficiency for running multiple benchmark builds


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GitHub Actions Workflow"] --> B["Concurrency Settings"]
  B --> C["cancel-in-progress: true"]
  C -->|"Change to"| D["cancel-in-progress: false"]
  D --> E["Allow Multiple Concurrent Builds"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build-binary.yml</strong><dd><code>Enable concurrent execution of build workflows</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/build-binary.yml

<ul><li>Modified concurrency settings in the workflow<br> <li> Changed <code>cancel-in-progress</code> from <code>true</code> to <code>false</code><br> <li> Allows multiple build binaries to run simultaneously</ul>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2172/files#diff-056d8a48a1886a7da6ec1139b0a22f18e4d938f4183e7e381a96949206e3efcd">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

