### PR TITLE
chore: remove allow(clippy::arc_with_non_send_sync) from Evm::new(\3)

### DIFF
--- a/src/eth/executor/evm.rs
+++ b/src/eth/executor/evm.rs
@@ -97,7 +97,6 @@ pub enum EvmKind {
 
 impl Evm {
     /// Creates a new instance of the Evm.
-    #[allow(clippy::arc_with_non_send_sync)]
     pub fn new(storage: Arc<StratusStorage>, config: ExecutorConfig, kind: EvmKind) -> Self {
         tracing::info!(?config, "creating revm");
 


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Remove clippy allow attribute for arc_with_non_send_sync


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Evm::new method"] -- "Remove" --> B["clippy ignore"]
  B -- "Improves" --> C["Code quality"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>evm.rs</strong><dd><code>Remove clippy ignore for arc_with_non_send_sync</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/executor/evm.rs

<ul><li>Removed #[allow(clippy::arc_with_non_send_sync)] attribute from <br>Evm::new method</ul>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2286/files#diff-7fabd204a68cff51c55ee1391074463fa8ac005dc8ba443218bc83a9dda96658">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

