### PR TITLE
fix(CI): use scoped token to clone brlc-monorepo which is now private

### DIFF
--- a/.github/workflows/e2e-contracts-rocks.yml
+++ b/.github/workflows/e2e-contracts-rocks.yml
@@ -105,6 +105,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           repository: cloudwalk/brlc-monorepo
+          token: ${{ secrets.BRLC_MONOREPO_TOKEN }}
 
       - name: Install Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -166,6 +167,8 @@ jobs:
 
       - name: Clone BRLC Monorepo repository
         run: just contracts-clone
+        env:
+          BRLC_MONOREPO_TOKEN: ${{ secrets.BRLC_MONOREPO_TOKEN }}
 
       - name: Run e2e tests
         run: just run-test contracts-test-stratus ${{ matrix.contract }}

--- a/.github/workflows/e2e-leader-follower.yml
+++ b/.github/workflows/e2e-leader-follower.yml
@@ -144,6 +144,8 @@ jobs:
           sudo apt-get install -y docker-compose
       - name: Clone BRLCToken repository
         run: just contracts-clone
+        env:
+          BRLC_MONOREPO_TOKEN: ${{ secrets.BRLC_MONOREPO_TOKEN }}
       - name: Flatten BRLCToken contract
         run: just contracts-flatten token BRLCToken
       - name: Run e2e tests

--- a/e2e/cloudwalk-contracts/contracts-clone.sh
+++ b/e2e/cloudwalk-contracts/contracts-clone.sh
@@ -19,10 +19,20 @@ clone() {
         git -C "$target" pull
     else
         log "Cloning: $repo"
-        if ! git clone https://github.com/cloudwalk/"$repo".git -b main "$target"; then
-            log "Clone failed. Removing folder and exiting."
-            rm -rf "$target"
-            return 1
+        if [ -n "${BRLC_MONOREPO_TOKEN:-}" ]; then
+            # Authenticated clone using the PAT. GitHub Actions masks secrets
+            # in logs, so the token is redacted if echoed in error output.
+            if ! git clone "https://x-access-token:${BRLC_MONOREPO_TOKEN}@github.com/cloudwalk/${repo}.git" -b main "$target"; then
+                log "Clone failed. Removing folder and exiting."
+                rm -rf "$target"
+                return 1
+            fi
+        else
+            if ! git clone "https://github.com/cloudwalk/${repo}.git" -b main "$target"; then
+                log "Clone failed. Removing folder and exiting."
+                rm -rf "$target"
+                return 1
+            fi
         fi
     fi
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Add token-based authentication for cloning private repo

- Inject `BRLC_MONOREPO_TOKEN` into checkout steps

- Pass the token as env var to clone in workflows


___

### Diagram Walkthrough


```mermaid
flowchart LR
  SC["clone script"] --> T["Check BRLC_MONOREPO_TOKEN"]
  T -- "yes" --> AT["Clone with token"]
  T -- "no" --> PC["Clone without token"]
  AT --> Finish["Post-clone steps"]
  PC --> Finish
  WH["GitHub workflows"] --> WC1["Add token to checkout"]
  WH --> WC2["Set token env for clone"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>contracts-clone.sh</strong><dd><code>Add token-based conditional cloning</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

e2e/cloudwalk-contracts/contracts-clone.sh

<ul><li>Check <code>BRLC_MONOREPO_TOKEN</code> before cloning<br> <li> Perform authenticated clone if token present<br> <li> Fallback to public clone when token missing<br> <li> Retain failure cleanup logic on errors</ul>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2526/files#diff-5b521c8f3ba50a86c4afd8303eab5079009a0e12e43f0ab45bc37b459dddab64">+14/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>e2e-contracts-rocks.yml</strong><dd><code>Inject BRLC token in e2e-contracts workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/e2e-contracts-rocks.yml

<ul><li>Provide <code>token: ${{ secrets.BRLC_MONOREPO_TOKEN }}</code> to checkout<br> <li> Set <code>BRLC_MONOREPO_TOKEN</code> env for clone step</ul>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2526/files#diff-68f3b7a6f3576ab20f596c2bbc5e0e09be41692b016d8240c289d126a684175f">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>e2e-leader-follower.yml</strong><dd><code>Set token env in e2e-leader-follower workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/e2e-leader-follower.yml

<ul><li>Export <code>BRLC_MONOREPO_TOKEN</code> env for clone step<br> <li> Ensure private repo cloning from workflows</ul>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2526/files#diff-6cb08ce033aeec24672fd91944789df5188b47bbf56f16d034c600ba66ea1461">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

