### PR TITLE
fix: clamp block ranges in get logs filter and deny negative ranges

### DIFF
--- a/src/eth/primitives/block_number.rs
+++ b/src/eth/primitives/block_number.rs
@@ -47,7 +47,11 @@ impl BlockNumber {
     ///
     /// Assumes that self is the lower-end of the range.
     pub fn count_to(self, higher_end: impl Into<u64>) -> u64 {
-        higher_end.into().saturating_sub(self.as_u64()) + 1
+        higher_end.into().saturating_sub(self.as_u64()).saturating_add(1)
+    }
+
+    pub fn as_i128(&self) -> i128 {
+        self.0.try_into().unwrap()
     }
 
     pub fn as_i64(&self) -> i64 {

--- a/src/eth/primitives/block_number.rs
+++ b/src/eth/primitives/block_number.rs
@@ -185,3 +185,35 @@ impl From<BlockNumber> for [u8; 8] {
         block_number.as_u64().to_be_bytes()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn count_to_includes_both_endpoints() {
+        assert_eq!(BlockNumber::ZERO.count_to(0u64), 1);
+        assert_eq!(BlockNumber::from(10u32).count_to(10u64), 1);
+        assert_eq!(BlockNumber::from(10u32).count_to(14u64), 5);
+    }
+
+    #[test]
+    fn count_to_saturates_instead_of_overflowing_at_max() {
+        // Before the saturating_add fix, ZERO.count_to(u64::MAX) would wrap around to 0.
+        let result = BlockNumber::ZERO.count_to(u64::MAX);
+        assert_eq!(result, u64::MAX);
+    }
+
+    #[test]
+    fn count_to_saturates_when_higher_end_below_self() {
+        // saturating_sub clamps to 0, then +1 => 1 (never underflows).
+        assert_eq!(BlockNumber::from(10u32).count_to(5u64), 1);
+    }
+
+    #[test]
+    fn as_i128_roundtrips() {
+        assert_eq!(BlockNumber::ZERO.as_i128(), 0);
+        assert_eq!(BlockNumber::from(10u32).as_i128(), 10);
+        assert_eq!(BlockNumber::MAX.as_i128(), i64::MAX as i128);
+    }
+}

--- a/src/eth/primitives/log_filter_input.rs
+++ b/src/eth/primitives/log_filter_input.rs
@@ -14,6 +14,8 @@ use crate::eth::primitives::Hash;
 use crate::eth::primitives::LogFilter;
 use crate::eth::primitives::LogTopic;
 use crate::eth::primitives::PointInTime;
+use crate::eth::primitives::RpcError;
+use crate::eth::primitives::StratusError;
 use crate::eth::storage::StratusStorage;
 
 /// JSON-RPC input used in methods like `eth_getLogs` and `eth_subscribe`.
@@ -42,7 +44,7 @@ pub struct LogFilterInput {
 
 impl LogFilterInput {
     /// Parses itself into a filter that can be applied in produced log events or to query the storage.
-    pub fn parse(self, storage: &Arc<StratusStorage>) -> anyhow::Result<LogFilter> {
+    pub fn parse(self, storage: &Arc<StratusStorage>) -> anyhow::Result<LogFilter, StratusError> {
         let original_input = self.clone();
 
         // parse point-in-time
@@ -69,6 +71,16 @@ impl LogFilterInput {
             PointInTime::Mined => None,
             PointInTime::MinedPast(number) => Some(number),
         };
+
+        if let Some(to_block) = to
+            && to_block < from
+        {
+            return Err(RpcError::BlockRangeInvalid {
+                actual: to_block.as_i128() - from.as_i128(),
+                max: None,
+            }
+            .into());
+        }
 
         Ok(LogFilter {
             from_block: from,

--- a/src/eth/primitives/log_filter_input.rs
+++ b/src/eth/primitives/log_filter_input.rs
@@ -157,4 +157,44 @@ mod tests {
         let expected = LogFilterInput::default();
         assert_eq!(result, expected);
     }
+
+    #[test]
+    fn parse_rejects_negative_block_range() {
+        use crate::eth::primitives::BlockNumber;
+
+        let storage = Arc::new(StratusStorage::new_test().unwrap());
+
+        let input = LogFilterInput {
+            from_block: Some(BlockFilter::Number(BlockNumber::from(10u32))),
+            to_block: Some(BlockFilter::Number(BlockNumber::from(5u32))),
+            ..LogFilterInput::default()
+        };
+
+        let err = input.parse(&storage).unwrap_err();
+        match err {
+            StratusError::RPC(RpcError::BlockRangeInvalid { actual, max }) => {
+                // to (5) - from (10) = -5
+                assert_eq!(actual, -5_i128);
+                assert_eq!(max, None);
+            }
+            other => panic!("expected BlockRangeInvalid, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_accepts_valid_block_range() {
+        use crate::eth::primitives::BlockNumber;
+
+        let storage = Arc::new(StratusStorage::new_test().unwrap());
+
+        let input = LogFilterInput {
+            from_block: Some(BlockFilter::Number(BlockNumber::from(5u32))),
+            to_block: Some(BlockFilter::Number(BlockNumber::from(10u32))),
+            ..LogFilterInput::default()
+        };
+
+        let filter = input.parse(&storage).unwrap();
+        assert_eq!(filter.from_block, BlockNumber::from(5u32));
+        assert_eq!(filter.to_block, Some(BlockNumber::from(10u32)));
+    }
 }

--- a/src/eth/primitives/stratus_error.rs
+++ b/src/eth/primitives/stratus_error.rs
@@ -30,9 +30,9 @@ pub enum RpcError {
     #[error_code = 1]
     BlockFilterInvalid { filter: BlockFilter },
 
-    #[error("denied because will fetch data from {actual} blocks, but the max allowed is {max}.")]
+    #[error("denied because will fetch data from {actual} blocks, but the max allowed is {max:?} and min allowed is 1.")]
     #[error_code = 2]
-    BlockRangeInvalid { actual: u64, max: u64 },
+    BlockRangeInvalid { actual: i128, max: Option<u64> },
 
     #[error("denied because client did not identify itself.")]
     #[error_code = 3]

--- a/src/eth/rpc/rpc_server.rs
+++ b/src/eth/rpc/rpc_server.rs
@@ -1369,10 +1369,10 @@ fn eth_get_logs(params: Params<'_>, ctx: Arc<RpcContext>, ext: Extensions) -> Re
     tracing::info!(?filter, filter_event = %event_name, "reading logs");
 
     // check range
-    if blocks_in_range > MAX_BLOCK_RANGE {
+    if blocks_in_range > MAX_BLOCK_RANGE || blocks_in_range == 0 {
         return Err(RpcError::BlockRangeInvalid {
-            actual: blocks_in_range,
-            max: MAX_BLOCK_RANGE,
+            actual: blocks_in_range as i128,
+            max: Some(MAX_BLOCK_RANGE),
         }
         .into());
     }


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix block range calculation and conversion

- Prevent negative or zero block ranges

- Update `BlockRangeInvalid` error signature

- Propagate structured errors in log parsing


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["LogFilterInput.parse"] --> B["Compute from/to blocks"]
  B --> C{"to < from or\nrange == 0?"}
  C -- "yes" --> D["RpcError::BlockRangeInvalid"]
  C -- "no" --> E["Return LogFilter"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>block_number.rs</strong><dd><code>Fix block counting and add i128 conversion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/block_number.rs

<ul><li>Use <code>saturating_add(1)</code> in <code>count_to</code><br> <li> Add <code>as_i128</code> conversion method</ul>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2565/files#diff-23597a90086820357b399bf33f2db790baaf7f0d4617a74a134c4d200022bb93">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>log_filter_input.rs</strong><dd><code>Enhance log filter parse with range check</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/log_filter_input.rs

<ul><li>Import <code>RpcError</code> and <code>StratusError</code><br> <li> Change <code>parse</code> return type to <code>StratusError</code><br> <li> Add check for negative <code>to < from</code></ul>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2565/files#diff-1fc314c5ef2bb71e10a986847e852f50d787c67b002131aa6f4afae62ebd4555">+13/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>stratus_error.rs</strong><dd><code>Extend BlockRangeInvalid error signature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/stratus_error.rs

<ul><li>Update <code>BlockRangeInvalid</code> error message<br> <li> Change <code>actual</code> to <code>i128</code>, <code>max</code> to <code>Option<u64></code></ul>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2565/files#diff-301cded01d772388e3e5c08ede093b91c3e4478c08e11a48f70e3d44351385fb">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>rpc_server.rs</strong><dd><code>Reject zero and out-of-range blocks in RPC</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/rpc/rpc_server.rs

<ul><li>Validate zero block range as invalid<br> <li> Use <code>i128</code> for <code>actual</code>, <code>Some(max)</code> in errors</ul>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2565/files#diff-835ba255c9a5c1fe0e13285bc39e058e1c74422e5e03ebba483c9d8a15c45405">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

