### PR TITLE
enha: populate current state CF block caches on flush

### DIFF
--- a/src/eth/storage/permanent/rocks/rocks_config.rs
+++ b/src/eth/storage/permanent/rocks/rocks_config.rs
@@ -2,6 +2,7 @@ use rocksdb::BlockBasedOptions;
 use rocksdb::Cache;
 use rocksdb::Options;
 
+#[derive(Debug, Clone, Copy)]
 pub enum CacheSetting {
     /// Enabled cache with the given size in bytes
     Enabled(usize),
@@ -14,6 +15,22 @@ pub enum DbConfig {
     HistoricalData,
     #[default]
     Default,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct ColumnFamilyConfig {
+    pub db_config: DbConfig,
+    pub cache_setting: CacheSetting,
+}
+
+impl ColumnFamilyConfig {
+    pub fn new(db_config: DbConfig, cache_setting: CacheSetting) -> Self {
+        Self { cache_setting, db_config }
+    }
+
+    pub fn to_options(self) -> Options {
+        self.db_config.to_options(self.cache_setting)
+    }
 }
 
 impl DbConfig {

--- a/src/eth/storage/permanent/rocks/rocks_db.rs
+++ b/src/eth/storage/permanent/rocks/rocks_db.rs
@@ -12,6 +12,18 @@ use super::rocks_config::DbConfig;
 #[cfg(feature = "metrics")]
 use crate::infra::metrics;
 
+const CURRENT_STATE_COLUMN_FAMILIES: [&str; 2] = ["accounts", "account_slots"];
+const PREPOPULATE_BLOCK_CACHE_ON_FLUSH: &str = "{prepopulate_block_cache=kFlushOnly;}";
+
+fn enable_populate_on_flush_current_state_caches(db: &DB) -> anyhow::Result<()> {
+    for name in CURRENT_STATE_COLUMN_FAMILIES {
+        let column_family = db.cf_handle(name).with_context(|| format!("column family '{name}' must exist"))?;
+        db.set_options_cf(&column_family, &[("block_based_table_factory", PREPOPULATE_BLOCK_CACHE_ON_FLUSH)])
+            .with_context(|| format!("enabling block-cache prepopulation for column family '{name}'"))?;
+    }
+    Ok(())
+}
+
 /// Open (or create) the Database with the configs applied to all column families.
 ///
 /// This function creates all the CFs in the database.
@@ -43,6 +55,8 @@ pub fn create_or_open_db(path: impl AsRef<Path>, cf_configs: &BTreeMap<&'static 
             open_db().context("trying to open RocksDB a second time, after repairing")?
         }
     };
+
+    enable_populate_on_flush_current_state_caches(&db)?;
 
     let waited_for = instant.elapsed();
     tracing::info!(?waited_for, db_path = ?path, "successfully opened RocksDB");

--- a/src/eth/storage/permanent/rocks/rocks_db.rs
+++ b/src/eth/storage/permanent/rocks/rocks_db.rs
@@ -8,20 +8,22 @@ use rocksdb::DB;
 use rocksdb::Options;
 
 use super::rocks_config::CacheSetting;
+use super::rocks_config::ColumnFamilyConfig;
 use super::rocks_config::DbConfig;
 #[cfg(feature = "metrics")]
 use crate::infra::metrics;
 
-const CURRENT_STATE_COLUMN_FAMILIES: [&str; 2] = ["accounts", "account_slots"];
-const PREPOPULATE_BLOCK_CACHE_ON_FLUSH: &str = "{prepopulate_block_cache=kFlushOnly;}";
+fn enable_populate_on_flush_current_state_caches(db: &DB, cf_configs: &BTreeMap<&'static str, ColumnFamilyConfig>) -> anyhow::Result<()> {
+    const PREPOPULATE_BLOCK_CACHE_ON_FLUSH: &str = "{prepopulate_block_cache=kFlushOnly;}";
 
-fn enable_populate_on_flush_current_state_caches(db: &DB) -> anyhow::Result<()> {
-    for name in CURRENT_STATE_COLUMN_FAMILIES {
-        let column_family = db.cf_handle(name).with_context(|| format!("column family '{name}' must exist"))?;
-        db.set_options_cf(&column_family, &[("block_based_table_factory", PREPOPULATE_BLOCK_CACHE_ON_FLUSH)])
-            .with_context(|| format!("enabling block-cache prepopulation for column family '{name}'"))?;
-    }
-    Ok(())
+    cf_configs.iter().try_for_each(|(name, config)| {
+        if matches!(config.db_config, DbConfig::OptimizedPointLookUp) {
+            let column_family = db.cf_handle(name).with_context(|| format!("column family '{name}' must exist"))?;
+            db.set_options_cf(&column_family, &[("block_based_table_factory", PREPOPULATE_BLOCK_CACHE_ON_FLUSH)])
+                .with_context(|| format!("enabling block-cache prepopulation for column family '{name}'"))?;
+        }
+        Ok(())
+    })
 }
 
 /// Open (or create) the Database with the configs applied to all column families.
@@ -30,13 +32,9 @@ fn enable_populate_on_flush_current_state_caches(db: &DB) -> anyhow::Result<()> 
 ///
 /// The returned `Options` **need** to be stored to refer to the DB metrics!
 #[tracing::instrument(skip_all, fields(path = ?path.as_ref()))]
-pub fn create_or_open_db(path: impl AsRef<Path>, cf_configs: &BTreeMap<&'static str, Options>) -> anyhow::Result<(&'static Arc<DB>, Options)> {
+pub fn create_or_open_db(path: impl AsRef<Path>, cf_configs: &BTreeMap<&'static str, ColumnFamilyConfig>) -> anyhow::Result<(&'static Arc<DB>, Options)> {
     let path = path.as_ref();
-
-    tracing::debug!("creating settings for each column family");
-    let cf_config_iter = cf_configs.iter().map(|(name, opts)| (*name, opts.clone()));
-
-    tracing::debug!("generating options for column families");
+    let cf_config_iter = cf_configs.iter().map(|(name, config)| (*name, config.to_options()));
     let db_opts = DbConfig::Default.to_options(CacheSetting::Disabled);
 
     if !path.exists() {
@@ -56,7 +54,7 @@ pub fn create_or_open_db(path: impl AsRef<Path>, cf_configs: &BTreeMap<&'static 
         }
     };
 
-    enable_populate_on_flush_current_state_caches(&db)?;
+    enable_populate_on_flush_current_state_caches(&db, cf_configs)?;
 
     let waited_for = instant.elapsed();
     tracing::info!(?waited_for, db_path = ?path, "successfully opened RocksDB");

--- a/src/eth/storage/permanent/rocks/rocks_state.rs
+++ b/src/eth/storage/permanent/rocks/rocks_state.rs
@@ -30,6 +30,7 @@ use super::cf_versions::CfTransactionsValue;
 use super::rocks_cf::RocksCfRef;
 use super::rocks_cf_cache_config::RocksCfCacheConfig;
 use super::rocks_config::CacheSetting;
+use super::rocks_config::ColumnFamilyConfig;
 use super::rocks_config::DbConfig;
 use super::rocks_db::create_or_open_db;
 use super::types::AccountRocksdb;
@@ -81,25 +82,25 @@ cfg_if::cfg_if! {
     }
 }
 
-pub fn generate_cf_options_map(cf_cache_config: &RocksCfCacheConfig) -> BTreeMap<&'static str, Options> {
+pub fn generate_cf_options_map(cf_cache_config: &RocksCfCacheConfig) -> BTreeMap<&'static str, ColumnFamilyConfig> {
     // Helper function to create cache setting from size
     let cache_setting_from_size = |size: usize| -> CacheSetting { CacheSetting::Enabled(size) };
 
     btmap! {
-        "accounts" => DbConfig::OptimizedPointLookUp.to_options(cache_setting_from_size(cf_cache_config.accounts)),
-        "accounts_history" => DbConfig::HistoricalData.to_options(cache_setting_from_size(cf_cache_config.accounts_history)),
-        "account_slots" => DbConfig::OptimizedPointLookUp.to_options(cache_setting_from_size(cf_cache_config.account_slots)),
-        "account_slots_history" => DbConfig::HistoricalData.to_options(cache_setting_from_size(cf_cache_config.account_slots_history)),
-        "transactions" => DbConfig::Default.to_options(cache_setting_from_size(cf_cache_config.transactions)),
-        "blocks_by_number" => DbConfig::Default.to_options(cache_setting_from_size(cf_cache_config.blocks_by_number)),
-        "blocks_by_hash" => DbConfig::Default.to_options(cache_setting_from_size(cf_cache_config.blocks_by_hash)),
-        "blocks_by_timestamp" => DbConfig::Default.to_options(cache_setting_from_size(cf_cache_config.blocks_by_timestamp)),
-        "block_changes" => DbConfig::Default.to_options(cache_setting_from_size(cf_cache_config.block_changes)),
+        "accounts" => ColumnFamilyConfig::new(DbConfig::OptimizedPointLookUp, cache_setting_from_size(cf_cache_config.accounts)),
+        "accounts_history" => ColumnFamilyConfig::new(DbConfig::HistoricalData, cache_setting_from_size(cf_cache_config.accounts_history)),
+        "account_slots" => ColumnFamilyConfig::new(DbConfig::OptimizedPointLookUp, cache_setting_from_size(cf_cache_config.account_slots)),
+        "account_slots_history" => ColumnFamilyConfig::new(DbConfig::HistoricalData, cache_setting_from_size(cf_cache_config.account_slots_history)),
+        "transactions" => ColumnFamilyConfig::new(DbConfig::Default, cache_setting_from_size(cf_cache_config.transactions)),
+        "blocks_by_number" => ColumnFamilyConfig::new(DbConfig::Default, cache_setting_from_size(cf_cache_config.blocks_by_number)),
+        "blocks_by_hash" => ColumnFamilyConfig::new(DbConfig::Default, cache_setting_from_size(cf_cache_config.blocks_by_hash)),
+        "blocks_by_timestamp" => ColumnFamilyConfig::new(DbConfig::Default, cache_setting_from_size(cf_cache_config.blocks_by_timestamp)),
+        "block_changes" => ColumnFamilyConfig::new(DbConfig::Default, cache_setting_from_size(cf_cache_config.block_changes)),
     }
 }
 
 /// Helper for creating a `RocksCfRef`, aborting if it wasn't declared in our option presets.
-fn new_cf_ref<'a, K, V>(db: &'a Arc<DB>, column_family: &str, cf_options_map: &BTreeMap<&str, Options>) -> Result<RocksCfRef<'a, K, V>>
+fn new_cf_ref<'a, K, V>(db: &'a Arc<DB>, column_family: &str, cf_options_map: &BTreeMap<&str, ColumnFamilyConfig>) -> Result<RocksCfRef<'a, K, V>>
 where
     K: Serialize + for<'de> Deserialize<'de> + Debug + std::hash::Hash + Eq + SerializeDeserializeWithContext + bincode::Encode + bincode::Decode<()>,
     V: Serialize + for<'de> Deserialize<'de> + Debug + Clone + SerializeDeserializeWithContext + bincode::Encode + bincode::Decode<()>,


### PR DESCRIPTION
### **User description**
My only guess on something that might fix #2582


___

### **PR Type**
Enhancement


___

### **Description**
- Add new `db-compare` binary for RocksDB diff
  - Ignores `gas_used` in `blocks_by_number`
  - Supports `--align-heads` head alignment

- Enable block cache prepopulation on flush for state CFs


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>db_compare.rs</strong><dd><code>New RocksDB diff binary tool</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/bin/db_compare.rs

<ul><li>Introduce <code>db-compare</code> binary for key-by-key DB diff<br> <li> Skip gas differences in <code>blocks_by_number</code> comparisons<br> <li> Add <code>--align-heads</code> mode to skip unsettled updates<br> <li> Show progress bars and summary report</ul>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2584/files#diff-352fcd3dee3112d0876a144018e7d5fa9fdf62ffe9cd4fc051a7cb6bb4841093">+442/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>rocks_db.rs</strong><dd><code>Prepopulate block cache on flush</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/permanent/rocks/rocks_db.rs

<ul><li>Define current state CFs constant and cache setting<br> <li> Add <code>enable_populate_on_flush_current_state_caches</code> function<br> <li> Invoke cache prepopulation in <code>create_or_open_db</code></ul>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2584/files#diff-dbfbd37776a9fa0a5c4dcc69c520cdfd65bd7206ab3fdd06351a54fdfd3657f5">+14/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

