### PR TITLE
chore: add dependency cooldown

### DIFF
--- a/e2e/.npmrc
+++ b/e2e/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=0.125

--- a/e2e/cloudwalk-contracts/integration/.npmrc
+++ b/e2e/cloudwalk-contracts/integration/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=0.125


### PR DESCRIPTION
## Summary
- Adds native 3-hour dependency cooldown config where supported.
- Skips ecosystems or repos where support/risk is uncertain.
- Does not change lockfiles or dependency versions.

## Validation
- Config-only change; PR CI validates repo-specific workflows.
- npm repos using internal @cloudwalk packages were intentionally skipped.
