### PR TITLE
chore: remove new_account and address from ExecutionAccountChanges

### DIFF
--- a/src/eth/executor/evm.rs
+++ b/src/eth/executor/evm.rs
@@ -521,9 +521,9 @@ fn parse_revm_execution(revm_result: ResultAndState, input: EvmInput, execution_
 
     tracing::debug!(?result, %gas, tx_output_len = %tx_output.len(), %tx_output, "evm executed");
     let mut deployed_contract_address = None;
-    for changes in changes.values() {
+    for (address, changes) in changes.iter() {
         if changes.bytecode.is_modified() {
-            deployed_contract_address = Some(changes.address);
+            deployed_contract_address = Some(*address);
         }
     }
 
@@ -593,8 +593,9 @@ fn parse_revm_state(revm_state: EvmState, mut execution_changes: ExecutionChange
 
         // handle account created (contracts) or touched (everything else)
         if account_created {
+            let addr = account.address;
             let account_changes = ExecutionAccountChanges::from_modified_values(account, account_modified_slots);
-            execution_changes.insert(account_changes.address, account_changes);
+            execution_changes.insert(addr, account_changes);
         } else if account_touched {
             let Some(account_changes) = execution_changes.get_mut(&address) else {
                 tracing::error!(keys = ?execution_changes.keys(), %address, "account touched, but not loaded by evm");

--- a/src/eth/primitives/execution.rs
+++ b/src/eth/primitives/execution.rs
@@ -58,6 +58,7 @@ impl EvmExecution {
         }
 
         // generate sender changes incrementing the nonce
+        let addr = sender.address;
         let mut sender_changes = ExecutionAccountChanges::from_original_values(sender); // NOTE: don't change from_original_values without updating .expect() below
         let sender_next_nonce = sender_changes
             .nonce
@@ -73,7 +74,7 @@ impl EvmExecution {
             output: Bytes::default(),                                            // we cannot really know without performing an eth_call to the external system
             logs: Vec::new(),
             gas: Gas::from(receipt.gas_used),
-            changes: BTreeMap::from([(sender_changes.address, sender_changes)]),
+            changes: BTreeMap::from([(addr, sender_changes)]),
             deployed_contract_address: None,
         };
         execution.apply_receipt(receipt)?;
@@ -293,7 +294,6 @@ mod tests {
 
         // Verify sender changes
         let sender_changes = execution.changes.get(&sender_address).unwrap();
-        assert_eq!(sender_changes.address, sender_address);
 
         // Nonce should be incremented
         let modified_nonce = sender_changes.nonce.take_modified_ref().unwrap();

--- a/src/eth/primitives/execution_account_changes.rs
+++ b/src/eth/primitives/execution_account_changes.rs
@@ -5,7 +5,6 @@ use display_json::DebugAsJson;
 use super::CodeHash;
 use crate::alias::RevmBytecode;
 use crate::eth::primitives::Account;
-use crate::eth::primitives::Address;
 use crate::eth::primitives::ExecutionValueChange;
 use crate::eth::primitives::Nonce;
 use crate::eth::primitives::Slot;
@@ -15,8 +14,6 @@ use crate::eth::primitives::Wei;
 /// Changes that happened to an account during a transaction.
 #[derive(DebugAsJson, Clone, PartialEq, Eq, fake::Dummy, serde::Serialize, serde::Deserialize)]
 pub struct ExecutionAccountChanges {
-    pub new_account: bool, // TODO: check if this is needed, remove if not so
-    pub address: Address,  // TODO: check if redundant because this is present in the BTreeMap
     pub nonce: ExecutionValueChange<Nonce>,
     pub balance: ExecutionValueChange<Wei>,
 
@@ -32,8 +29,6 @@ impl ExecutionAccountChanges {
     pub fn from_original_values(account: impl Into<Account>) -> Self {
         let account: Account = account.into();
         Self {
-            new_account: false,
-            address: account.address,
             nonce: ExecutionValueChange::from_original(account.nonce),
             balance: ExecutionValueChange::from_original(account.balance),
             bytecode: ExecutionValueChange::from_original(account.bytecode),
@@ -46,8 +41,6 @@ impl ExecutionAccountChanges {
     pub fn from_modified_values(account: impl Into<Account>, modified_slots: Vec<Slot>) -> Self {
         let account: Account = account.into();
         let mut changes = Self {
-            new_account: true,
-            address: account.address,
             nonce: ExecutionValueChange::from_modified(account.nonce),
             balance: ExecutionValueChange::from_modified(account.balance),
 

--- a/src/eth/storage/cache.rs
+++ b/src/eth/storage/cache.rs
@@ -12,7 +12,6 @@ use rustc_hash::FxBuildHasher;
 use super::AccountWithSlots;
 use crate::eth::primitives::Account;
 use crate::eth::primitives::Address;
-use crate::eth::primitives::ExecutionAccountChanges;
 use crate::eth::primitives::ExecutionChanges;
 use crate::eth::primitives::Slot;
 use crate::eth::primitives::SlotIndex;
@@ -100,14 +99,14 @@ impl StorageCache {
     }
 
     pub fn cache_account_and_slots_from_changes(&self, changes: ExecutionChanges) {
-        for change in changes.into_values() {
+        for (address, change) in changes {
             // cache slots
             for slot in change.slots.into_values().flat_map(|slot| slot.take()) {
-                self.slot_cache.insert((change.address, slot.index), slot.value);
+                self.slot_cache.insert((address, slot.index), slot.value);
             }
 
             // cache account
-            let mut account = AccountWithSlots::new(change.address);
+            let mut account = AccountWithSlots::new(address);
             if let Some(nonce) = change.nonce.take_ref() {
                 account.info.nonce = *nonce;
             }
@@ -117,19 +116,19 @@ impl StorageCache {
             if let Some(Some(bytecode)) = change.bytecode.take_ref() {
                 account.info.bytecode = Some(bytecode.clone());
             }
-            self.account_cache.insert(change.address, account.info);
+            self.account_cache.insert(address, account.info);
         }
     }
 
-    pub fn cache_account_and_slots_latest_from_changes(&self, changes: Vec<ExecutionAccountChanges>) {
-        for change in changes {
+    pub fn cache_account_and_slots_latest_from_changes(&self, changes: ExecutionChanges) {
+        for (address, change) in changes {
             // cache slots
             for slot in change.slots.into_values().flat_map(|slot| slot.take()) {
-                self.slot_latest_cache.insert((change.address, slot.index), slot.value);
+                self.slot_latest_cache.insert((address, slot.index), slot.value);
             }
 
             // cache account
-            let mut account = AccountWithSlots::new(change.address);
+            let mut account = AccountWithSlots::new(address);
             if let Some(nonce) = change.nonce.take_ref() {
                 account.info.nonce = *nonce;
             }
@@ -139,7 +138,7 @@ impl StorageCache {
             if let Some(Some(bytecode)) = change.bytecode.take_ref() {
                 account.info.bytecode = Some(bytecode.clone());
             }
-            self.account_latest_cache.insert(change.address, account.info);
+            self.account_latest_cache.insert(address, account.info);
         }
     }
 

--- a/src/eth/storage/permanent/rocks/types/block_changes.rs
+++ b/src/eth/storage/permanent/rocks/types/block_changes.rs
@@ -38,8 +38,6 @@ impl From<BlockChangesRocksdb> for ExecutionChanges {
                 (
                     address.into(),
                     ExecutionAccountChanges {
-                        new_account: false,
-                        address: address.into(),
                         nonce: changes.nonce.map(Nonce::from).into(),
                         balance: changes.balance.map(Wei::from).into(),
                         bytecode: changes.bytecode.map(|inner| Some(RevmBytecode::from(inner))).into(),

--- a/src/eth/storage/temporary/inmemory/transaction.rs
+++ b/src/eth/storage/temporary/inmemory/transaction.rs
@@ -83,12 +83,9 @@ impl InmemoryTransactionTemporaryStorage {
         let mut pending_block = RwLockUpgradableReadGuard::<InMemoryTemporaryStorageState>::upgrade(pending_block);
 
         // save account changes
-        let changes = tx.result.execution.changes.values();
-        for change in changes {
-            let account = pending_block
-                .accounts
-                .entry(change.address)
-                .or_insert_with(|| AccountWithSlots::new(change.address));
+        let changes = tx.result.execution.changes.iter();
+        for (address, change) in changes {
+            let account = pending_block.accounts.entry(*address).or_insert_with(|| AccountWithSlots::new(*address));
 
             // account basic info
             if let Some(nonce) = change.nonce.take_ref() {


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Remove `new_account` and `address` from ExecutionAccountChanges

- Update related code to use address from map

- Refactor compact_account_changes to return ExecutionChanges

- Adjust function signatures and implementations accordingly


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ExecutionAccountChanges"]
  B["Remove fields"]
  C["Update usage"]
  D["Refactor functions"]
  A --> B
  B --> C
  C --> D
  B --"new_account"--> E["Removed"]
  B --"address"--> E
  C --"Use map key"--> F["Address"]
  D --"Return type"--> G["ExecutionChanges"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td><strong>evm.rs</strong><dd><code>Update ExecutionAccountChanges usage in EVM execution</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2263/files#diff-7fabd204a68cff51c55ee1391074463fa8ac005dc8ba443218bc83a9dda96658">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>block.rs</strong><dd><code>Refactor compact_account_changes to use ExecutionChanges</code>&nbsp; </dd></td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2263/files#diff-1713a99b45fd64ac0570786603a3a17edc97657646bd333e5e214e4a531def10">+7/-11</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>execution.rs</strong><dd><code>Update EvmExecution to use address from map</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2263/files#diff-cd13932ed3cbc97c18547275105d872a204eda4ad4bf0c2811b18553b48e9038">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>execution_account_changes.rs</strong><dd><code>Remove new_account and address fields from ExecutionAccountChanges</code></dd></td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2263/files#diff-2f8319711f3b8bc5b706dcbb93ad7aeb7fc461b3416f6e5adcd715852a88c619">+0/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cache.rs</strong><dd><code>Update cache operations to use address from map</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2263/files#diff-b8200ddbedbd8dab58d6c980baad75e39c70b818c009a4d556ee71b13f046307">+9/-10</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>rocks_state.rs</strong><dd><code>Refactor prepare_batch_with_execution_changes for ExecutionChanges</code></dd></td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2263/files#diff-9d38c98aa2d77c1665d2e2e11a0abc4787424d1b41a610d2fc1c4ea0311014a9">+20/-17</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>block_changes.rs</strong><dd><code>Update ExecutionChanges conversion to remove redundant fields</code></dd></td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2263/files#diff-1637be6bcc5629a3791c313d6fd042496c170eaa7aeae546c4415cbc8d9c3695">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>transaction.rs</strong><dd><code>Update InmemoryTransactionTemporaryStorage to use address from map</code></dd></td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2263/files#diff-aa8907844fe3cab37ddcd4e92d572cf96d7df979879081488e541327f0f4f13b">+3/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

