### PR TITLE
chore: remove dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,13 +11,7 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "09:00"
-      timezone: "UTC"
-
-    groups:
-      alloy-revm-updates:
-        patterns:
-          - "alloy-*"
-          - "revm*"
+      timezone: "America/Sao_Paulo"
     
     labels:
       - "dependencies"


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Remove Dependabot group for Alloy and REVM updates

- Change timezone from UTC to America/Sao_Paulo

- Simplify Dependabot configuration


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Dependabot Config"] --> B["Remove Group"]
  A --> C["Update Timezone"]
  B --> D["Simplify Configuration"]
  C --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dependabot.yml</strong><dd><code>Refine Dependabot settings: remove group, update timezone</code></dd></summary>
<hr>

.github/dependabot.yml

<ul><li>Removed <code>groups</code> section for Alloy and REVM updates<br> <li> Changed timezone from UTC to America/Sao_Paulo<br> <li> Simplified overall configuration structure</ul>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2252/files#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28">+1/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

