### PR TITLE
enha: disable EIP-3607 on eth_call

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,10 +135,10 @@ dashmap = "6.1.0"
 # ------------------------------------------------------------------------------
 
 [target.'cfg(not(all(target_arch = "aarch64", target_os = "linux")))'.dependencies]
-revm = { version = "=27.1.0", features = ["asm-keccak", "serde"] }
+revm = { version = "=27.1.0", features = ["asm-keccak", "serde", "optional_eip3607"] }
 
 [target.'cfg(all(target_arch = "aarch64", target_os = "linux"))'.dependencies]
-revm = { version = "=27.1.0", features = ["serde"]}
+revm = { version = "=27.1.0", features = ["serde", "optional_eip3607"]}
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = { version = "=0.6", optional = true }

--- a/src/eth/executor/evm.rs
+++ b/src/eth/executor/evm.rs
@@ -186,6 +186,7 @@ impl Evm {
             .modify_cfg_chained(|cfg_env| {
                 cfg_env.chain_id = chain_id;
                 cfg_env.disable_nonce_check = matches!(kind, EvmKind::Call);
+                cfg_env.disable_eip3607 = matches!(kind, EvmKind::Call);
                 cfg_env.limit_contract_code_size = Some(usize::MAX);
             })
             .modify_block_chained(|block_env: &mut BlockEnv| {


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Disable EIP-3607 for eth_call operations

- Update revm dependency to include optional_eip3607 feature


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["EVM Configuration"] --> B["Disable EIP-3607"]
  B --> C["eth_call operations"]
  D["revm dependency"] --> E["Add optional_eip3607 feature"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>evm.rs</strong><dd><code>Disable EIP-3607 for eth_call in EVM configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/executor/evm.rs

<ul><li>Added <code>cfg_env.disable_eip3607 = matches!(kind, EvmKind::Call);</code> to <br>disable EIP-3607 for eth_call operations</ul>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2275/files#diff-7fabd204a68cff51c55ee1391074463fa8ac005dc8ba443218bc83a9dda96658">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Update revm dependency to include optional_eip3607 feature</code></dd></summary>
<hr>

Cargo.toml

<ul><li>Added "optional_eip3607" feature to revm dependency for both aarch64 <br>Linux and other platforms</ul>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2275/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

