### PR TITLE
fix: allow runnig build scripts

### DIFF
--- a/e2e/cloudwalk-contracts/contracts-clone.sh
+++ b/e2e/cloudwalk-contracts/contracts-clone.sh
@@ -16,6 +16,7 @@ clone() {
 
     if [ -d "$target" ]; then
         log "Updating: $repo"
+        git -C "$target" checkout -- pnpm-workspace.yaml 2>/dev/null || true
         git -C "$target" pull
     else
         log "Cloning: $repo"
@@ -30,7 +31,10 @@ clone() {
     corepack enable
     # pnpm v10+ blocks build scripts by default. Allow all packages to run
     # their build scripts so native deps like keccak and secp256k1 compile.
-    grep -q 'onlyBuiltDependencies' "$target/.npmrc" 2>/dev/null || echo 'onlyBuiltDependencies[]=*' >> "$target/.npmrc"
+    if [ -f "$target/pnpm-workspace.yaml" ]; then
+        grep -q 'onlyBuiltDependencies' "$target/pnpm-workspace.yaml" 2>/dev/null ||
+            printf '\nonlyBuiltDependencies:\n  - "*"\n' >>"$target/pnpm-workspace.yaml"
+    fi
     if ! corepack pnpm -C "$target" install; then
         log "Dependencies install failed. Removing folder and exiting."
         rm -rf "$target"

--- a/e2e/cloudwalk-contracts/contracts-clone.sh
+++ b/e2e/cloudwalk-contracts/contracts-clone.sh
@@ -28,6 +28,9 @@ clone() {
 
     log "Installing dependencies: $repo"
     corepack enable
+    # pnpm v10+ blocks build scripts by default. Allow all packages to run
+    # their build scripts so native deps like keccak and secp256k1 compile.
+    grep -q 'onlyBuiltDependencies' "$target/.npmrc" 2>/dev/null || echo 'onlyBuiltDependencies[]=*' >> "$target/.npmrc"
     if ! corepack pnpm -C "$target" install; then
         log "Dependencies install failed. Removing folder and exiting."
         rm -rf "$target"


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Allow pnpm build scripts in CI clones

- Append onlyBuiltDependencies flag if missing


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>contracts-clone.sh</strong><dd><code>Enable build scripts in pnpm installs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

e2e/cloudwalk-contracts/contracts-clone.sh

<ul><li>Added comment on pnpm v10+ blocking scripts<br> <li> Check <code>.npmrc</code> for <code>onlyBuiltDependencies</code><br> <li> Append <code>onlyBuiltDependencies[]=*</code> if absent</ul>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2508/files#diff-5b521c8f3ba50a86c4afd8303eab5079009a0e12e43f0ab45bc37b459dddab64">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

