### PR TITLE
chore: allow queued runs build pgo actions

### DIFF
--- a/.github/workflows/build-pgo-optimized.yml
+++ b/.github/workflows/build-pgo-optimized.yml
@@ -19,7 +19,7 @@ jobs:
 
     concurrency:
       group: ${{ github.workflow }}-${{ github.run_id }}
-      cancel-in-progress: true
+      cancel-in-progress: false
 
     steps:
       - name: Checkout code

--- a/.github/workflows/build-pgo.yml
+++ b/.github/workflows/build-pgo.yml
@@ -30,7 +30,7 @@ jobs:
 
     concurrency:
       group: ${{ github.workflow }}-{{ github.run_id }}
-      cancel-in-progress: true
+      cancel-in-progress: false
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
This improvement makes queued runs not get cancelled if a new PR is merged in the meantime a build is running. For build actions it is ideal that each PR is merged sequentially and not get skipped.