### PR TITLE
feat: stop_at_block importer config

### DIFF
--- a/src/eth/follower/importer/importer_config.rs
+++ b/src/eth/follower/importer/importer_config.rs
@@ -12,6 +12,7 @@ use crate::eth::follower::importer::ImporterMode;
 use crate::eth::follower::importer::importer_supervisor::ImporterConsensus;
 use crate::eth::follower::importer::importer_supervisor::start_importer;
 use crate::eth::miner::Miner;
+use crate::eth::primitives::BlockNumber;
 use crate::eth::primitives::ConsensusError;
 use crate::eth::primitives::ImporterError;
 use crate::eth::primitives::StateError;
@@ -53,6 +54,10 @@ pub struct ImporterConfig {
     /// Enable replication of block changes
     #[arg(long = "enable-block-changes-replication", env = "ENABLE_BLOCK_CHANGES_REPLICATION", default_value = "false")]
     pub enable_block_changes_replication: bool,
+
+    /// Specify the block to stop importing. (useful for validating a follower db against a fake leader)
+    #[arg(long = "stop-at-block", env = "STOP_AT_BLOCK")]
+    pub stop_at_block: Option<BlockNumber>,
 }
 
 impl ImporterConfig {
@@ -109,7 +114,16 @@ impl ImporterConfig {
 
         spawn(
             TASK_NAME,
-            start_importer(importer_mode, storage, executor, miner, chain, kafka_connector, self.sync_interval),
+            start_importer(
+                importer_mode,
+                storage,
+                executor,
+                miner,
+                chain,
+                kafka_connector,
+                self.sync_interval,
+                self.stop_at_block,
+            ),
         );
 
         Ok(Some(consensus))

--- a/src/eth/follower/importer/importer_supervisor.rs
+++ b/src/eth/follower/importer/importer_supervisor.rs
@@ -91,14 +91,20 @@ where
     Fetcher: DataFetcher + 'static,
     Importer: ImporterWorker<DataType = Fetcher::PostProcessType> + 'static,
 {
-    async fn run(self, resume_from: BlockNumber, sync_interval: Duration, chain: Arc<BlockchainClient>) -> anyhow::Result<()> {
+    async fn run(
+        self,
+        resume_from: BlockNumber,
+        sync_interval: Duration,
+        chain: Arc<BlockchainClient>,
+        stop_at_block: Option<BlockNumber>,
+    ) -> anyhow::Result<()> {
         let _timer = DropTimer::start("importer-online::run_importer_online");
 
         // Spawn common tasks: number fetcher
         let number_fetcher_task = spawn("importer::number-fetcher", start_number_fetcher(Arc::clone(&chain), sync_interval));
 
         let (backlog_tx, backlog_rx) = mpsc::channel(10_000);
-        let importer_task = spawn("importer::importer", self.importer.run(backlog_rx));
+        let importer_task = spawn("importer::importer", self.importer.run(backlog_rx, stop_at_block));
 
         let fetcher_task = spawn("importer::fetcher", self.fetcher.run(backlog_tx, resume_from));
 
@@ -111,6 +117,7 @@ where
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn start_importer(
     importer_mode: ImporterMode,
     storage: Arc<StratusStorage>,
@@ -119,23 +126,24 @@ pub async fn start_importer(
     chain: Arc<BlockchainClient>,
     kafka_connector: Option<KafkaConnector>,
     sync_interval: Duration,
+    stop_at_block: Option<BlockNumber>,
 ) -> anyhow::Result<()> {
     let resume_from: BlockNumber = storage.read_block_number_to_resume_import()?;
 
     match importer_mode {
         ImporterMode::BlockWithChanges => {
             ReplicationFollower::new(storage, miner, Arc::clone(&chain), kafka_connector)
-                .run(resume_from, sync_interval, chain)
+                .run(resume_from, sync_interval, chain, stop_at_block)
                 .await?;
         }
         ImporterMode::ReexecutionFollower => {
             ReexecutionFollower::new(executor, miner, Arc::clone(&chain), kafka_connector)
-                .run(resume_from, sync_interval, chain)
+                .run(resume_from, sync_interval, chain, stop_at_block)
                 .await?;
         }
         ImporterMode::FakeLeader =>
             FakeLeader::new(executor, miner, storage, Arc::clone(&chain))
-                .run(resume_from, sync_interval, chain)
+                .run(resume_from, sync_interval, chain, stop_at_block)
                 .await?,
     }
     Ok(())

--- a/src/eth/follower/importer/importers/execution.rs
+++ b/src/eth/follower/importer/importers/execution.rs
@@ -4,6 +4,7 @@ use async_trait::async_trait;
 
 use crate::GlobalState;
 use crate::eth::executor::Executor;
+use crate::eth::follower::importer::importers::ImportData;
 use crate::eth::follower::importer::importers::ImporterWorker;
 use crate::eth::follower::importer::send_block_to_kafka;
 use crate::eth::miner::Miner;
@@ -18,6 +19,12 @@ pub struct ReexecutionWorker {
     pub executor: Arc<Executor>,
     pub miner: Arc<Miner>,
     pub kafka_connector: Option<KafkaConnector>,
+}
+
+impl ImportData for <ReexecutionWorker as ImporterWorker>::DataType {
+    fn block_number(&self) -> crate::eth::primitives::BlockNumber {
+        self.0.number()
+    }
 }
 
 #[async_trait]

--- a/src/eth/follower/importer/importers/fake_leader.rs
+++ b/src/eth/follower/importer/importers/fake_leader.rs
@@ -7,6 +7,7 @@ use crate::GlobalState;
 use crate::eth::executor::Executor;
 use crate::eth::follower::importer::fetchers::DataFetcher;
 use crate::eth::follower::importer::fetchers::fake_leader::FakeLeaderFetcher;
+use crate::eth::follower::importer::importers::ImportData;
 use crate::eth::follower::importer::importers::ImporterWorker;
 use crate::eth::miner::Miner;
 use crate::eth::miner::miner::interval_miner::commit_retry;
@@ -22,6 +23,12 @@ pub struct FakeLeaderWorker {
     pub executor: Arc<Executor>,
     pub miner: Arc<Miner>,
     pub storage: Arc<StratusStorage>,
+}
+
+impl ImportData for <FakeLeaderWorker as ImporterWorker>::DataType {
+    fn block_number(&self) -> crate::eth::primitives::BlockNumber {
+        self.0.block_number()
+    }
 }
 
 #[async_trait]

--- a/src/eth/follower/importer/importers/mod.rs
+++ b/src/eth/follower/importer/importers/mod.rs
@@ -1,9 +1,11 @@
 use async_trait::async_trait;
 use tokio::sync::mpsc;
 
+use crate::GlobalState;
 use crate::eth::follower::importer::receive_with_timeout;
 use crate::eth::follower::importer::record_import_metrics;
 use crate::eth::follower::importer::should_shutdown;
+use crate::eth::primitives::BlockNumber;
 use crate::globals::IMPORTER_ONLINE_TASKS_SEMAPHORE;
 use crate::infra::metrics;
 use crate::infra::tracing::warn_task_tx_closed;
@@ -12,13 +14,17 @@ pub mod execution;
 pub mod fake_leader;
 pub mod replication;
 
+pub trait ImportData {
+    fn block_number(&self) -> BlockNumber;
+}
+
 #[async_trait]
 pub trait ImporterWorker: Send + Sync + Sized {
-    type DataType: Send + 'static;
+    type DataType: ImportData + Send + 'static;
 
     /// Import the block. Returns the transaction count of the block.
     async fn import(&self, data: Self::DataType) -> anyhow::Result<usize>;
-    async fn run(self, mut backlog_rx: mpsc::Receiver<Self::DataType>) -> anyhow::Result<()> {
+    async fn run(self, mut backlog_rx: mpsc::Receiver<Self::DataType>, stop_at_block: Option<BlockNumber>) -> anyhow::Result<()> {
         const TASK_NAME: &str = "importer-worker";
         let _permit = IMPORTER_ONLINE_TASKS_SEMAPHORE.acquire().await;
         loop {
@@ -32,6 +38,13 @@ pub trait ImporterWorker: Send + Sync + Sized {
                 Err(_) => break,
             };
 
+            if let Some(target_block) = stop_at_block
+                && data.block_number() > target_block
+            {
+                GlobalState::shutdown_importer_from(TASK_NAME, "Importer reached target block");
+                return Ok(());
+            }
+
             let start = metrics::now();
             let block_tx_len = self.import(data).await?;
             record_import_metrics(block_tx_len, start.elapsed());
@@ -39,5 +52,94 @@ pub trait ImporterWorker: Send + Sync + Sized {
 
         warn_task_tx_closed(TASK_NAME);
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::Mutex;
+
+    use async_trait::async_trait;
+    use tokio::sync::mpsc;
+
+    use crate::GlobalState;
+    use crate::eth::follower::importer::importers::ImportData;
+    use crate::eth::follower::importer::importers::ImporterWorker;
+    use crate::eth::primitives::BlockNumber;
+
+    /// Minimal block-like datum: just carries a block number.
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    struct NumberedBlock(BlockNumber);
+
+    impl ImportData for NumberedBlock {
+        fn block_number(&self) -> BlockNumber {
+            self.0
+        }
+    }
+
+    /// Worker that records every block number it imports.
+    struct RecordingWorker {
+        imported: Arc<Mutex<Vec<BlockNumber>>>,
+    }
+
+    #[async_trait]
+    impl ImporterWorker for RecordingWorker {
+        type DataType = NumberedBlock;
+
+        async fn import(&self, data: Self::DataType) -> anyhow::Result<usize> {
+            self.imported.lock().expect("imported lock").push(data.0);
+            Ok(0)
+        }
+    }
+
+    /// `IMPORTER_SHUTDOWN` defaults to `true`, which makes `should_shutdown()` short-circuit `run`
+    /// before it imports anything. The production startup path flips it to `false` before starting
+    /// the importer (`ImporterConfig::init_follower_importer`); the test must do the same. This
+    /// guard restores the previous value on drop so the test cannot leak state into siblings.
+    struct ImporterShutdownGuard(bool);
+    impl ImporterShutdownGuard {
+        fn new() -> Self {
+            let prev = GlobalState::is_importer_shutdown();
+            GlobalState::set_importer_shutdown(false);
+            Self(prev)
+        }
+    }
+    impl Drop for ImporterShutdownGuard {
+        fn drop(&mut self) {
+            GlobalState::set_importer_shutdown(self.0);
+        }
+    }
+
+    /// With `stop_at_block = Some(N)`, the importer must import blocks `1..=N` and stop (returning
+    /// `Ok`) when it receives the first block past `N`, without importing it.
+    ///
+    /// The imported-blocks list is the discriminating assertion: if the stop logic never fired the
+    /// worker would also import block 4 (`[1, 2, 3, 4]`); if it fired one block too early (e.g. `>=`
+    /// instead of `>`) the worker would stop at `[1, 2]`.
+    #[tokio::test]
+    async fn importer_stops_at_target_block() {
+        let _guard = ImporterShutdownGuard::new();
+
+        let imported = Arc::new(Mutex::new(Vec::new()));
+        let worker = RecordingWorker {
+            imported: Arc::clone(&imported),
+        };
+
+        let (tx, rx) = mpsc::channel::<NumberedBlock>(8);
+        for n in [1u64, 2, 3, 4] {
+            tx.send(NumberedBlock(BlockNumber::from(n))).await.expect("send block");
+        }
+        drop(tx);
+
+        let result = worker.run(rx, Some(BlockNumber::from(3u64))).await;
+        assert!(result.is_ok(), "importer should stop cleanly at the target block: {result:?}");
+
+        let imported = imported.lock().expect("imported lock");
+        assert_eq!(
+            *imported,
+            vec![BlockNumber::from(1u64), BlockNumber::from(2u64), BlockNumber::from(3u64)],
+            "importer must import blocks up to and including the target, but not past it"
+        );
     }
 }

--- a/src/eth/follower/importer/importers/replication.rs
+++ b/src/eth/follower/importer/importers/replication.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 
+use crate::eth::follower::importer::importers::ImportData;
 use crate::eth::follower::importer::importers::ImporterWorker;
 use crate::eth::follower::importer::send_block_to_kafka;
 use crate::eth::miner::Miner;
@@ -16,6 +17,12 @@ pub struct ReplicationWorker {
     pub miner: Arc<Miner>,
     pub storage: Arc<StratusStorage>,
     pub kafka_connector: Option<KafkaConnector>,
+}
+
+impl ImportData for <ReplicationWorker as ImporterWorker>::DataType {
+    fn block_number(&self) -> crate::eth::primitives::BlockNumber {
+        self.0.number()
+    }
 }
 
 #[async_trait]

--- a/src/eth/rpc/rpc_server.rs
+++ b/src/eth/rpc/rpc_server.rs
@@ -622,6 +622,7 @@ async fn stratus_init_importer(params: Params<'_>, ctx: Arc<RpcContext>, ext: Ex
         enable_block_changes_replication: std::env::var("ENABLE_BLOCK_CHANGES_REPLICATION")
             .ok()
             .is_some_and(|val| val == "1" || val == "true"),
+        stop_at_block: None,
     };
 
     importer_config.init_follower_importer(ctx).await


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Add `--stop-at-block` option to importer config

- Pass `stop_at_block` through `start_importer` and supervisor

- Extend `ImporterWorker` with stop logic via `ImportData`

- Add tests for stop-at-block importer behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Config["ImporterConfig with stop_at_block option"]
  Start["start_importer accepts stop_at_block"]
  Sup["ImporterSupervisor.run passes stop_at_block"]
  Worker["ImporterWorker.run checks stop_at_block"]
  Shutdown["Shutdown when block > stop_at_block"]

  Config -- "configure" --> Start
  Start -- "invoke" --> Sup
  Sup -- "forward" --> Worker
  Worker -- "exceeds limit" --> Shutdown
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>importer_config.rs</strong><dd><code>Add `stop_at_block` option and propagate to starter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2564/files#diff-d6208b041b3fff7e5d6e8ed530417cc9ac4d6037a7a9737370e05322418d1d34">+15/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>importer_supervisor.rs</strong><dd><code>Include `stop_at_block` in run and start_importer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2564/files#diff-15cf969173dbb739ea94cc44386de325e70fcaafc71a22b5addd05fdd17da216">+13/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>execution.rs</strong><dd><code>Implement `ImportData` for reexecution worker</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2564/files#diff-5e09e7780273ecc20fd18fa2bd3c819f1438ede9e0bb4b435e3c2b3d2b108526">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>fake_leader.rs</strong><dd><code>Implement `ImportData` for fake leader worker</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2564/files#diff-a8a2406c4432265cab0e4d322f606003777edf15d1b3b6bf8a31395c1f1f569e">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>replication.rs</strong><dd><code>Implement `ImportData` for replication worker</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2564/files#diff-6c65eaedd65180b5df236b89cf111a5c58bdd1c9f05761022c91cd00c9d28006">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong><dd><code>Add `ImportData` trait, stop logic, and tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2564/files#diff-86144d4e80f1e39f8174be0351cde32a18d0b15828e0da47d5902adc304a758c">+104/-2</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>rpc_server.rs</strong><dd><code>Initialize `stop_at_block` in RPC server</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2564/files#diff-835ba255c9a5c1fe0e13285bc39e058e1c74422e5e03ebba483c9d8a15c45405">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

