### PR TITLE
chore: set mined block number in save_block instead of miner

### DIFF
--- a/src/eth/miner/miner.rs
+++ b/src/eth/miner/miner.rs
@@ -324,7 +324,6 @@ impl Miner {
 
         // save storage
         self.storage.save_block(block)?;
-        self.storage.set_mined_block_number(block_number)?;
 
         // Send notifications after saving the block
         self.send_log_notifications(&block_logs);

--- a/src/eth/storage/stratus_storage.rs
+++ b/src/eth/storage/stratus_storage.rs
@@ -629,7 +629,11 @@ impl StratusStorage {
             if let Err(ref e) = m.result {
                 tracing::error!(reason = ?e, %block_number, "failed to save block");
             }
-        })
+        })?;
+
+        self.set_mined_block_number(block_number)?;
+
+        Ok(())
     }
 
     pub fn read_block(&self, filter: BlockFilter) -> Result<Option<Block>, StorageError> {

--- a/src/eth/storage/stratus_storage.rs
+++ b/src/eth/storage/stratus_storage.rs
@@ -631,9 +631,7 @@ impl StratusStorage {
             }
         })?;
 
-        self.set_mined_block_number(block_number)?;
-
-        Ok(())
+        self.set_mined_block_number(block_number)
     }
 
     pub fn read_block(&self, filter: BlockFilter) -> Result<Option<Block>, StorageError> {


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Moved `set_mined_block_number` call to `save_block` method

- Improved block saving process in `StratusStorage`

- Removed `set_mined_block_number` from `Miner` implementation

- Enhanced error handling in `save_block` method


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Miner["Miner"]
  SaveBlock["save_block()"]
  SetMinedBlockNumber["set_mined_block_number()"]
  Miner -- "Calls" --> SaveBlock
  SaveBlock -- "Now includes" --> SetMinedBlockNumber
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>miner.rs</strong><dd><code>Remove mined block number setting from Miner</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/miner/miner.rs

- Removed `self.storage.set_mined_block_number(block_number)?;` call


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2245/files#diff-16f448afc7dae3e8e802f676a86dbd7051e19f6c17cbbeb53eb730d726372629">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>stratus_storage.rs</strong><dd><code>Enhance save_block method with mined block number setting</code></dd></summary>
<hr>

src/eth/storage/stratus_storage.rs

<ul><li>Added <code>self.set_mined_block_number(block_number)?;</code> to <code>save_block</code> method<br> <li> Improved error handling with explicit <code>Ok(())</code> return<br> <li> Enhanced tracing and metrics for block saving process</ul>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2245/files#diff-3b2e36e47959decdfe26b2c4fab90b41f9242bfdad29cc43b2377ee851f4f40a">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

