### PR TITLE
fix(importer): check sender's nonce on reverted external transaction

### DIFF
--- a/src/eth/executor/executor.rs
+++ b/src/eth/executor/executor.rs
@@ -403,7 +403,7 @@ impl Executor {
                 let sender = self.storage.read_account(receipt.from.into(), PointInTime::Pending, ReadKind::Transaction)?;
                 if tx_input.nonce != sender.nonce {
                     bail!(
-                        "external failed transaction should have the correct nonce. address: {:?}, input: {:?}, sender: {:?}",
+                        "reverted external transaction should have the correct nonce. address: {:?}, input: {:?}, sender: {:?}",
                         tx_input.signer,
                         tx_input.nonce,
                         sender.nonce


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Check sender's nonce on reverted external transactions

- Improve error handling for failed external transactions

- Ensure correct nonce for failed external transactions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["External Transaction"] --> B{"Is Failed?"}
  B -->|Yes| C["Check Sender's Nonce"]
  C -->|Mismatch| D["Throw Error"]
  C -->|Match| E["Process Failed Transaction"]
  B -->|No| F["Normal Execution"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>executor.rs</strong><dd><code>Add nonce validation for failed external transactions</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/executor/executor.rs

<ul><li>Added nonce check for failed external transactions<br> <li> Implemented error handling using <code>anyhow::bail!</code><br> <li> Added detailed error message for nonce mismatch</ul>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2334/files#diff-6b460d7dee8280c0287e8d9d9d59cf66a57ec9fed1bc003c6ede6fef60c7376b">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

