### PR TITLE
update rust to 1.97.1

### DIFF
--- a/.github/workflows/_setup-e2e.yml
+++ b/.github/workflows/_setup-e2e.yml
@@ -38,9 +38,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-        with:
-          toolchain: 1.88
+        run: rustup show
       - name: Rust Cache - Restore shared key
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -58,9 +58,7 @@ jobs:
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
-        with:
-          toolchain: 1.88
+        run: rustup show
 
       - name: Install libsasl2-dev libssl-dev
         run: sudo apt-get update && sudo apt install -y build-essential pkg-config libssl-dev libsasl2-dev

--- a/.github/workflows/build-debug-cache.yml
+++ b/.github/workflows/build-debug-cache.yml
@@ -46,9 +46,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
-        with:
-          toolchain: 1.88
+        run: rustup show
 
       - name: Install libsasl2-dev libssl-dev
         run: sudo apt-get update && sudo apt install -y build-essential pkg-config libssl-dev libsasl2-dev

--- a/.github/workflows/build-pgo-optimized.yml
+++ b/.github/workflows/build-pgo-optimized.yml
@@ -47,7 +47,7 @@ jobs:
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Set up Rust
-        run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.88
+        run: rustup show
 
       - name: Install libsasl2-dev libssl-dev
         run: sudo apt-get update && sudo apt install -y build-essential pkg-config libssl-dev libsasl2-dev

--- a/.github/workflows/build-pgo.yml
+++ b/.github/workflows/build-pgo.yml
@@ -47,9 +47,7 @@ jobs:
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
-        with:
-          toolchain: 1.88
+        run: rustup show
 
       - name: Install libsasl2-dev libssl-dev
         run: sudo apt-get update && sudo apt install -y build-essential pkg-config libssl-dev libsasl2-dev

--- a/.github/workflows/cargo-vet.yml
+++ b/.github/workflows/cargo-vet.yml
@@ -36,7 +36,7 @@ jobs:
       uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
     - name: Set up Rust
-      run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.88
+      run: rustup show
 
     - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:

--- a/.github/workflows/check-features.yml
+++ b/.github/workflows/check-features.yml
@@ -45,9 +45,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-        with:
-          toolchain: 1.88
+        run: rustup show
 
       - name: Rust Cache - Restore shared key
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0

--- a/.github/workflows/check-unused-deps.yml
+++ b/.github/workflows/check-unused-deps.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Set up Rust Nightly
         uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2 # nightly
         with:
-          toolchain: nightly-2025-05-22
+          toolchain: nightly-2026-05-08
           components: rustfmt, clippy
 
       - name: Rust Cache
@@ -61,4 +61,4 @@ jobs:
         uses: extractions/setup-just@dd310ad5a97d8e7b41793f8ef055398d51ad4de6 # v2
 
       - name: Check for unused dependencies
-        run: just check-unused-deps -2025-05-22
+        run: just check-unused-deps -2026-05-08

--- a/.github/workflows/comment-tag-report.yml
+++ b/.github/workflows/comment-tag-report.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Rust
-        run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.88
+        run: rustup show
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@97ecb7b512899eb71ab1bf2310a624c6f1589ac6 # v1

--- a/.github/workflows/dependabot-auto-vet.yml
+++ b/.github/workflows/dependabot-auto-vet.yml
@@ -18,7 +18,6 @@ jobs:
       pull-requests: write
 
     env:
-      RUST_TOOLCHAIN: "1.89"
       CARGO_VET_VERSION: "0.10.0"
       CODEX_MODEL: "gpt-5-codex"
       CRITERIA: "safe-to-deploy"
@@ -40,9 +39,7 @@ jobs:
       - name: Set up Rust
         run: |
           set -euo pipefail
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain "${RUST_TOOLCHAIN}"
-          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-          source "$HOME/.cargo/env"
+          rustup show
           rustc --version
           cargo --version
 

--- a/.github/workflows/doc-test.yml
+++ b/.github/workflows/doc-test.yml
@@ -44,9 +44,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-        with:
-          toolchain: 1.88
+        run: rustup show
 
       - name: Rust Cache - Restore shared key
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0

--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Set up Rust Nightly and Rust Docs
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain nightly-2025-05-22
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain nightly-2026-05-08
           rustup component add rust-docs
 
       - name: Rust Cache - Restore shared key
@@ -56,7 +56,7 @@ jobs:
 
       - name: Generate docs
         run: |
-          just doc -2025-05-22
+          just doc -2026-05-08
           echo "<meta http-equiv='refresh' content='0; URL=./stratus/'>" >> target/doc/index.html
           chmod -c -R +rX target/doc/
 

