### PR TITLE
fix(test): add sleep before checking balances

### DIFF
--- a/e2e/cloudwalk-contracts/integration/test/leader-follower-brlc.test.ts
+++ b/e2e/cloudwalk-contracts/integration/test/leader-follower-brlc.test.ts
@@ -244,6 +244,7 @@ describe("Leader & Follower BRLC integration test", function () {
             });
 
             it(`${params.name}: Validate balances between Stratus Leader and Follower`, async function () {
+                await new Promise((resolve) => setTimeout(resolve, 10000));
                 for (let i = 0; i < wallets.length; i++) {
                     // Get Stratus Leader balance
                     updateProviderUrl("stratus");


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Add sleep before balance check in integration test

- Improve test reliability for Leader & Follower BRLC


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Test Execution"] --> B["10s Delay"]
  B --> C["Balance Validation"]
  C --> D["Leader & Follower Comparison"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>leader-follower-brlc.test.ts</strong><dd><code>Add delay before balance validation in BRLC test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

e2e/cloudwalk-contracts/integration/test/leader-follower-brlc.test.ts

<ul><li>Added a 10-second delay before checking balances<br> <li> Improves test reliability by allowing time for balance updates</ul>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2287/files#diff-9c6d7de0f652c0d9179b3a178bc7626eccf0bc0a5bc3402b2dd4d910f9fc359a">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

