### PR TITLE
Generalize account/slot reads

### DIFF
--- a/src/eth/storage/mod.rs
+++ b/src/eth/storage/mod.rs
@@ -12,6 +12,7 @@ pub use temporary::TemporaryStorageConfig;
 
 mod cache;
 pub mod permanent;
+mod resolve_pending;
 mod stratus_storage;
 mod temporary;
 

--- a/src/eth/storage/resolve_pending.rs
+++ b/src/eth/storage/resolve_pending.rs
@@ -1,0 +1,237 @@
+use parking_lot::RwLockReadGuard;
+
+use crate::eth::primitives::Account;
+use crate::eth::primitives::BlockNumber;
+use crate::eth::primitives::PointInTime;
+use crate::eth::primitives::Slot;
+use crate::eth::primitives::StorageError;
+use crate::eth::storage::ReadKind;
+use crate::eth::storage::StratusStorage;
+use crate::eth::storage::TxCount;
+use crate::eth::storage::stratus_storage::EntityRead;
+use crate::infra::metrics::MetricLabelValue;
+
+/// Prevents construction of [`MinedPointInTime`] outside this module.
+/// `Seal` is public (so the enum variants can be pattern-matched) but cannot be constructed
+/// externally because its field type is private.
+#[derive(Debug)]
+pub struct Seal(SealPrivate);
+
+#[derive(Debug)]
+struct SealPrivate;
+
+/// A [`PointInTime`] that has been resolved past the pending case.
+///
+/// `Latest` carries an optional `transient_state_lock` read guard held across the latest read.
+///
+/// The [`Seal`] field makes both variants impossible to construct outside this module,
+/// while still allowing pattern matching externally.
+#[derive(Debug, strum::Display)]
+pub enum MinedPointInTime<'a> {
+    #[strum(to_string = "latest")]
+    Latest(Seal, Option<RwLockReadGuard<'a, ()>>),
+    #[strum(to_string = "past")]
+    Past(Seal, BlockNumber),
+}
+
+impl<'a> MinedPointInTime<'a> {
+    fn mined(guard: Option<RwLockReadGuard<'a, ()>>) -> Self {
+        Self::Latest(Seal(SealPrivate), guard)
+    }
+
+    fn mined_past(number: BlockNumber) -> Self {
+        Self::Past(Seal(SealPrivate), number)
+    }
+
+    /// Extracts the read guard if present, leaving `Mined(None)` in its place.
+    fn take_guard(&mut self) -> Option<RwLockReadGuard<'a, ()>> {
+        match self {
+            Self::Latest(_, guard) => guard.take(),
+            Self::Past(_, _) => None,
+        }
+    }
+}
+
+impl From<MinedPointInTime<'_>> for MetricLabelValue {
+    fn from(value: MinedPointInTime<'_>) -> Self {
+        Self::Some(value.to_string())
+    }
+}
+
+/// Unlocks the guard fairly when dropped.
+impl<'a> Drop for MinedPointInTime<'a> {
+    fn drop(&mut self) {
+        if let Some(guard) = self.take_guard() {
+            RwLockReadGuard::unlock_fair(guard);
+        }
+    }
+}
+
+/// Outcome of resolving pending state for a read.
+#[derive(Debug)]
+pub(super) enum Resolved<'a, T> {
+    /// Found in the pending cache.
+    PendingCache(T),
+    /// Found in temporary storage.
+    Temp(T),
+    /// Nothing pending.
+    Miss(MinedPointInTime<'a>),
+}
+
+/// Pending-state resolution, generic over the entity being read.
+pub(super) trait Resolve: EntityRead {
+    fn resolve(s: &StratusStorage, pit: PointInTime, key: Self::Key, kind: ReadKind) -> Result<Resolved<'_, Self>, StorageError> {
+        if pit == PointInTime::Pending {
+            if matches!(kind, ReadKind::Transaction)
+                && let Some(value) = Self::read_pending_cache(s, key)
+            {
+                return Ok(Resolved::PendingCache(value));
+            }
+            if let Some(value) = Self::read_temp(s, key, kind)? {
+                return Ok(Resolved::Temp(value));
+            }
+        }
+        Ok(Resolved::Miss(s.resolve_mined_point(pit, kind)))
+    }
+}
+
+impl Resolve for Account {}
+
+impl Resolve for Slot {}
+
+impl StratusStorage {
+    /// Determines the mined point-in-time for a read.
+    fn resolve_mined_point(&self, pit: PointInTime, kind: ReadKind) -> MinedPointInTime<'_> {
+        if let PointInTime::MinedPast(number) = pit {
+            return MinedPointInTime::mined_past(number);
+        }
+        match kind {
+            ReadKind::Call((block_number, tx_count)) => {
+                let guard = self.transient_state_lock.read();
+                let mined = self.read_mined_block_number();
+                if (block_number, tx_count) >= (mined, TxCount::Full) {
+                    MinedPointInTime::mined(Some(guard))
+                } else {
+                    drop(guard);
+                    let target = match tx_count {
+                        TxCount::Partial(_) => block_number.prev().unwrap_or_default(),
+                        TxCount::Full => block_number,
+                    };
+                    MinedPointInTime::mined_past(target)
+                }
+            }
+            ReadKind::Transaction | ReadKind::RPC => MinedPointInTime::mined(None),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::StratusStorage;
+    use super::Resolve;
+    use crate::eth::primitives::Address;
+    use crate::eth::primitives::BlockNumber;
+    use crate::eth::primitives::PointInTime;
+    use crate::eth::primitives::Slot;
+    use crate::eth::primitives::SlotIndex;
+    use crate::eth::storage::ReadKind;
+    use crate::eth::storage::TxCount;
+
+    #[test]
+    fn pending_partial_call_latest_becomes_stale_once_block_is_mined() {
+        let storage = StratusStorage::new_test().expect("failed to build test storage");
+
+        let address = Address::ZERO;
+        let index = SlotIndex::ZERO;
+
+        // Pending call: block_number is the pending block (mined + 1 = 6), pinned to tx 0.
+        let mined_at_start = 5u64;
+        let pending_block_number = BlockNumber::from(mined_at_start + 1);
+        storage.set_mined_block_number(BlockNumber::from(mined_at_start));
+
+        let kind = ReadKind::Call((pending_block_number, TxCount::Partial(0)));
+
+        // At call start: block 6 is still pending (mined=5). Latest (block 5) is a safe base.
+        // resolve_slot should return Miss(Mined(Some(guard))).
+        let resolved = Slot::resolve(&storage, PointInTime::Pending, (address, index), kind).expect("resolve_slot");
+        match resolved {
+            super::Resolved::Miss(mut point) => {
+                assert!(
+                    matches!(point, super::MinedPointInTime::Latest(_, _)),
+                    "should read latest mined base while block is still pending"
+                );
+                assert!(point.take_guard().is_some(), "guard should be held for valid latest read");
+            }
+            other => panic!("expected Miss, got {other:?}"),
+        }
+
+        // The pending block is mined mid-call, advancing the mined tip to 6.
+        storage.set_mined_block_number(pending_block_number);
+
+        // The call is now stale: reading "latest" would observe block 6's aggregate state,
+        // not the tx-0 base. resolve_slot should downgrade to MinedPast(5) = b.prev() with no guard.
+        let resolved = Slot::resolve(&storage, PointInTime::Pending, (address, index), kind).expect("resolve_slot");
+        match resolved {
+            super::Resolved::Miss(mut point) => {
+                assert!(!matches!(point, super::MinedPointInTime::Latest(_, _)), "stale call should not read latest");
+                match &point {
+                    super::MinedPointInTime::Past(_, number) => {
+                        assert_eq!(
+                            *number,
+                            BlockNumber::from(mined_at_start),
+                            "stale Partial call should downgrade to MinedPast(b.prev())"
+                        );
+                    }
+                    other => panic!("expected Past, got {other:?}"),
+                }
+                assert!(point.take_guard().is_none(), "no guard for historical read");
+            }
+            other => panic!("expected Miss, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn mined_full_call_downgrades_to_minedpast_block_not_prev() {
+        let storage = StratusStorage::new_test().expect("failed to build test storage");
+
+        let address = Address::ZERO;
+        let index = SlotIndex::ZERO;
+
+        // Mined Full call: block_number = 5, mined = 5 → valid (b >= mined).
+        let call_block = BlockNumber::from(5u64);
+        storage.set_mined_block_number(call_block);
+
+        let kind = ReadKind::Call((call_block, TxCount::Full));
+
+        let resolved = Slot::resolve(&storage, PointInTime::Mined, (address, index), kind).expect("resolve_slot");
+        match resolved {
+            super::Resolved::Miss(mut point) => {
+                assert!(
+                    matches!(point, super::MinedPointInTime::Latest(_, _)),
+                    "Full call should read latest while block is the mined tip"
+                );
+                assert!(point.take_guard().is_some(), "guard should be held for valid latest read");
+            }
+            other => panic!("expected Miss, got {other:?}"),
+        }
+
+        // A newer block is mined mid-call, advancing the mined tip to 6.
+        storage.set_mined_block_number(BlockNumber::from(6u64));
+
+        // Stale: b=5 < mined=6. Full → MinedPast(5), NOT MinedPast(4).
+        let resolved = Slot::resolve(&storage, PointInTime::Mined, (address, index), kind).expect("resolve_slot");
+        match resolved {
+            super::Resolved::Miss(mut point) => {
+                assert!(!matches!(point, super::MinedPointInTime::Latest(_, _)), "stale call should not read latest");
+                match &point {
+                    super::MinedPointInTime::Past(_, number) => {
+                        assert_eq!(*number, call_block, "stale Full call should downgrade to MinedPast(block_number), not prev()");
+                    }
+                    other => panic!("expected Past, got {other:?}"),
+                }
+                assert!(point.take_guard().is_none(), "no guard for historical read");
+            }
+            other => panic!("expected Miss, got {other:?}"),
+        }
+    }
+}

--- a/src/eth/storage/stratus_storage.rs
+++ b/src/eth/storage/stratus_storage.rs
@@ -69,10 +69,10 @@ impl AccountOriginalsReader for StratusStorage {
     }
 }
 
-pub use resolve::MinedPointInTime;
+pub use resolve_pending::MinedPointInTime;
 
 /// Pending-state resolution
-mod resolve {
+mod resolve_pending {
     use super::Account;
     use super::Address;
     use super::BlockNumber;
@@ -338,6 +338,134 @@ mod resolve {
     }
 }
 
+/// Where a completed read obtained its value. Drives the post-read caching decision.
+#[derive(Debug)]
+enum FoundAt {
+    /// Hit in a cache (pending or latest). Already cached; nothing to write.
+    Cache,
+    /// Found in temporary (pending or latest) storage.
+    Temp,
+    /// Read from permanent storage at the latest mined point.
+    PermLatest,
+    /// Read from permanent storage at a historical block.
+    PermHistorical,
+}
+
+/// Abstraction over address-keyed ([`Account`]) and slot-keyed ([`Slot`]) reads
+trait EntityRead: Sized + Clone {
+    type Key: Copy;
+
+    /// Resolves pending state for `key`, returning where the value came from (or a mined miss).
+    fn resolve(s: &StratusStorage, pit: PointInTime, key: Self::Key, kind: ReadKind) -> Result<resolve_pending::Resolved<'_, Self>, StorageError>;
+    /// Reads the latest (mined tip) value from the cache, if present.
+    fn read_latest_cache(s: &StratusStorage, key: Self::Key) -> Option<Self>;
+    /// Reads from permanent storage at the resolved mined point.
+    fn read_perm(s: &StratusStorage, key: Self::Key, point: MinedPointInTime<'_>) -> Result<Self, StorageError>;
+    /// Caches the value as a pending entry, if not already cached.
+    fn cache_if_missing(s: &StratusStorage, key: Self::Key, value: Self);
+    /// Caches the value as a latest (mined tip) entry, if not already cached.
+    fn cache_latest_if_missing(s: &StratusStorage, key: Self::Key, value: Self);
+}
+
+impl EntityRead for Account {
+    type Key = Address;
+
+    fn resolve(s: &StratusStorage, pit: PointInTime, address: Address, kind: ReadKind) -> Result<resolve_pending::Resolved<'_, Self>, StorageError> {
+        s.resolve_account(pit, address, kind)
+    }
+
+    fn read_latest_cache(s: &StratusStorage, address: Address) -> Option<Self> {
+        timed(|| s.cache.get_account_latest(address)).with(|m| {
+            if m.result.is_some() {
+                tracing::debug!(storage = %label::CACHE, %address, "account found in cache");
+                metrics::inc_storage_read_account(m.elapsed, label::CACHE, PointInTime::Mined);
+            }
+        })
+    }
+
+    fn read_perm(s: &StratusStorage, address: Address, point: MinedPointInTime<'_>) -> Result<Self, StorageError> {
+        tracing::debug!(storage = %label::PERM, %address, "reading account");
+        let account = timed(|| s.perm.read_account(address, &point)).with(|m| {
+            if m.result.as_ref().is_ok_and(|opt| opt.is_some()) {
+                metrics::inc_storage_read_account(m.elapsed, label::PERM, point);
+            }
+            if let Err(ref e) = m.result {
+                tracing::error!(reason = ?e, "failed to read account from permanent storage");
+            }
+        })?;
+        Ok(match account {
+            Some(account) => {
+                tracing::debug!(storage = %label::PERM, %address, ?account, "account found in permanent storage");
+                account
+            }
+            None => {
+                tracing::debug!(storage = %label::PERM, %address, "account not found, assuming default value");
+                Account::new_empty(address)
+            }
+        })
+    }
+
+    fn cache_if_missing(s: &StratusStorage, _address: Address, account: Self) {
+        s.cache.cache_account_if_missing(account);
+    }
+
+    fn cache_latest_if_missing(s: &StratusStorage, address: Address, account: Self) {
+        s.cache.cache_account_latest_if_missing(address, account);
+    }
+}
+
+impl EntityRead for Slot {
+    type Key = (Address, SlotIndex);
+
+    fn resolve(s: &StratusStorage, pit: PointInTime, key: (Address, SlotIndex), kind: ReadKind) -> Result<resolve_pending::Resolved<'_, Self>, StorageError> {
+        let (address, index) = key;
+        s.resolve_slot(pit, address, index, kind)
+    }
+
+    fn read_latest_cache(s: &StratusStorage, key: (Address, SlotIndex)) -> Option<Self> {
+        let (address, index) = key;
+        timed(|| s.cache.get_slot_latest(address, index)).with(|m| {
+            if m.result.is_some() {
+                tracing::debug!(storage = %label::CACHE, %address, slot = ?m.result, "slot found in cache");
+                metrics::inc_storage_read_slot(m.elapsed, label::CACHE, PointInTime::Mined);
+            }
+        })
+    }
+
+    fn read_perm(s: &StratusStorage, key: (Address, SlotIndex), point: MinedPointInTime<'_>) -> Result<Self, StorageError> {
+        let (address, index) = key;
+        tracing::debug!(storage = %label::PERM, %address, %index, %point, "reading slot");
+        let slot = timed(|| s.perm.read_slot(address, index, &point)).with(|m| {
+            if m.result.as_ref().is_ok_and(|opt| opt.is_some()) {
+                metrics::inc_storage_read_slot(m.elapsed, label::PERM, point);
+            }
+            if let Err(ref e) = m.result {
+                tracing::error!(reason = ?e, "failed to read slot from permanent storage");
+            }
+        })?;
+        Ok(match slot {
+            Some(slot) => {
+                tracing::debug!(storage = %label::PERM, %address, %index, ?slot, "slot found in permanent storage");
+                slot
+            }
+            None => {
+                tracing::debug!(storage = %label::PERM, %address, %index, "slot not found, assuming default value");
+                Slot::new_empty(index)
+            }
+        })
+    }
+
+    fn cache_if_missing(s: &StratusStorage, key: (Address, SlotIndex), slot: Self) {
+        let (address, _) = key;
+        s.cache.cache_slot_if_missing(address, slot);
+    }
+
+    fn cache_latest_if_missing(s: &StratusStorage, key: (Address, SlotIndex), slot: Self) {
+        let (address, _) = key;
+        s.cache.cache_slot_latest_if_missing(address, slot);
+    }
+}
+
 impl StratusStorage {
     /// Creates a new storage with the specified temporary and permanent implementations.
     pub fn new(
@@ -497,15 +625,6 @@ impl StratusStorage {
         })
     }
 
-    fn _read_account_latest_cache(&self, address: Address) -> Option<Account> {
-        timed(|| self.cache.get_account_latest(address)).with(|m| {
-            if m.result.is_some() {
-                tracing::debug!(storage = %label::CACHE, %address, "account found in cache");
-                metrics::inc_storage_read_account(m.elapsed, label::CACHE, PointInTime::Mined);
-            }
-        })
-    }
-
     fn _read_account_temp(&self, address: Address, kind: ReadKind) -> Result<Option<Account>, StorageError> {
         tracing::debug!(storage = %label::TEMP, %address, "reading account");
         timed(|| self.temp.read_account(address, kind)).with(|m| {
@@ -518,66 +637,54 @@ impl StratusStorage {
         })
     }
 
-    fn _read_account_perm(&self, address: Address, mined_point: resolve::MinedPointInTime<'_>) -> Result<Account, StorageError> {
-        tracing::debug!(storage = %label::PERM, %address, "reading account");
-        let account = timed(|| self.perm.read_account(address, &mined_point)).with(|m| {
-            if m.result.as_ref().is_ok_and(|opt| opt.is_some()) {
-                metrics::inc_storage_read_account(m.elapsed, label::PERM, mined_point);
+    /// Generic read algorithm shared by [`read_account`] and [`read_slot`].
+    fn read<E: EntityRead>(&self, key: E::Key, target_point_in_time: PointInTime, kind: ReadKind) -> Result<E, StorageError> {
+        let (value, found_at) = 'query: {
+            match E::resolve(self, target_point_in_time, key, kind)? {
+                resolve_pending::Resolved::PendingCache(value) => break 'query (value, FoundAt::Cache),
+                resolve_pending::Resolved::Temp(value) => break 'query (value, FoundAt::Temp),
+                resolve_pending::Resolved::Miss(mined_point) => {
+                    let found_at = match &mined_point {
+                        MinedPointInTime::Latest(_, _) =>
+                        // Latest: try latest cache while guard is held, then fall through to perm.
+                        {
+                            if let Some(value) = E::read_latest_cache(self, key) {
+                                break 'query (value, FoundAt::Cache);
+                            }
+                            FoundAt::PermLatest
+                        }
+                        MinedPointInTime::Past(_, _) => FoundAt::PermHistorical,
+                    };
+                    break 'query (E::read_perm(self, key, mined_point)?, found_at);
+                }
             }
-            if let Err(ref e) = m.result {
-                tracing::error!(reason = ?e, "failed to read account from permanent storage");
+        };
+
+        // Cache non-historical reads according to the point-in-time and where the value came from.
+        match (target_point_in_time, found_at) {
+            // A pending read that hit perm (i.e. not in any cache/temp) is already mined, so cache in both.
+            (PointInTime::Pending, FoundAt::PermLatest) => {
+                E::cache_if_missing(self, key, value.clone());
+                E::cache_latest_if_missing(self, key, value.clone());
             }
-        })?;
-        Ok(match account {
-            Some(account) => {
-                tracing::debug!(storage = %label::PERM, %address, ?account, "account found in permanent storage");
-                account
+            // A pending read that hit temp was not found in the pending cache, so populate it.
+            (PointInTime::Pending, FoundAt::Temp) => {
+                E::cache_if_missing(self, key, value.clone());
             }
-            None => {
-                tracing::debug!(storage = %label::PERM, %address, "account not found, assuming default value");
-                Account::new_empty(address)
+            // A mined read that hit perm is the latest state, so populate the latest cache.
+            (PointInTime::Mined, FoundAt::PermLatest) => {
+                E::cache_latest_if_missing(self, key, value.clone());
             }
-        })
+            // Cache / Historical / (Mined, Temp): nothing to cache.
+            _ => {}
+        }
+        Ok(value)
     }
 
     pub fn read_account(&self, address: Address, point_in_time: PointInTime, kind: ReadKind) -> Result<Account, StorageError> {
         #[cfg(feature = "tracing")]
         let _span = tracing::debug_span!("storage::read_account", %address, %point_in_time).entered();
-
-        let (account, found_in_perm, is_historical) = 'query: {
-            match self.resolve_account(point_in_time, address, kind)? {
-                resolve::Resolved::PendingCache(account) => return Ok(account),
-                resolve::Resolved::Temp(account) => break 'query (account, false, false),
-                resolve::Resolved::Miss(mined_point) => {
-                    let is_historical = !mined_point.is_mined();
-                    if !is_historical {
-                        // Latest: try latest cache while guard is held, then fall through to perm.
-                        if let Some(account) = self._read_account_latest_cache(address) {
-                            return Ok(account);
-                        }
-                    }
-                    (self._read_account_perm(address, mined_point)?, true, is_historical)
-                }
-            }
-        };
-
-        if !is_historical {
-            match (point_in_time, found_in_perm) {
-                // Pending accounts found in the permanent storage (or not found in any storage) are always mined already
-                (PointInTime::Pending, true) => {
-                    self.cache.cache_account_if_missing(account.clone());
-                    self.cache.cache_account_latest_if_missing(address, account.clone());
-                }
-                (PointInTime::Pending, false) => {
-                    self.cache.cache_account_if_missing(account.clone());
-                }
-                (PointInTime::Mined, _) => {
-                    self.cache.cache_account_latest_if_missing(address, account.clone());
-                }
-                _ => {}
-            }
-        }
-        Ok(account)
+        self.read::<Account>(address, point_in_time, kind)
     }
 
     fn _read_slot_pending_cache(&self, address: Address, index: SlotIndex) -> Option<Slot> {
@@ -585,15 +692,6 @@ impl StratusStorage {
             if m.result.is_some() {
                 tracing::debug!(storage = %label::CACHE, %address, slot = ?m.result, "slot found in cache");
                 metrics::inc_storage_read_slot(m.elapsed, label::CACHE, PointInTime::Pending);
-            }
-        })
-    }
-
-    fn _read_slot_latest_cache(&self, address: Address, index: SlotIndex) -> Option<Slot> {
-        timed(|| self.cache.get_slot_latest(address, index)).with(|m| {
-            if m.result.is_some() {
-                tracing::debug!(storage = %label::CACHE, %address, slot = ?m.result, "slot found in cache");
-                metrics::inc_storage_read_slot(m.elapsed, label::CACHE, PointInTime::Mined);
             }
         })
     }
@@ -610,66 +708,10 @@ impl StratusStorage {
         })
     }
 
-    fn _read_slot_perm(&self, address: Address, index: SlotIndex, mined_point: resolve::MinedPointInTime<'_>) -> Result<Slot, StorageError> {
-        tracing::debug!(storage = %label::PERM, %address, %index, %mined_point, "reading slot");
-        let slot = timed(|| self.perm.read_slot(address, index, &mined_point)).with(|m| {
-            if m.result.as_ref().is_ok_and(|opt| opt.is_some()) {
-                metrics::inc_storage_read_slot(m.elapsed, label::PERM, mined_point);
-            }
-            if let Err(ref e) = m.result {
-                tracing::error!(reason = ?e, "failed to read slot from permanent storage");
-            }
-        })?;
-        Ok(match slot {
-            Some(slot) => {
-                tracing::debug!(storage = %label::PERM, %address, %index, ?slot, "slot found in permanent storage");
-                slot
-            }
-            None => {
-                tracing::debug!(storage = %label::PERM, %address, %index, "slot not found, assuming default value");
-                Slot::new_empty(index)
-            }
-        })
-    }
-
     pub fn read_slot(&self, address: Address, index: SlotIndex, point_in_time: PointInTime, kind: ReadKind) -> Result<Slot, StorageError> {
         #[cfg(feature = "tracing")]
         let _span = tracing::debug_span!("storage::read_slot", %address, %index, %point_in_time).entered();
-
-        let (slot, found_in_perm, is_historical) = 'query: {
-            match self.resolve_slot(point_in_time, address, index, kind)? {
-                resolve::Resolved::PendingCache(slot) => return Ok(slot),
-                resolve::Resolved::Temp(slot) => break 'query (slot, false, false),
-                resolve::Resolved::Miss(mined_point) => {
-                    let is_historical = !mined_point.is_mined();
-                    if !is_historical {
-                        // Latest: try latest cache while guard is held, then fall through to perm.
-                        if let Some(slot) = self._read_slot_latest_cache(address, index) {
-                            return Ok(slot);
-                        }
-                    }
-                    (self._read_slot_perm(address, index, mined_point)?, true, is_historical)
-                }
-            }
-        };
-
-        if !is_historical {
-            match (point_in_time, found_in_perm) {
-                // Pending slots found in the permanent storage (or not found in any storage) are always mined already
-                (PointInTime::Pending, true) => {
-                    self.cache.cache_slot_if_missing(address, slot);
-                    self.cache.cache_slot_latest_if_missing(address, slot);
-                }
-                (PointInTime::Pending, false) => {
-                    self.cache.cache_slot_if_missing(address, slot);
-                }
-                (PointInTime::Mined, _) => {
-                    self.cache.cache_slot_latest_if_missing(address, slot);
-                }
-                _ => {}
-            }
-        }
-        Ok(slot)
+        self.read::<Slot>((address, index), point_in_time, kind)
     }
 
     // -------------------------------------------------------------------------

--- a/src/eth/storage/stratus_storage.rs
+++ b/src/eth/storage/stratus_storage.rs
@@ -1,10 +1,5 @@
-use parking_lot::RwLockReadGuard;
 use tracing::Span;
 
-use super::InMemoryTemporaryStorage;
-use super::RocksPermanentStorage;
-use super::StorageCache;
-use super::permanent::rocks::types::BlockRocksdb;
 #[cfg(feature = "dev")]
 use crate::eth::genesis::GenesisConfig;
 use crate::eth::primitives::Account;
@@ -36,9 +31,14 @@ use crate::eth::primitives::TransactionStage;
 use crate::eth::primitives::Wei;
 #[cfg(feature = "dev")]
 use crate::eth::primitives::test_accounts;
+use crate::eth::storage::InMemoryTemporaryStorage;
 use crate::eth::storage::ReadKind;
+use crate::eth::storage::RocksPermanentStorage;
+use crate::eth::storage::StorageCache;
 use crate::eth::storage::TxCount;
 use crate::eth::storage::permanent::rocks::types::BlockChangesRocksdb;
+use crate::eth::storage::permanent::rocks::types::BlockRocksdb;
+use crate::eth::storage::resolve_pending;
 use crate::ext::not;
 use crate::infra::metrics;
 use crate::infra::metrics::timed;
@@ -58,7 +58,7 @@ pub struct StratusStorage {
     cache: StorageCache,
     pub perm: RocksPermanentStorage,
     // CONTRACT: Always acquire a lock when reading slots or accounts from latest (cache OR perm) and when saving a block
-    transient_state_lock: parking_lot::RwLock<()>,
+    pub(super) transient_state_lock: parking_lot::RwLock<()>,
     #[cfg(feature = "dev")]
     perm_config: crate::eth::storage::permanent::PermanentStorageConfig,
 }
@@ -70,245 +70,6 @@ impl AccountOriginalsReader for StratusStorage {
 }
 
 pub use resolve_pending::MinedPointInTime;
-
-/// Pending-state resolution
-mod resolve_pending {
-    use super::Account;
-    use super::BlockNumber;
-    use super::PointInTime;
-    use super::ReadKind;
-    use super::RwLockReadGuard;
-    use super::Slot;
-    use super::StorageError;
-    use super::StratusStorage;
-    use super::TxCount;
-    use crate::infra::metrics::MetricLabelValue;
-
-    /// Prevents construction of [`MinedPointInTime`] outside this module.
-    /// `Seal` is public (so the enum variants can be pattern-matched) but cannot be constructed
-    /// externally because its field type is private.
-    #[derive(Debug)]
-    pub struct Seal(SealPrivate);
-
-    #[derive(Debug)]
-    struct SealPrivate;
-
-    /// A [`PointInTime`] that has been resolved past the pending case.
-    ///
-    /// `Latest` carries an optional `transient_state_lock` read guard held across the latest read.
-    ///
-    /// The [`Seal`] field makes both variants impossible to construct outside this module,
-    /// while still allowing pattern matching externally.
-    #[derive(Debug, strum::Display)]
-    pub enum MinedPointInTime<'a> {
-        #[strum(to_string = "latest")]
-        Latest(Seal, Option<RwLockReadGuard<'a, ()>>),
-        #[strum(to_string = "past")]
-        Past(Seal, BlockNumber),
-    }
-
-    impl<'a> MinedPointInTime<'a> {
-        fn mined(guard: Option<RwLockReadGuard<'a, ()>>) -> Self {
-            Self::Latest(Seal(SealPrivate), guard)
-        }
-
-        fn mined_past(number: BlockNumber) -> Self {
-            Self::Past(Seal(SealPrivate), number)
-        }
-
-        /// Extracts the read guard if present, leaving `Mined(None)` in its place.
-        fn take_guard(&mut self) -> Option<RwLockReadGuard<'a, ()>> {
-            match self {
-                Self::Latest(_, guard) => guard.take(),
-                Self::Past(_, _) => None,
-            }
-        }
-    }
-
-    impl From<MinedPointInTime<'_>> for MetricLabelValue {
-        fn from(value: MinedPointInTime<'_>) -> Self {
-            Self::Some(value.to_string())
-        }
-    }
-
-    /// Unlocks the guard fairly when dropped.
-    impl<'a> Drop for MinedPointInTime<'a> {
-        fn drop(&mut self) {
-            if let Some(guard) = self.take_guard() {
-                RwLockReadGuard::unlock_fair(guard);
-            }
-        }
-    }
-
-    /// Outcome of resolving pending state for a read.
-    #[derive(Debug)]
-    pub(super) enum Resolved<'a, T> {
-        /// Found in the pending cache.
-        PendingCache(T),
-        /// Found in temporary storage.
-        Temp(T),
-        /// Nothing pending.
-        Miss(MinedPointInTime<'a>),
-    }
-
-    /// Pending-state resolution, generic over the entity being read.
-    pub(super) trait Resolve: super::EntityRead {
-        fn resolve(s: &StratusStorage, pit: PointInTime, key: Self::Key, kind: ReadKind) -> Result<Resolved<'_, Self>, StorageError> {
-            if pit == PointInTime::Pending {
-                if matches!(kind, ReadKind::Transaction)
-                    && let Some(value) = Self::read_pending_cache(s, key)
-                {
-                    return Ok(Resolved::PendingCache(value));
-                }
-                if let Some(value) = Self::read_temp(s, key, kind)? {
-                    return Ok(Resolved::Temp(value));
-                }
-            }
-            Ok(Resolved::Miss(s.resolve_mined_point(pit, kind)))
-        }
-    }
-
-    impl Resolve for Account {}
-
-    impl Resolve for Slot {}
-
-    impl StratusStorage {
-        /// Determines the mined point-in-time for a read.
-        fn resolve_mined_point(&self, pit: PointInTime, kind: ReadKind) -> MinedPointInTime<'_> {
-            if let PointInTime::MinedPast(number) = pit {
-                return MinedPointInTime::mined_past(number);
-            }
-            match kind {
-                ReadKind::Call((block_number, tx_count)) => {
-                    let guard = self.transient_state_lock.read();
-                    let mined = self.read_mined_block_number();
-                    if (block_number, tx_count) >= (mined, TxCount::Full) {
-                        MinedPointInTime::mined(Some(guard))
-                    } else {
-                        drop(guard);
-                        let target = match tx_count {
-                            TxCount::Partial(_) => block_number.prev().unwrap_or_default(),
-                            TxCount::Full => block_number,
-                        };
-                        MinedPointInTime::mined_past(target)
-                    }
-                }
-                ReadKind::Transaction | ReadKind::RPC => MinedPointInTime::mined(None),
-            }
-        }
-    }
-
-    #[cfg(test)]
-    mod tests {
-        use super::super::StratusStorage;
-        use super::Resolve;
-        use crate::eth::primitives::Address;
-        use crate::eth::primitives::BlockNumber;
-        use crate::eth::primitives::PointInTime;
-        use crate::eth::primitives::Slot;
-        use crate::eth::primitives::SlotIndex;
-        use crate::eth::storage::ReadKind;
-        use crate::eth::storage::TxCount;
-
-        #[test]
-        fn pending_partial_call_latest_becomes_stale_once_block_is_mined() {
-            let storage = StratusStorage::new_test().expect("failed to build test storage");
-
-            let address = Address::ZERO;
-            let index = SlotIndex::ZERO;
-
-            // Pending call: block_number is the pending block (mined + 1 = 6), pinned to tx 0.
-            let mined_at_start = 5u64;
-            let pending_block_number = BlockNumber::from(mined_at_start + 1);
-            storage.set_mined_block_number(BlockNumber::from(mined_at_start));
-
-            let kind = ReadKind::Call((pending_block_number, TxCount::Partial(0)));
-
-            // At call start: block 6 is still pending (mined=5). Latest (block 5) is a safe base.
-            // resolve_slot should return Miss(Mined(Some(guard))).
-            let resolved = Slot::resolve(&storage, PointInTime::Pending, (address, index), kind).expect("resolve_slot");
-            match resolved {
-                super::Resolved::Miss(mut point) => {
-                    assert!(
-                        matches!(point, super::MinedPointInTime::Latest(_, _)),
-                        "should read latest mined base while block is still pending"
-                    );
-                    assert!(point.take_guard().is_some(), "guard should be held for valid latest read");
-                }
-                other => panic!("expected Miss, got {other:?}"),
-            }
-
-            // The pending block is mined mid-call, advancing the mined tip to 6.
-            storage.set_mined_block_number(pending_block_number);
-
-            // The call is now stale: reading "latest" would observe block 6's aggregate state,
-            // not the tx-0 base. resolve_slot should downgrade to MinedPast(5) = b.prev() with no guard.
-            let resolved = Slot::resolve(&storage, PointInTime::Pending, (address, index), kind).expect("resolve_slot");
-            match resolved {
-                super::Resolved::Miss(mut point) => {
-                    assert!(!matches!(point, super::MinedPointInTime::Latest(_, _)), "stale call should not read latest");
-                    match &point {
-                        super::MinedPointInTime::Past(_, number) => {
-                            assert_eq!(
-                                *number,
-                                BlockNumber::from(mined_at_start),
-                                "stale Partial call should downgrade to MinedPast(b.prev())"
-                            );
-                        }
-                        other => panic!("expected Past, got {other:?}"),
-                    }
-                    assert!(point.take_guard().is_none(), "no guard for historical read");
-                }
-                other => panic!("expected Miss, got {other:?}"),
-            }
-        }
-
-        #[test]
-        fn mined_full_call_downgrades_to_minedpast_block_not_prev() {
-            let storage = StratusStorage::new_test().expect("failed to build test storage");
-
-            let address = Address::ZERO;
-            let index = SlotIndex::ZERO;
-
-            // Mined Full call: block_number = 5, mined = 5 → valid (b >= mined).
-            let call_block = BlockNumber::from(5u64);
-            storage.set_mined_block_number(call_block);
-
-            let kind = ReadKind::Call((call_block, TxCount::Full));
-
-            let resolved = Slot::resolve(&storage, PointInTime::Mined, (address, index), kind).expect("resolve_slot");
-            match resolved {
-                super::Resolved::Miss(mut point) => {
-                    assert!(
-                        matches!(point, super::MinedPointInTime::Latest(_, _)),
-                        "Full call should read latest while block is the mined tip"
-                    );
-                    assert!(point.take_guard().is_some(), "guard should be held for valid latest read");
-                }
-                other => panic!("expected Miss, got {other:?}"),
-            }
-
-            // A newer block is mined mid-call, advancing the mined tip to 6.
-            storage.set_mined_block_number(BlockNumber::from(6u64));
-
-            // Stale: b=5 < mined=6. Full → MinedPast(5), NOT MinedPast(4).
-            let resolved = Slot::resolve(&storage, PointInTime::Mined, (address, index), kind).expect("resolve_slot");
-            match resolved {
-                super::Resolved::Miss(mut point) => {
-                    assert!(!matches!(point, super::MinedPointInTime::Latest(_, _)), "stale call should not read latest");
-                    match &point {
-                        super::MinedPointInTime::Past(_, number) => {
-                            assert_eq!(*number, call_block, "stale Full call should downgrade to MinedPast(block_number), not prev()");
-                        }
-                        other => panic!("expected Past, got {other:?}"),
-                    }
-                    assert!(point.take_guard().is_none(), "no guard for historical read");
-                }
-                other => panic!("expected Miss, got {other:?}"),
-            }
-        }
-    }
-}
 
 /// Where a completed read obtained its value. Drives the post-read caching decision.
 #[derive(Debug)]
