### PR TITLE
feat: blocked clients config

### DIFF
--- a/e2e/test/automine/e2e-json-rpc.test.ts
+++ b/e2e/test/automine/e2e-json-rpc.test.ts
@@ -111,6 +111,66 @@ describe("JSON-RPC", () => {
         });
     });
 
+    describe("Blocked Clients", () => {
+        const blockedClient = "blocked-test-client";
+
+        before(async () => {
+            if (isStratus) {
+                await send("stratus_enableUnknownClients");
+                await send("stratus_clearBlockedClients");
+            }
+        });
+
+        after(async () => {
+            if (isStratus) {
+                await send("stratus_clearBlockedClients");
+                await send("stratus_enableUnknownClients");
+            }
+        });
+
+        it("blocking a client rejects its requests but allows others", async function () {
+            if (!isStratus) {
+                this.skip();
+                return;
+            }
+
+            const blockedList = await send("stratus_blockClient", [blockedClient]);
+            expect(blockedList).to.be.an("array").that.is.not.empty;
+
+            // request from the blocked client should fail
+            const error = await sendAndGetError("eth_blockNumber", [], { "x-app": blockedClient });
+            expect(error.code).eq(1011);
+
+            // request from a different client should succeed
+            const blockNumber = await send("eth_blockNumber", [], { "x-app": "other-client" });
+            expect(blockNumber).to.match(/^0x[0-9a-f]+$/);
+        });
+
+        it("unblocking a client allows its requests again", async function () {
+            if (!isStratus) {
+                this.skip();
+                return;
+            }
+
+            await send("stratus_blockClient", [blockedClient]);
+            await send("stratus_unblockClient", [blockedClient]);
+
+            const blockNumber = await send("eth_blockNumber", [], { "x-app": blockedClient });
+            expect(blockNumber).to.match(/^0x[0-9a-f]+$/);
+        });
+
+        it("stratus_state exposes blocked clients", async function () {
+            if (!isStratus) {
+                this.skip();
+                return;
+            }
+
+            await send("stratus_blockClient", [blockedClient]);
+            const state = await send("stratus_state");
+            expect(state.blocked_clients).to.be.an("array").that.is.not.empty;
+        });
+    });
+
     describe("Metadata", () => {
         it("eth_chainId", async () => {
             (await sendExpect("eth_chainId")).eq(CHAIN_ID);

--- a/src/config.rs
+++ b/src/config.rs
@@ -117,6 +117,11 @@ pub struct CommonConfig {
     /// Enables or disables unknown client interactions.
     #[arg(long = "unknown-client-enabled", env = "UNKNOWN_CLIENT_ENABLED", default_value = "true")]
     pub unknown_client_enabled: bool,
+
+    /// Comma-separated list of client names that are blocked from interacting with the application.
+    /// Client names are matched the same way as the `app`/`client` identification headers/params.
+    #[arg(long = "blocked-clients", env = "BLOCKED_CLIENTS", value_delimiter = ',')]
+    pub blocked_clients: Vec<String>,
 }
 
 impl WithCommonConfig for CommonConfig {

--- a/src/eth/primitives/stratus_error.rs
+++ b/src/eth/primitives/stratus_error.rs
@@ -38,6 +38,10 @@ pub enum RpcError {
     #[error_code = 3]
     ClientMissing,
 
+    #[error("denied because client is blocked.")]
+    #[error_code = 11]
+    ClientBlocked { client: String },
+
     #[error("failed to decode {rust_type} parameter.")]
     #[error_code = 4]
     ParameterDecodeError { rust_type: &'static str, decode_error: String },
@@ -293,6 +297,7 @@ impl StratusError {
             // RPC
             Self::RPC(RpcError::BlockFilterInvalid { filter }) => to_json_value(filter),
             Self::RPC(RpcError::ParameterDecodeError { decode_error, .. }) => to_json_value(decode_error),
+            Self::RPC(RpcError::ClientBlocked { client }) => to_json_value(client),
 
             // Transaction
             Self::RPC(RpcError::TransactionInvalid { decode_error }) => to_json_value(decode_error),
@@ -308,7 +313,8 @@ impl StratusError {
     }
 
     pub fn to_response_future<'a>(self, id: Id<'_>) -> ResponseFuture<BoxFuture<'a, MethodResponse>, MethodResponse> {
-        let response = ResponsePayload::<()>::error(StratusError::RPC(RpcError::ClientMissing));
+        let error: ErrorObjectOwned = self.into();
+        let response = ResponsePayload::<()>::error(error);
         let method_response = MethodResponse::response(id, response, u32::MAX as usize);
         ResponseFuture::ready(method_response)
     }

--- a/src/eth/rpc/rpc_middleware.rs
+++ b/src/eth/rpc/rpc_middleware.rs
@@ -256,7 +256,7 @@ impl RpcServiceT for RpcMiddleware {
 
         let id = request.id.to_string();
 
-        let future_response = reject_unknown_client(&client, request.id.clone()).unwrap_or(Box::pin(self.service.call(request)));
+        let future_response = reject_client(&client, request.id.clone()).unwrap_or(Box::pin(self.service.call(request)));
         RpcResponse {
             client,
             id,
@@ -269,9 +269,16 @@ impl RpcServiceT for RpcMiddleware {
 }
 
 /// Returns an error JSON-RPC response if the client is not allowed to perform the current operation.
-fn reject_unknown_client<'a>(client: &RpcClientApp, id: Id<'_>) -> Option<BoxFuture<'a, MethodResponse>> {
+fn reject_client<'a>(client: &RpcClientApp, id: Id<'_>) -> Option<BoxFuture<'a, MethodResponse>> {
+    // reject unidentified clients when unknown clients are disabled
     if client.is_unknown() && !GlobalState::is_unknown_client_enabled() {
         return Some(Box::pin(StratusError::RPC(RpcError::ClientMissing).to_response_future(id)));
+    }
+    // reject explicitly blocked clients
+    if GlobalState::is_client_blocked(client) {
+        return Some(Box::pin(
+            StratusError::RPC(RpcError::ClientBlocked { client: client.to_string() }).to_response_future(id),
+        ));
     }
     None
 }

--- a/src/eth/rpc/rpc_server.rs
+++ b/src/eth/rpc/rpc_server.rs
@@ -301,6 +301,9 @@ fn register_methods(mut module: RpcModule<RpcContext>) -> anyhow::Result<RpcModu
     module.register_method("stratus_disableMiner", stratus_disable_miner)?;
     module.register_method("stratus_enableUnknownClients", stratus_enable_unknown_clients)?;
     module.register_method("stratus_disableUnknownClients", stratus_disable_unknown_clients)?;
+    module.register_method("stratus_blockClient", stratus_block_client)?;
+    module.register_method("stratus_unblockClient", stratus_unblock_client)?;
+    module.register_method("stratus_clearBlockedClients", stratus_clear_blocked_clients)?;
     module.register_method("stratus_enableRestartOnUnhealthy", stratus_enable_restart_on_unhealthy)?;
     module.register_method("stratus_disableRestartOnUnhealthy", stratus_disable_restart_on_unhealthy)?;
     module.register_async_method("stratus_changeToLeader", stratus_change_to_leader)?;
@@ -719,6 +722,26 @@ fn stratus_disable_unknown_clients(_: Params<'_>, _: &RpcContext, ext: &Extensio
     ext.authentication().auth_admin()?;
     GlobalState::set_unknown_client_enabled(false);
     Ok(GlobalState::is_unknown_client_enabled())
+}
+
+fn stratus_block_client(params: Params<'_>, _: &RpcContext, ext: &Extensions) -> Result<Vec<String>, StratusError> {
+    ext.authentication().auth_admin()?;
+    let (_, client) = next_rpc_param::<String>(params.sequence())?;
+    GlobalState::add_blocked_client(&client);
+    Ok(GlobalState::list_blocked_clients())
+}
+
+fn stratus_unblock_client(params: Params<'_>, _: &RpcContext, ext: &Extensions) -> Result<Vec<String>, StratusError> {
+    ext.authentication().auth_admin()?;
+    let (_, client) = next_rpc_param::<String>(params.sequence())?;
+    GlobalState::remove_blocked_client(&client);
+    Ok(GlobalState::list_blocked_clients())
+}
+
+fn stratus_clear_blocked_clients(_: Params<'_>, _: &RpcContext, ext: &Extensions) -> Result<Vec<String>, StratusError> {
+    ext.authentication().auth_admin()?;
+    GlobalState::clear_blocked_clients();
+    Ok(GlobalState::list_blocked_clients())
 }
 
 fn stratus_enable_transactions(_: Params<'_>, _: &RpcContext, ext: &Extensions) -> Result<bool, StratusError> {

--- a/src/globals.rs
+++ b/src/globals.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::fmt::Debug;
 use std::sync::LazyLock;
 use std::sync::atomic::AtomicBool;
@@ -19,6 +20,7 @@ use crate::alias::JsonValue;
 use crate::config;
 use crate::config::StratusConfig;
 use crate::config::WithCommonConfig;
+use crate::eth::rpc::RpcClientApp;
 use crate::eth::rpc::RpcContext;
 use crate::ext::not;
 use crate::ext::spawn_signal_handler;
@@ -59,6 +61,9 @@ where
 
         // Set the unknown_client_enabled value
         GlobalState::set_unknown_client_enabled(common.unknown_client_enabled);
+
+        // Set the blocked clients
+        GlobalState::init_blocked_clients(&common.blocked_clients);
 
         // init tokio
         let tokio = common.init_tokio_runtime().expect("failed to init tokio runtime");
@@ -122,6 +127,9 @@ static TRANSACTIONS_ENABLED: AtomicBool = AtomicBool::new(true);
 
 /// Unknown clients can interact with the application?
 static UNKNOWN_CLIENT_ENABLED: AtomicBool = AtomicBool::new(true);
+
+/// Clients that are blocked from interacting with the application.
+static BLOCKED_CLIENTS: LazyLock<Mutex<HashSet<String>>> = LazyLock::new(|| Mutex::new(HashSet::new()));
 
 /// Current node mode.
 static NODE_MODE: Mutex<NodeMode> = Mutex::new(NodeMode::Follower);
@@ -276,6 +284,60 @@ impl GlobalState {
     }
 
     // -------------------------------------------------------------------------
+    // Blocked Clients
+    // -------------------------------------------------------------------------
+
+    /// Initializes the blocked clients set from configuration. Names are normalized the same way as incoming client identification.
+    pub fn init_blocked_clients(names: &[String]) {
+        let mut blocked = BLOCKED_CLIENTS.lock();
+        for name in names {
+            if let RpcClientApp::Identified(normalized) = RpcClientApp::parse(name) {
+                blocked.insert(normalized);
+            }
+        }
+    }
+
+    /// Adds a client to the blocked clients set. Returns the normalized name when added.
+    pub fn add_blocked_client(name: &str) -> Option<String> {
+        match RpcClientApp::parse(name) {
+            RpcClientApp::Identified(normalized) => {
+                BLOCKED_CLIENTS.lock().insert(normalized.clone());
+                Some(normalized)
+            }
+            RpcClientApp::Unknown => None,
+        }
+    }
+
+    /// Removes a client from the blocked clients set. Returns whether it was present.
+    pub fn remove_blocked_client(name: &str) -> bool {
+        match RpcClientApp::parse(name) {
+            RpcClientApp::Identified(normalized) => BLOCKED_CLIENTS.lock().remove(&normalized),
+            RpcClientApp::Unknown => false,
+        }
+    }
+
+    /// Clears the blocked clients set.
+    pub fn clear_blocked_clients() {
+        BLOCKED_CLIENTS.lock().clear();
+    }
+
+    /// Checks if a client is blocked.
+    pub fn is_client_blocked(client: &RpcClientApp) -> bool {
+        match client {
+            RpcClientApp::Identified(name) => BLOCKED_CLIENTS.lock().contains(name),
+            RpcClientApp::Unknown => false,
+        }
+    }
+
+    /// Returns the list of blocked clients (normalized names).
+    pub fn list_blocked_clients() -> Vec<String> {
+        let blocked = BLOCKED_CLIENTS.lock();
+        let mut list: Vec<String> = blocked.iter().cloned().collect();
+        list.sort();
+        list
+    }
+
+    // -------------------------------------------------------------------------
     // Node Mode
     // -------------------------------------------------------------------------
 
@@ -328,6 +390,7 @@ impl GlobalState {
             "transactions_enabled": Self::is_transactions_enabled(),
             "miner_paused": ctx.server.miner.is_paused(),
             "unknown_client_enabled": Self::is_unknown_client_enabled(),
+            "blocked_clients": Self::list_blocked_clients(),
             "start_time": start_time.format("%d/%m/%Y %H:%M UTC").to_string(),
             "elapsed_time": elapsed_time,
         })


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Add blocked_clients config and global state support

- Implement RPC methods to manage blocklist

- Enforce blocklist in middleware with ClientBlocked error

- Add unit and end-to-end tests for blocking behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  CFG["Parse blocked_clients config"] --> INIT["GlobalState.init_blocked_clients"]
  INIT --> STORE["BLOCKED_CLIENTS set"]
  RPC["RPC methods (block/unblock/clear)"] --> STORE
  STORE --> MW["Middleware reject_client check"]
  MW --> ERR["RpcError::ClientBlocked"]
  ERR --> RESP["JSON-RPC error response"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.rs</strong><dd><code>Add blocked_clients configuration field</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/config.rs

<ul><li>Add <code>blocked_clients: Vec<String></code> to CommonConfig<br> <li> Define <code>--blocked-clients</code> clap arg and env var parsing<br> <li> Support comma-delimited client names</ul>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2545/files#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecd">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>stratus_error.rs</strong><dd><code>Add ClientBlocked error variant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/stratus_error.rs

<ul><li>Introduce <code>ClientBlocked</code> RpcError variant with code 11<br> <li> Handle <code>ClientBlocked</code> in <code>rpc_data</code><br> <li> Refactor <code>to_response_future</code> to use dynamic error object</ul>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2545/files#diff-301cded01d772388e3e5c08ede093b91c3e4478c08e11a48f70e3d44351385fb">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>rpc_middleware.rs</strong><dd><code>Enforce blocked clients in middleware</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/rpc/rpc_middleware.rs

<ul><li>Rename <code>reject_unknown_client</code> to <code>reject_client</code><br> <li> Add blocklist check via <code>GlobalState::is_client_blocked</code><br> <li> Return ClientBlocked error response when blocked</ul>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2545/files#diff-31b7182aec4416845e60ec9ec16720ae97d31260e1a9c50d601d542dee8776f5">+9/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rpc_server.rs</strong><dd><code>Add blocklist management RPC methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/rpc/rpc_server.rs

<ul><li>Register <code>stratus_blockClient</code>, <code>stratus_unblockClient</code>, <br><code>stratus_clearBlockedClients</code><br> <li> Implement handlers to add/remove/clear blocklist entries<br> <li> Return updated blocked clients list</ul>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2545/files#diff-835ba255c9a5c1fe0e13285bc39e058e1c74422e5e03ebba483c9d8a15c45405">+23/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>globals.rs</strong><dd><code>Implement global blocked clients API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/globals.rs

<ul><li>Import <code>HashSet</code> and <code>RpcClientApp</code><br> <li> Define <code>BLOCKED_CLIENTS</code> static set with Mutex<br> <li> Add init/add/remove/clear/is_client_blocked/list methods<br> <li> Include <code>blocked_clients</code> in status JSON<br> <li> Add unit tests for blocklist behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2545/files#diff-48d6fbc3a4ed67100952dcccfada858623c931e73d6de32984d4d1457e68d3a9">+100/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>e2e-json-rpc.test.ts</strong><dd><code>Add E2E tests for client blocking</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

e2e/test/automine/e2e-json-rpc.test.ts

<ul><li>Add end-to-end tests for blocking, unblocking clients<br> <li> Verify error code 1011 for blocked requests<br> <li> Check <code>stratus_state</code> exposes blocked_clients</ul>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2545/files#diff-3d74b20bca5732bd9d71f766b668d339a52e53e6b7fd18ff8f9000c077184439">+60/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

