### PR TITLE
ci: Clean cargo target before doing build for cache.

### DIFF
--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -100,6 +100,7 @@ jobs:
 
       - name: Build Debug binaries for cache
         run: |
+          cargo clean
           source <(cargo llvm-cov show-env --export-prefix)
           cargo build --features dev
 

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -93,6 +93,10 @@ jobs:
           echo "Artifact ID: ${{ steps.upload-str.outputs.artifact-id }} (stratus)"
           echo "Artifact URL: ${{ steps.upload-str.outputs.artifact-url }} (stratus)"
 
+      - name: Clean built binaries
+        run: |
+          cargo clean
+  
       - name: Set up dependencies
         uses: taiki-e/install-action@v2
         with:
@@ -100,7 +104,6 @@ jobs:
 
       - name: Build Debug binaries for cache
         run: |
-          cargo clean
           source <(cargo llvm-cov show-env --export-prefix)
           cargo build --features dev
 


### PR DESCRIPTION
### **User description**
This solution addresses the build process's instability, which has been causing intermittent "out of space" errors.

closes #74


___

### **PR Type**
Enhancement, Other


___

### **Description**
- Clean cargo target before building debug binaries

- Optimize CI process to prevent "out of space" errors


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CI Workflow"] --> B["Clean cargo target"]
  B --> C["Build Debug binaries"]
  C --> D["Cache Rust artifacts"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build-binary.yml</strong><dd><code>Add cargo clean step before building debug binaries</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/build-binary.yml

<ul><li>Added <code>cargo clean</code> command before building debug binaries<br> <li> Ensures a clean build environment for each CI run</ul>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2357/files#diff-056d8a48a1886a7da6ec1139b0a22f18e4d938f4183e7e381a96949206e3efcd">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

