### PR TITLE
chore: simplify the executor's evm pool configuration

### DIFF
--- a/src/eth/executor/executor.rs
+++ b/src/eth/executor/executor.rs
@@ -1,4 +1,3 @@
-use std::cmp::max;
 use std::mem;
 use std::sync::Arc;
 
@@ -97,11 +96,8 @@ impl InspectorTask {
 
 /// Manages EVM pool and communication channels.
 struct Evms {
-    /// Pool for serial execution of transactions received via `eth_sendRawTransaction`. Usually contains a single EVM.
-    pub tx_local: crossbeam_channel::Sender<EvmTask>,
-
-    /// Pool for serial execution of external transactions received via `importer-online` or `importer-offline`. Usually contains a single EVM.
-    pub tx_external: crossbeam_channel::Sender<EvmTask>,
+    /// Worker for execution of transactions.
+    pub tx: crossbeam_channel::Sender<EvmTask>,
 
     /// Pool for parallel execution of calls (eth_call and eth_estimateGas) reading from current state. Usually contains multiple EVMs.
     pub call_present: crossbeam_channel::Sender<EvmTask>,
@@ -109,6 +105,7 @@ struct Evms {
     /// Pool for parallel execution of calls (eth_call and eth_estimateGas) reading from past state. Usually contains multiple EVMs.
     pub call_past: crossbeam_channel::Sender<EvmTask>,
 
+    /// Pool for parallel execution of tx inspections (debug_traceTransaction). Usually contains multiple EVMs.
     pub inspector: crossbeam_channel::Sender<InspectorTask>,
 }
 
@@ -188,23 +185,13 @@ impl Evms {
             tx
         };
 
-        let tx_local = spawn_evms("evm-tx-serial", 1, EvmKind::Transaction);
-        let tx_external = spawn_evms("evm-tx-external", 1, EvmKind::Transaction);
-        let call_present = spawn_evms(
-            "evm-call-present",
-            max(config.executor_call_present_evms.unwrap_or(config.executor_evms / 2), 1),
-            EvmKind::Call,
-        );
-        let call_past = spawn_evms(
-            "evm-call-past",
-            max(config.executor_call_past_evms.unwrap_or(config.executor_evms / 4), 1),
-            EvmKind::Call,
-        );
-        let inspector = spawn_inspectors("inspector", max(config.executor_inspector_evms.unwrap_or(config.executor_evms / 4), 1));
+        let tx = spawn_evms("evm-tx", 1, EvmKind::Transaction);
+        let call_present = spawn_evms("evm-call-present", config.call_present_evms, EvmKind::Call);
+        let call_past = spawn_evms("evm-call-past", config.call_past_evms, EvmKind::Call);
+        let inspector = spawn_inspectors("inspector", config.inspector_evms);
 
         Evms {
-            tx_local,
-            tx_external,
+            tx,
             call_present,
             call_past,
             inspector,
@@ -217,8 +204,7 @@ impl Evms {
 
         let task = EvmTask::new(evm_input, execution_tx);
         let _ = match route {
-            EvmRoute::Local => self.tx_local.send(task),
-            EvmRoute::External => self.tx_external.send(task),
+            EvmRoute::Transaction => self.tx.send(task),
             EvmRoute::CallPresent => self.call_present.send(task),
             EvmRoute::CallPast => self.call_past.send(task),
         };
@@ -242,11 +228,8 @@ impl Evms {
 
 #[derive(Debug, Clone, Copy, strum::Display)]
 pub enum EvmRoute {
-    #[strum(to_string = "local")]
-    Local,
-
-    #[strum(to_string = "external")]
-    External,
+    #[strum(to_string = "transaction")]
+    Transaction,
 
     #[strum(to_string = "call_present")]
     CallPresent,
@@ -371,7 +354,7 @@ impl Executor {
             // successful external transaction, re-execute locally
             true => {
                 // re-execute transaction
-                let evm_execution = self.evms.execute(evm_input.clone(), EvmRoute::External);
+                let evm_execution = self.evms.execute(evm_input.clone(), EvmRoute::Transaction);
 
                 // handle re-execution result
                 let mut evm_execution = match evm_execution {
@@ -532,7 +515,7 @@ impl Executor {
                 "executing local transaction attempt"
             );
 
-            let evm_result = self.evms.execute(evm_input.clone(), EvmRoute::Local)?;
+            let evm_result = self.evms.execute(evm_input.clone(), EvmRoute::Transaction)?;
 
             // save execution to temporary storage
             // in case of failure, retry if conflict or abandon if unexpected error

--- a/src/eth/executor/executor_config.rs
+++ b/src/eth/executor/executor_config.rs
@@ -1,4 +1,3 @@
-use std::cmp::max;
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -16,18 +15,14 @@ pub struct ExecutorConfig {
     #[arg(long = "executor-chain-id", alias = "chain-id", env = "EXECUTOR_CHAIN_ID")]
     pub executor_chain_id: u64,
 
-    /// Number of EVM instances to run.
-    #[arg(long = "executor-evms", alias = "evms", env = "EXECUTOR_EVMS", default_value = "30")]
-    pub executor_evms: usize,
+    #[arg(long = "executor-call-present-evms", env = "EXECUTOR_CALL_PRESENT_EVMS", default_value_t = 50)]
+    pub call_present_evms: usize,
 
-    #[arg(long = "executor-call-present-evms", env = "EXECUTOR_CALL_PRESENT_EVMS")]
-    pub executor_call_present_evms: Option<usize>,
+    #[arg(long = "executor-call-past-evms", env = "EXECUTOR_CALL_PAST_EVMS", default_value_t = 50)]
+    pub call_past_evms: usize,
 
-    #[arg(long = "executor-call-past-evms", env = "EXECUTOR_CALL_PAST_EVMS")]
-    pub executor_call_past_evms: Option<usize>,
-
-    #[arg(long = "executor-inspector-evms", env = "EXECUTOR_INSPECTOR_EVMS")]
-    pub executor_inspector_evms: Option<usize>,
+    #[arg(long = "executor-inspector-evms", env = "EXECUTOR_INSPECTOR_EVMS", default_value_t = 50)]
+    pub inspector_evms: usize,
 
     /// Should reject contract transactions and calls to accounts that are not contracts?
     #[arg(
@@ -51,8 +46,7 @@ impl ExecutorConfig {
     ///
     /// Note: Should be called only after async runtime is initialized.
     pub fn init(&self, storage: Arc<StratusStorage>, miner: Arc<Miner>) -> Arc<Executor> {
-        let mut config = self.clone();
-        config.executor_evms = max(config.executor_evms, 1);
+        let config = self.clone();
         tracing::info!(?config, "creating executor");
 
         let executor = Executor::new(storage, miner, config);


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Simplified EVM pool configuration

- Consolidated transaction execution channels

- Removed unnecessary EVM count calculations

- Updated command-line arguments for EVM pools


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Old Config"] --> B["Simplified Config"]
  B --> C["Consolidated tx_local and tx_external"]
  B --> D["Direct EVM pool sizes"]
  C --> E["Single tx channel"]
  D --> F["Removed max() calculations"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>executor.rs</strong><dd><code>Consolidate transaction channels and simplify EVM pool management</code></dd></summary>
<hr>

src/eth/executor/executor.rs

<ul><li>Merged <code>tx_local</code> and <code>tx_external</code> into single <code>tx</code> channel<br> <li> Removed <code>max()</code> calculations for EVM pool sizes<br> <li> Updated <code>EvmRoute</code> enum to use <code>Transaction</code> instead of <code>Local</code> and <code>External</code><br> <li> Simplified <code>Evms</code> struct and its implementation</ul>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2372/files#diff-6b460d7dee8280c0287e8d9d9d59cf66a57ec9fed1bc003c6ede6fef60c7376b">+13/-30</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>executor_config.rs</strong><dd><code>Update ExecutorConfig to use direct EVM pool size settings</code></dd></summary>
<hr>

src/eth/executor/executor_config.rs

<ul><li>Removed <code>executor_evms</code> configuration option<br> <li> Added direct configuration options for <code>call_present_evms</code>, <br><code>call_past_evms</code>, and <code>inspector_evms</code><br> <li> Set default values for EVM pool sizes<br> <li> Removed unnecessary <code>max()</code> calculation in <code>init</code> method</ul>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2372/files#diff-6cf7fa175d8d21c44043aca3b3690957542a08dc37446bf33cc7e5cf5c330024">+7/-13</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

