### PR TITLE
perf: rework conflicting read handling for calls by allowing transactions do bypass read lock acquisition

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![codecov](https://codecov.io/github/cloudwalk/stratus/graph/badge.svg?token=D1795GHLG6)](https://codecov.io/github/cloudwalk/stratus)
 
 # Stratus ☁️
-A
+
 Welcome to Stratus, the cutting-edge EVM executor and JSON-RPC server with custom storage that scales horizontally. Built in Rust 🦀 for speed and reliability, Stratus is here to take your blockchain projects to the next level!
 
 ## Current storage implementations


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Optimized _latest_is_valid function for improved performance

- Modified read_account and read_slot to use new return format

- Reduced unnecessary lock acquisitions for non-call operations

- Improved readability and efficiency in conflict handling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["_latest_is_valid"] -- "Returns tuple" --> B["(is_valid, guard)"]
  B -- "Used in" --> C["read_account"]
  B -- "Used in" --> D["read_slot"]
  E["Lock acquisition"] -- "Optimized for" --> F["Call operations"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>stratus_storage.rs</strong><dd><code>Optimize storage read operations and conflict handling</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/stratus_storage.rs

<ul><li>Refactored <code>_latest_is_valid</code> to return a tuple (bool, Option<RwLockReadGuard>)<br> <li> Updated <code>read_account</code> and <code>read_slot</code> to use new <code>_latest_is_valid</code> return <br>format<br> <li> Optimized lock acquisition for non-call operations<br> <li> Improved readability and efficiency in handling conflicting reads</ul>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2177/files#diff-3b2e36e47959decdfe26b2c4fab90b41f9242bfdad29cc43b2377ee851f4f40a">+14/-11</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

