### PR TITLE
fix: lock the state when reading from latest

### DIFF
--- a/src/eth/storage/mod.rs
+++ b/src/eth/storage/mod.rs
@@ -78,7 +78,6 @@ impl StorageConfig {
     }
 }
 
-
 #[derive(Clone, Copy, PartialEq, Debug, serde::Serialize, serde::Deserialize, fake::Dummy, Eq)]
 pub enum TxCount {
     Full,

--- a/src/eth/storage/mod.rs
+++ b/src/eth/storage/mod.rs
@@ -6,9 +6,7 @@ pub use permanent::PermanentStorageConfig;
 pub use permanent::RocksPermanentStorage;
 pub use stratus_storage::StratusStorage;
 pub use temporary::InMemoryTemporaryStorage;
-pub use temporary::ReadKind;
 pub use temporary::TemporaryStorageConfig;
-pub use temporary::TxCount;
 
 mod cache;
 pub mod permanent;
@@ -23,6 +21,7 @@ use display_json::DebugAsJson;
 
 use crate::eth::primitives::Account;
 use crate::eth::primitives::Address;
+use crate::eth::primitives::BlockNumber;
 use crate::eth::primitives::Slot;
 use crate::eth::primitives::SlotIndex;
 use crate::eth::primitives::StratusError;
@@ -77,4 +76,57 @@ impl StorageConfig {
 
         Ok(Arc::new(storage))
     }
+}
+
+
+#[derive(Clone, Copy, PartialEq, Debug, serde::Serialize, serde::Deserialize, fake::Dummy, Eq)]
+pub enum TxCount {
+    Full,
+    Partial(u64),
+}
+
+impl From<u64> for TxCount {
+    fn from(value: u64) -> Self {
+        TxCount::Partial(value)
+    }
+}
+
+impl Default for TxCount {
+    fn default() -> Self {
+        TxCount::Partial(0)
+    }
+}
+
+impl std::ops::AddAssign<u64> for TxCount {
+    fn add_assign(&mut self, rhs: u64) {
+        match self {
+            TxCount::Full => {}                       // If it's Full, keep it Full
+            TxCount::Partial(count) => *count += rhs, // If it's Partial, increment the counter
+        }
+    }
+}
+
+impl Ord for TxCount {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        match (self, other) {
+            (TxCount::Full, TxCount::Full) => std::cmp::Ordering::Equal,
+            (TxCount::Full, TxCount::Partial(_)) => std::cmp::Ordering::Greater,
+            (TxCount::Partial(_), TxCount::Full) => std::cmp::Ordering::Less,
+            (TxCount::Partial(a), TxCount::Partial(b)) => a.cmp(b),
+        }
+    }
+}
+
+impl PartialOrd for TxCount {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+#[derive(Clone, Copy, serde::Serialize, serde::Deserialize, PartialEq, Default, fake::Dummy)]
+pub enum ReadKind {
+    Call((BlockNumber, TxCount)),
+    #[default]
+    Transaction,
+    RPC,
 }

--- a/src/eth/storage/permanent/rocks/rocks_permanent.rs
+++ b/src/eth/storage/permanent/rocks/rocks_permanent.rs
@@ -168,7 +168,7 @@ impl RocksPermanentStorage {
     }
 
     #[cfg(feature = "replication")]
-    pub fn apply_replication_log(&self, block_number: BlockNumber, replication_log: WriteBatch) -> anyhow::Result<(), StorageError> {
+    pub fn apply_replication_log(&mut self, block_number: BlockNumber, replication_log: WriteBatch) -> anyhow::Result<(), StorageError> {
         self.state
             .apply_replication_log(block_number, replication_log)
             .map_err(|err| StorageError::RocksError { err })
@@ -181,7 +181,7 @@ impl RocksPermanentStorage {
         Ok(())
     }
 
-    pub fn save_genesis_block(&self, block: Block, accounts: Vec<Account>) -> anyhow::Result<(), StorageError> {
+    pub fn save_genesis_block(&mut self, block: Block, accounts: Vec<Account>) -> anyhow::Result<(), StorageError> {
         #[cfg(feature = "rocks_metrics")]
         {
             self.state.export_metrics().map_err(|err| StorageError::RocksError { err }).inspect_err(|e| {
@@ -197,7 +197,7 @@ impl RocksPermanentStorage {
             })
     }
 
-    pub fn save_block(&self, block: Block) -> anyhow::Result<(), StorageError> {
+    pub fn save_block(&mut self, block: Block) -> anyhow::Result<(), StorageError> {
         #[cfg(feature = "rocks_metrics")]
         {
             self.state.export_metrics().map_err(|err| StorageError::RocksError { err }).inspect_err(|e| {

--- a/src/eth/storage/stratus_storage.rs
+++ b/src/eth/storage/stratus_storage.rs
@@ -37,8 +37,8 @@ use crate::eth::primitives::TransactionStage;
 use crate::eth::primitives::Wei;
 #[cfg(feature = "dev")]
 use crate::eth::primitives::test_accounts;
-use crate::eth::storage::TxCount;
 use crate::eth::storage::ReadKind;
+use crate::eth::storage::TxCount;
 use crate::ext::not;
 use crate::infra::metrics;
 use crate::infra::metrics::timed;
@@ -463,7 +463,9 @@ impl StratusStorage {
                 && let Some(slot) = self._read_slot_latest_cache(address, index)
             {
                 return Ok(slot);
-            } else if let ReadKind::Call((block_number, _)) = kind {
+            } else if let ReadKind::Call((block_number, _)) = kind
+                && !matches!(point_in_time, PointInTime::MinedPast(_))
+            {
                 point_in_time = PointInTime::MinedPast(block_number);
             }
 

--- a/src/eth/storage/temporary/inmemory/mod.rs
+++ b/src/eth/storage/temporary/inmemory/mod.rs
@@ -2,7 +2,6 @@
 
 use std::collections::HashMap;
 
-
 use crate::eth::primitives::Account;
 use crate::eth::primitives::Address;
 use crate::eth::primitives::BlockNumber;
@@ -20,14 +19,13 @@ use crate::eth::primitives::TransactionExecution;
 #[cfg(feature = "dev")]
 use crate::eth::primitives::Wei;
 use crate::eth::storage::AccountWithSlots;
-use crate::eth::storage::temporary::inmemory::call::InMemoryCallTemporaryStorage;
-use crate::eth::storage::temporary::inmemory::transaction::InmemoryTransactionTemporaryStorage;
 use crate::eth::storage::ReadKind;
 use crate::eth::storage::TxCount;
+use crate::eth::storage::temporary::inmemory::call::InMemoryCallTemporaryStorage;
+use crate::eth::storage::temporary::inmemory::transaction::InmemoryTransactionTemporaryStorage;
 
 mod call;
 mod transaction;
-
 
 #[derive(Debug)]
 pub struct InMemoryTemporaryStorage {

--- a/src/eth/storage/temporary/inmemory/mod.rs
+++ b/src/eth/storage/temporary/inmemory/mod.rs
@@ -2,8 +2,6 @@
 
 use std::collections::HashMap;
 
-use serde::Deserialize;
-use serde::Serialize;
 
 use crate::eth::primitives::Account;
 use crate::eth::primitives::Address;
@@ -24,61 +22,12 @@ use crate::eth::primitives::Wei;
 use crate::eth::storage::AccountWithSlots;
 use crate::eth::storage::temporary::inmemory::call::InMemoryCallTemporaryStorage;
 use crate::eth::storage::temporary::inmemory::transaction::InmemoryTransactionTemporaryStorage;
+use crate::eth::storage::ReadKind;
+use crate::eth::storage::TxCount;
 
 mod call;
 mod transaction;
 
-#[derive(Clone, Copy, PartialEq, Debug, Serialize, Deserialize, fake::Dummy, Eq)]
-pub enum TxCount {
-    Full,
-    Partial(u64),
-}
-
-impl From<u64> for TxCount {
-    fn from(value: u64) -> Self {
-        TxCount::Partial(value)
-    }
-}
-
-impl Default for TxCount {
-    fn default() -> Self {
-        TxCount::Partial(0)
-    }
-}
-
-impl std::ops::AddAssign<u64> for TxCount {
-    fn add_assign(&mut self, rhs: u64) {
-        match self {
-            TxCount::Full => {}                       // If it's Full, keep it Full
-            TxCount::Partial(count) => *count += rhs, // If it's Partial, increment the counter
-        }
-    }
-}
-
-impl Ord for TxCount {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        match (self, other) {
-            (TxCount::Full, TxCount::Full) => std::cmp::Ordering::Equal,
-            (TxCount::Full, TxCount::Partial(_)) => std::cmp::Ordering::Greater,
-            (TxCount::Partial(_), TxCount::Full) => std::cmp::Ordering::Less,
-            (TxCount::Partial(a), TxCount::Partial(b)) => a.cmp(b),
-        }
-    }
-}
-
-impl PartialOrd for TxCount {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-#[derive(Clone, Copy, Serialize, Deserialize, PartialEq, Default, fake::Dummy)]
-pub enum ReadKind {
-    Call((BlockNumber, TxCount)),
-    #[default]
-    Transaction,
-    RPC,
-}
 
 #[derive(Debug)]
 pub struct InMemoryTemporaryStorage {

--- a/src/eth/storage/temporary/mod.rs
+++ b/src/eth/storage/temporary/mod.rs
@@ -1,6 +1,4 @@
 pub use inmemory::InMemoryTemporaryStorage;
-pub use inmemory::ReadKind;
-pub use inmemory::TxCount;
 
 mod inmemory;
 


### PR DESCRIPTION
Note that only functions that save blocks are acquiring locks, this is because this is both sufficient and reduces the risk of a deadlock being introduced.

closes #2154 