--- a/.github/workflows/e2e-contracts-rocks.yml
+++ b/.github/workflows/e2e-contracts-rocks.yml
@@ -58,9 +58,7 @@ jobs:
           echo "key=$CACHE_KEY" >> $GITHUB_OUTPUT
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-        with:
-          toolchain: 1.88
+        run: rustup show
 
       - name: Rust Cache - Restore workflow cache
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
@@ -142,9 +140,7 @@ jobs:
         run: sudo apt-get update && sudo apt install -y build-essential pkg-config libssl-dev libsasl2-dev
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-        with:
-          toolchain: 1.88
+        run: rustup show
 
       - name: Rust Restore Cache
         id: cache-cargo

--- a/.github/workflows/e2e-leader-follower.yml
+++ b/.github/workflows/e2e-leader-follower.yml
@@ -56,9 +56,7 @@ jobs:
           echo "CACHE_KEY=$CACHE_KEY" >> $GITHUB_ENV
           echo "key=$CACHE_KEY" >> $GITHUB_OUTPUT
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-        with:
-          toolchain: 1.88
+        run: rustup show
       - name: Rust Cache - Restore workflow cache
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
@@ -104,9 +102,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-        with:
-          toolchain: 1.88
+        run: rustup show
       - name: Rust Restore Cache
         id: cache-cargo
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0

--- a/.github/workflows/lint-check.yml
+++ b/.github/workflows/lint-check.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Set up Rust Nightly
         uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2 # nightly
         with:
-          toolchain: nightly-2025-05-22
+          toolchain: nightly-2026-05-08
           components: rustfmt, clippy
 
       - name: Rust Cache
@@ -71,7 +71,7 @@ jobs:
         uses: extractions/setup-just@dd310ad5a97d8e7b41793f8ef055398d51ad4de6 # v2
 
       - name: Just lint-check
-        run: just lint-check -2025-05-22
+        run: just lint-check -2026-05-08
 
   e2e_lint:
     name: E2E Lint

--- a/.github/workflows/outdated.yml
+++ b/.github/workflows/outdated.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Rust
-        run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.88
+        run: rustup show
 
       - name: Set up Just
         uses: extractions/setup-just@dd310ad5a97d8e7b41793f8ef055398d51ad4de6 # v2

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -58,9 +58,7 @@ jobs:
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-        with:
-          toolchain: 1.88
+        run: rustup show
 
       - name: Rust Cache - Restore shared key
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     hooks:
       - id: just-lint
         name: just lint-check
-        entry: just lint-check -2025-05-22
+        entry: just lint-check
         language: system
         types: [rust]
         pass_filenames: false

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.88"
+channel = "1.97"
 targets = []
 profile = "default"


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Bump Rust stable channel to `1.97`

- Update nightly toolchain date to `nightly-2026-05-08`

- Adjust Just command date flags

- Simplify pre-commit just-lint entry


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>check-unused-deps.yml</strong><dd><code>Update nightly and Just deps check</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/check-unused-deps.yml

<ul><li>Updated Rust nightly date to nightly-2026-05-08<br> <li> Updated Just check-unused-deps date flag</ul>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2560/files#diff-7e1c0e8c41e58ea1a2f741dc5d5877f1c0698ea7b65f6be3047a31b421aca97e">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>docs-release.yml</strong><dd><code>Update docs workflow nightly date</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/docs-release.yml

<ul><li>Updated rustup default-toolchain to nightly-2026-05-08<br> <li> Updated Just doc command date flag</ul>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2560/files#diff-b6f2546d438fa8cf000fdf5fb9409857d1cd8f24a70fab05725d3501a7a4c753">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>lint-check.yml</strong><dd><code>Update lint workflow nightly date</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/lint-check.yml

<ul><li>Updated Rust nightly date to nightly-2026-05-08<br> <li> Updated Just lint-check date flag</ul>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2560/files#diff-dda267615bb53af994fa659ec8de11a5c4855ee18b1922370924f65759d8cae1">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>.pre-commit-config.yaml</strong><dd><code>Simplify pre-commit just-lint entry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.pre-commit-config.yaml

- Removed date argument from just lint-check entry


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2560/files#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rust-toolchain.toml</strong><dd><code>Bump Rust stable channel version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rust-toolchain.toml

- Bumped Rust stable channel version to 1.97


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2560/files#diff-2b1bde2cf3a858b7bf7424cb8bcbf01f35b94dc80b925d9432cbab3319ca9b4e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

