### PR TITLE
chore: remove protoc and rust cache from build-pgo action

### DIFF
--- a/.github/workflows/build-pgo.yml
+++ b/.github/workflows/build-pgo.yml
@@ -48,9 +48,6 @@ jobs:
           cache-provider: "github"
           save-if: ${{ github.ref_name == 'main' && github.event_name == 'push' }}
 
-      - name: Install protoc
-        run: sudo apt-get install -y protobuf-compiler
-
       - name: Install libsasl2-dev libssl-dev
         run: sudo apt-get update && sudo apt install -y build-essential pkg-config libssl-dev libsasl2-dev
 

--- a/.github/workflows/build-pgo.yml
+++ b/.github/workflows/build-pgo.yml
@@ -39,15 +39,6 @@ jobs:
       - name: Set up Rust
         run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.88
 
-      - name: Rust Cache
-        uses: Swatinem/rust-cache@v2
-        id: cache-cargo
-        with:
-          prefix-key: ${{ runner.os }}-v3-cargo
-          shared-key: artifact
-          cache-provider: "github"
-          save-if: ${{ github.ref_name == 'main' && github.event_name == 'push' }}
-
       - name: Install libsasl2-dev libssl-dev
         run: sudo apt-get update && sudo apt install -y build-essential pkg-config libssl-dev libsasl2-dev
 


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Remove protoc installation from build-pgo workflow

- Streamline CI process by eliminating unnecessary dependency


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GitHub Action Workflow"] -- "Removes" --> B["protoc installation"]
  A -- "Retains" --> C["Other dependencies"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build-pgo.yml</strong><dd><code>Remove protoc installation step from build-pgo workflow</code>&nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/build-pgo.yml

<ul><li>Removed the step to install protobuf-compiler (protoc)<br> <li> Kept other dependency installations like libsasl2-dev and libssl-dev</ul>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2194/files#diff-93bbdbe14ff1cb0fd12a28fbf8cdb91794c00aeaf03fb04aa1023125ef4768d0">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