@@ -324,7 +85,7 @@ enum FoundAt {
 }
 
 /// Abstraction over address-keyed ([`Account`]) and slot-keyed ([`Slot`]) reads
-trait EntityRead: Sized + Clone {
+pub(super) trait EntityRead: Sized + Clone {
     type Key: Copy;
 
     /// Reads the pending (current block) value from the cache, if present.
@@ -516,7 +277,7 @@ impl StratusStorage {
     pub fn new_test() -> Result<Self, StorageError> {
         use tempfile::tempdir;
 
-        use super::cache::CacheConfig;
+        use crate::eth::storage::cache::CacheConfig;
 
         let temp = InMemoryTemporaryStorage::new(0.into());
 

--- a/src/eth/storage/stratus_storage.rs
+++ b/src/eth/storage/stratus_storage.rs
@@ -138,12 +138,13 @@ impl EntityRead for Account {
     fn read_perm(s: &StratusStorage, address: Address, point: MinedPointInTime<'_>) -> Result<Self, StorageError> {
         tracing::debug!(storage = %label::PERM, %address, "reading account");
         let account = timed(|| s.perm.read_account(address, &point)).with(|m| {
-            if m.result.as_ref().is_ok_and(|opt| opt.is_some()) {
-                metrics::inc_storage_read_account(m.elapsed, label::PERM, point);
-            }
-            if let Err(ref e) = m.result {
-                tracing::error!(reason = ?e, "failed to read account from permanent storage");
-            }
+            m.result
+                .as_ref()
+                .inspect(|opt| {
+                    opt.is_some().then(|| metrics::inc_storage_read_account(m.elapsed, label::PERM, point));
+                })
+                .inspect_err(|err| tracing::error!(reason = ?err, "failed to read account from permanent storage"))
+                .ok();
         })?;
         Ok(match account {
             Some(account) => {
@@ -206,12 +207,13 @@ impl EntityRead for Slot {
         let (address, index) = key;
         tracing::debug!(storage = %label::PERM, %address, %index, %point, "reading slot");
         let slot = timed(|| s.perm.read_slot(address, index, &point)).with(|m| {
-            if m.result.as_ref().is_ok_and(|opt| opt.is_some()) {
-                metrics::inc_storage_read_slot(m.elapsed, label::PERM, point);
-            }
-            if let Err(ref e) = m.result {
-                tracing::error!(reason = ?e, "failed to read slot from permanent storage");
-            }
+            m.result
+                .as_ref()
+                .inspect(|opt| {
+                    opt.is_some().then(|| metrics::inc_storage_read_account(m.elapsed, label::PERM, point));
+                })
+                .inspect_err(|err| tracing::error!(reason = ?err, "failed to read account from permanent storage"))
+                .ok();
         })?;
         Ok(match slot {
             Some(slot) => {

--- a/src/eth/storage/stratus_storage.rs
+++ b/src/eth/storage/stratus_storage.rs
@@ -74,17 +74,14 @@ pub use resolve_pending::MinedPointInTime;
 /// Pending-state resolution
 mod resolve_pending {
     use super::Account;
-    use super::Address;
     use super::BlockNumber;
     use super::PointInTime;
     use super::ReadKind;
     use super::RwLockReadGuard;
     use super::Slot;
-    use super::SlotIndex;
     use super::StorageError;
     use super::StratusStorage;
     use super::TxCount;
-    use super::label;
     use crate::infra::metrics::MetricLabelValue;
 
     /// Prevents construction of [`MinedPointInTime`] outside this module.
@@ -117,11 +114,6 @@ mod resolve_pending {
 
         fn mined_past(number: BlockNumber) -> Self {
             Self::Past(Seal(SealPrivate), number)
-        }
-
-        /// Returns `true` if this is the `Mined` (latest) point.
-        pub fn is_mined(&self) -> bool {
-            matches!(self, Self::Latest(_, _))
         }
 
         /// Extracts the read guard if present, leaving `Mined(None)` in its place.
@@ -159,61 +151,33 @@ mod resolve_pending {
         Miss(MinedPointInTime<'a>),
     }
 
+    /// Pending-state resolution, generic over the entity being read.
+    pub(super) trait Resolve: super::EntityRead {
+        fn resolve(s: &StratusStorage, pit: PointInTime, key: Self::Key, kind: ReadKind) -> Result<Resolved<'_, Self>, StorageError> {
+            if pit == PointInTime::Pending {
+                if matches!(kind, ReadKind::Transaction)
+                    && let Some(value) = Self::read_pending_cache(s, key)
+                {
+                    return Ok(Resolved::PendingCache(value));
+                }
+                if let Some(value) = Self::read_temp(s, key, kind)? {
+                    return Ok(Resolved::Temp(value));
+                }
+            }
+            Ok(Resolved::Miss(s.resolve_mined_point(pit, kind)))
+        }
+    }
+
+    impl Resolve for Account {}
+
+    impl Resolve for Slot {}
+
     impl StratusStorage {
-        /// Resolves pending state for a slot read.
-        /// Returns [`Resolved::Miss`] if no valid pending slot was found.
-        pub(super) fn resolve_slot(
-            &self,
-            point_in_time: PointInTime,
-            address: Address,
-            index: SlotIndex,
-            kind: ReadKind,
-        ) -> Result<Resolved<'_, Slot>, StorageError> {
-            // MinedPast is historical and immutable
-            if let PointInTime::MinedPast(number) = point_in_time {
-                return Ok(Resolved::Miss(MinedPointInTime::mined_past(number)));
+        /// Determines the mined point-in-time for a read.
+        fn resolve_mined_point(&self, pit: PointInTime, kind: ReadKind) -> MinedPointInTime<'_> {
+            if let PointInTime::MinedPast(number) = pit {
+                return MinedPointInTime::mined_past(number);
             }
-
-            if point_in_time == PointInTime::Pending {
-                if matches!(kind, ReadKind::Transaction)
-                    && let Some(slot) = self._read_slot_pending_cache(address, index)
-                {
-                    return Ok(Resolved::PendingCache(slot));
-                }
-                if let Some(slot) = self._read_slot_temp(address, index, kind)? {
-                    tracing::debug!(storage = %label::TEMP, %address, %index, value = %slot.value, "slot found in temporary storage");
-                    return Ok(Resolved::Temp(slot));
-                }
-            }
-
-            Ok(Resolved::Miss(self.resolve_mined_staleness(kind)))
-        }
-
-        /// Resolves pending state for an account read.
-        /// Returns [`Resolved::Miss`] if no valid pending account was found.
-        pub(super) fn resolve_account(&self, point_in_time: PointInTime, address: Address, kind: ReadKind) -> Result<Resolved<'_, Account>, StorageError> {
-            if let PointInTime::MinedPast(number) = point_in_time {
-                return Ok(Resolved::Miss(MinedPointInTime::mined_past(number)));
-            }
-
-            if point_in_time == PointInTime::Pending {
-                if matches!(kind, ReadKind::Transaction)
-                    && let Some(account) = self._read_account_pending_cache(address)
-                {
-                    return Ok(Resolved::PendingCache(account));
-                }
-                if let Some(account) = self._read_account_temp(address, kind)? {
-                    tracing::debug!(storage = %label::TEMP, %address, ?account, "account found in temporary storage");
-                    return Ok(Resolved::Temp(account));
-                }
-            }
-            Ok(Resolved::Miss(self.resolve_mined_staleness(kind)))
-        }
-
-        /// Determines the mined point-in-time and whether a read guard is needed for a `Call` kind.
-        /// The mined state `(<latest block>, TxCount::Full)` is stale for a call if it is newer (gt)
-        /// than the state the call is running on (`(BlockNumber, TxCount)`).
-        fn resolve_mined_staleness(&self, kind: ReadKind) -> MinedPointInTime<'_> {
             match kind {
                 ReadKind::Call((block_number, tx_count)) => {
                     let guard = self.transient_state_lock.read();
@@ -237,9 +201,11 @@ mod resolve_pending {
     #[cfg(test)]
     mod tests {
         use super::super::StratusStorage;
+        use super::Resolve;
         use crate::eth::primitives::Address;
         use crate::eth::primitives::BlockNumber;
         use crate::eth::primitives::PointInTime;
+        use crate::eth::primitives::Slot;
         use crate::eth::primitives::SlotIndex;
         use crate::eth::storage::ReadKind;
         use crate::eth::storage::TxCount;
@@ -260,10 +226,13 @@ mod resolve_pending {
 
             // At call start: block 6 is still pending (mined=5). Latest (block 5) is a safe base.
             // resolve_slot should return Miss(Mined(Some(guard))).
-            let resolved = storage.resolve_slot(PointInTime::Pending, address, index, kind).expect("resolve_slot");
+            let resolved = Slot::resolve(&storage, PointInTime::Pending, (address, index), kind).expect("resolve_slot");
             match resolved {
                 super::Resolved::Miss(mut point) => {
-                    assert!(point.is_mined(), "should read latest mined base while block is still pending");
+                    assert!(
+                        matches!(point, super::MinedPointInTime::Latest(_, _)),
+                        "should read latest mined base while block is still pending"
+                    );
                     assert!(point.take_guard().is_some(), "guard should be held for valid latest read");
                 }
                 other => panic!("expected Miss, got {other:?}"),
@@ -274,10 +243,10 @@ mod resolve_pending {
 
             // The call is now stale: reading "latest" would observe block 6's aggregate state,
             // not the tx-0 base. resolve_slot should downgrade to MinedPast(5) = b.prev() with no guard.
-            let resolved = storage.resolve_slot(PointInTime::Pending, address, index, kind).expect("resolve_slot");
+            let resolved = Slot::resolve(&storage, PointInTime::Pending, (address, index), kind).expect("resolve_slot");
             match resolved {
                 super::Resolved::Miss(mut point) => {
-                    assert!(!point.is_mined(), "stale call should not read latest");
+                    assert!(!matches!(point, super::MinedPointInTime::Latest(_, _)), "stale call should not read latest");
                     match &point {
                         super::MinedPointInTime::Past(_, number) => {
                             assert_eq!(
@@ -307,10 +276,13 @@ mod resolve_pending {
 
             let kind = ReadKind::Call((call_block, TxCount::Full));
 
-            let resolved = storage.resolve_slot(PointInTime::Mined, address, index, kind).expect("resolve_slot");
+            let resolved = Slot::resolve(&storage, PointInTime::Mined, (address, index), kind).expect("resolve_slot");
             match resolved {
                 super::Resolved::Miss(mut point) => {
-                    assert!(point.is_mined(), "Full call should read latest while block is the mined tip");
+                    assert!(
+                        matches!(point, super::MinedPointInTime::Latest(_, _)),
+                        "Full call should read latest while block is the mined tip"
+                    );
                     assert!(point.take_guard().is_some(), "guard should be held for valid latest read");
                 }
                 other => panic!("expected Miss, got {other:?}"),
@@ -320,10 +292,10 @@ mod resolve_pending {
             storage.set_mined_block_number(BlockNumber::from(6u64));
 
             // Stale: b=5 < mined=6. Full → MinedPast(5), NOT MinedPast(4).
-            let resolved = storage.resolve_slot(PointInTime::Mined, address, index, kind).expect("resolve_slot");
+            let resolved = Slot::resolve(&storage, PointInTime::Mined, (address, index), kind).expect("resolve_slot");
             match resolved {
                 super::Resolved::Miss(mut point) => {
-                    assert!(!point.is_mined(), "stale call should not read latest");
+                    assert!(!matches!(point, super::MinedPointInTime::Latest(_, _)), "stale call should not read latest");
                     match &point {
                         super::MinedPointInTime::Past(_, number) => {
                             assert_eq!(*number, call_block, "stale Full call should downgrade to MinedPast(block_number), not prev()");
@@ -355,10 +327,12 @@ enum FoundAt {
 trait EntityRead: Sized + Clone {
     type Key: Copy;
 
-    /// Resolves pending state for `key`, returning where the value came from (or a mined miss).
-    fn resolve(s: &StratusStorage, pit: PointInTime, key: Self::Key, kind: ReadKind) -> Result<resolve_pending::Resolved<'_, Self>, StorageError>;
+    /// Reads the pending (current block) value from the cache, if present.
+    fn read_pending_cache(s: &StratusStorage, key: Self::Key) -> Option<Self>;
     /// Reads the latest (mined tip) value from the cache, if present.
     fn read_latest_cache(s: &StratusStorage, key: Self::Key) -> Option<Self>;
+    /// Reads from temporary (pending) storage.
+    fn read_temp(s: &StratusStorage, key: Self::Key, kind: ReadKind) -> Result<Option<Self>, StorageError>;
     /// Reads from permanent storage at the resolved mined point.
     fn read_perm(s: &StratusStorage, key: Self::Key, point: MinedPointInTime<'_>) -> Result<Self, StorageError>;
     /// Caches the value as a pending entry, if not already cached.
@@ -370,8 +344,25 @@ trait EntityRead: Sized + Clone {
 impl EntityRead for Account {
     type Key = Address;
 
-    fn resolve(s: &StratusStorage, pit: PointInTime, address: Address, kind: ReadKind) -> Result<resolve_pending::Resolved<'_, Self>, StorageError> {
-        s.resolve_account(pit, address, kind)
+    fn read_pending_cache(s: &StratusStorage, address: Address) -> Option<Self> {
+        timed(|| s.cache.get_account(address)).with(|m| {
+            if m.result.is_some() {
+                tracing::debug!(storage = %label::CACHE, %address, "account found in cache");
+                metrics::inc_storage_read_account(m.elapsed, label::CACHE, PointInTime::Pending);
+            }
+        })
+    }
+
+    fn read_temp(s: &StratusStorage, address: Address, kind: ReadKind) -> Result<Option<Self>, StorageError> {
+        tracing::debug!(storage = %label::TEMP, %address, "reading account");
+        timed(|| s.temp.read_account(address, kind)).with(|m| {
+            if m.result.as_ref().is_ok_and(|opt| opt.is_some()) {
+                metrics::inc_storage_read_account(m.elapsed, label::TEMP, PointInTime::Pending);
+            }
+            if let Err(ref e) = m.result {
+                tracing::error!(reason = ?e, "failed to read account from temporary storage");
+            }
+        })
     }
 
     fn read_latest_cache(s: &StratusStorage, address: Address) -> Option<Self> {
@@ -417,9 +408,27 @@ impl EntityRead for Account {
 impl EntityRead for Slot {
     type Key = (Address, SlotIndex);
 
-    fn resolve(s: &StratusStorage, pit: PointInTime, key: (Address, SlotIndex), kind: ReadKind) -> Result<resolve_pending::Resolved<'_, Self>, StorageError> {
+    fn read_pending_cache(s: &StratusStorage, key: (Address, SlotIndex)) -> Option<Self> {
         let (address, index) = key;
-        s.resolve_slot(pit, address, index, kind)
+        timed(|| s.cache.get_slot(address, index)).with(|m| {
+            if m.result.is_some() {
+                tracing::debug!(storage = %label::CACHE, %address, slot = ?m.result, "slot found in cache");
+                metrics::inc_storage_read_slot(m.elapsed, label::CACHE, PointInTime::Pending);
+            }
+        })
+    }
+
+    fn read_temp(s: &StratusStorage, key: (Address, SlotIndex), kind: ReadKind) -> Result<Option<Self>, StorageError> {
+        let (address, index) = key;
+        tracing::debug!(storage = %label::TEMP, %address, %index, "reading slot");
+        timed(|| s.temp.read_slot(address, index, kind)).with(|m| {
+            if m.result.as_ref().is_ok_and(|opt| opt.is_some()) {
+                metrics::inc_storage_read_slot(m.elapsed, label::TEMP, PointInTime::Pending);
+            }
+            if let Err(ref e) = m.result {
+                tracing::error!(reason = ?e, "failed to read slot from temporary storage");
+            }
+        })
     }
 
     fn read_latest_cache(s: &StratusStorage, key: (Address, SlotIndex)) -> Option<Self> {
@@ -616,29 +625,8 @@ impl StratusStorage {
         })
     }
 
-    fn _read_account_pending_cache(&self, address: Address) -> Option<Account> {
-        timed(|| self.cache.get_account(address)).with(|m| {
-            if m.result.is_some() {
-                tracing::debug!(storage = %label::CACHE, %address, "account found in cache");
-                metrics::inc_storage_read_account(m.elapsed, label::CACHE, PointInTime::Pending);
-            }
-        })
-    }
-
-    fn _read_account_temp(&self, address: Address, kind: ReadKind) -> Result<Option<Account>, StorageError> {
-        tracing::debug!(storage = %label::TEMP, %address, "reading account");
-        timed(|| self.temp.read_account(address, kind)).with(|m| {
-            if m.result.as_ref().is_ok_and(|opt| opt.is_some()) {
-                metrics::inc_storage_read_account(m.elapsed, label::TEMP, PointInTime::Pending);
-            }
-            if let Err(ref e) = m.result {
-                tracing::error!(reason = ?e, "failed to read account from temporary storage");
-            }
-        })
-    }
-
     /// Generic read algorithm shared by [`read_account`] and [`read_slot`].
-    fn read<E: EntityRead>(&self, key: E::Key, target_point_in_time: PointInTime, kind: ReadKind) -> Result<E, StorageError> {
+    fn read<E: resolve_pending::Resolve>(&self, key: E::Key, target_point_in_time: PointInTime, kind: ReadKind) -> Result<E, StorageError> {
         let (value, found_at) = 'query: {
             match E::resolve(self, target_point_in_time, key, kind)? {
                 resolve_pending::Resolved::PendingCache(value) => break 'query (value, FoundAt::Cache),
@@ -685,27 +673,6 @@ impl StratusStorage {
         #[cfg(feature = "tracing")]
         let _span = tracing::debug_span!("storage::read_account", %address, %point_in_time).entered();
         self.read::<Account>(address, point_in_time, kind)
-    }
-
-    fn _read_slot_pending_cache(&self, address: Address, index: SlotIndex) -> Option<Slot> {
-        timed(|| self.cache.get_slot(address, index)).with(|m| {
-            if m.result.is_some() {
-                tracing::debug!(storage = %label::CACHE, %address, slot = ?m.result, "slot found in cache");
-                metrics::inc_storage_read_slot(m.elapsed, label::CACHE, PointInTime::Pending);
-            }
-        })
-    }
-
-    fn _read_slot_temp(&self, address: Address, index: SlotIndex, kind: ReadKind) -> Result<Option<Slot>, StorageError> {
-        tracing::debug!(storage = %label::TEMP, %address, %index, "reading slot");
-        timed(|| self.temp.read_slot(address, index, kind)).with(|m| {
-            if m.result.as_ref().is_ok_and(|opt| opt.is_some()) {
-                metrics::inc_storage_read_slot(m.elapsed, label::TEMP, PointInTime::Pending);
-            }
-            if let Err(ref e) = m.result {
-                tracing::error!(reason = ?e, "failed to read slot from temporary storage");
-            }
-        })
     }
 
     pub fn read_slot(&self, address: Address, index: SlotIndex, point_in_time: PointInTime, kind: ReadKind) -> Result<Slot, StorageError> {

--- a/src/eth/storage/stratus_storage.rs
+++ b/src/eth/storage/stratus_storage.rs
@@ -210,9 +210,9 @@ impl EntityRead for Slot {
             m.result
                 .as_ref()
                 .inspect(|opt| {
-                    opt.is_some().then(|| metrics::inc_storage_read_account(m.elapsed, label::PERM, point));
+                    opt.is_some().then(|| metrics::inc_storage_read_slot(m.elapsed, label::PERM, point));
                 })
-                .inspect_err(|err| tracing::error!(reason = ?err, "failed to read account from permanent storage"))
+                .inspect_err(|err| tracing::error!(reason = ?err, "failed to read slot from permanent storage"))
                 .ok();
         })?;
         Ok(match slot {


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Extract generic `read` method for accounts and slots

- Define `EntityRead` trait and `FoundAt` enum

- Implement unified resolution and caching logic

- Rename `resolve` module to `resolve_pending`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["StratusStorage.read<E>"] --> B["EntityRead.resolve"]
  B -->|PendingCache| C["return value"]
  B -->|Temp| C
  B -->|Miss| D["match MinedPointInTime"]
  D -->|Latest| E["EntityRead.read_latest_cache"]
  E -->|Some| C
  E -->|None| F["EntityRead.read_perm"]
  D -->|Past| F
  F --> C
  C --> G["decide caches"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>stratus_storage.rs</strong><dd><code>Add generic EntityRead refactor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/stratus_storage.rs

<ul><li>Renamed <code>resolve</code> module to <code>resolve_pending</code><br> <li> Introduced <code>FoundAt</code> enum for read origin<br> <li> Added <code>EntityRead</code> trait and implementations for <code>Account</code> and <code>Slot</code><br> <li> Refactored <code>read_account</code> and <code>read_slot</code> to use generic <code>read</code> method</ul>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2554/files#diff-3b2e36e47959decdfe26b2c4fab90b41f9242bfdad29cc43b2377ee851f4f40a">+170/-128</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

