### PR TITLE
perf: use rwlock for blocked clients global instead of mutex

### DIFF
--- a/src/globals.rs
+++ b/src/globals.rs
@@ -7,6 +7,7 @@ use std::sync::atomic::Ordering;
 use chrono::DateTime;
 use chrono::Utc;
 use parking_lot::Mutex;
+use parking_lot::RwLock;
 use sentry::ClientInitGuard;
 use serde::Deserialize;
 use serde::Serialize;
@@ -129,7 +130,7 @@ static TRANSACTIONS_ENABLED: AtomicBool = AtomicBool::new(true);
 static UNKNOWN_CLIENT_ENABLED: AtomicBool = AtomicBool::new(true);
 
 /// Clients that are blocked from interacting with the application.
-static BLOCKED_CLIENTS: LazyLock<Mutex<HashSet<String>>> = LazyLock::new(|| Mutex::new(HashSet::new()));
+static BLOCKED_CLIENTS: LazyLock<RwLock<HashSet<String>>> = LazyLock::new(|| RwLock::new(HashSet::new()));
 
 /// Current node mode.
 static NODE_MODE: Mutex<NodeMode> = Mutex::new(NodeMode::Follower);
@@ -289,7 +290,7 @@ impl GlobalState {
 
     /// Initializes the blocked clients set from configuration. Names are normalized the same way as incoming client identification.
     pub fn init_blocked_clients(names: &[String]) {
-        let mut blocked = BLOCKED_CLIENTS.lock();
+        let mut blocked = BLOCKED_CLIENTS.write();
         for name in names {
             if let RpcClientApp::Identified(normalized) = RpcClientApp::parse(name) {
                 blocked.insert(normalized);
@@ -301,7 +302,7 @@ impl GlobalState {
     pub fn add_blocked_client(name: &str) -> Option<String> {
         match RpcClientApp::parse(name) {
             RpcClientApp::Identified(normalized) => {
-                BLOCKED_CLIENTS.lock().insert(normalized.clone());
+                BLOCKED_CLIENTS.write().insert(normalized.clone());
                 Some(normalized)
             }
             RpcClientApp::Unknown => None,
@@ -311,27 +312,27 @@ impl GlobalState {
     /// Removes a client from the blocked clients set. Returns whether it was present.
     pub fn remove_blocked_client(name: &str) -> bool {
         match RpcClientApp::parse(name) {
-            RpcClientApp::Identified(normalized) => BLOCKED_CLIENTS.lock().remove(&normalized),
+            RpcClientApp::Identified(normalized) => BLOCKED_CLIENTS.write().remove(&normalized),
             RpcClientApp::Unknown => false,
         }
     }
 
     /// Clears the blocked clients set.
     pub fn clear_blocked_clients() {
-        BLOCKED_CLIENTS.lock().clear();
+        BLOCKED_CLIENTS.write().clear();
     }
 
     /// Checks if a client is blocked.
     pub fn is_client_blocked(client: &RpcClientApp) -> bool {
         match client {
-            RpcClientApp::Identified(name) => BLOCKED_CLIENTS.lock().contains(name),
+            RpcClientApp::Identified(name) => BLOCKED_CLIENTS.read().contains(name),
             RpcClientApp::Unknown => false,
         }
     }
 
     /// Returns the list of blocked clients (normalized names).
     pub fn list_blocked_clients() -> Vec<String> {
-        let blocked = BLOCKED_CLIENTS.lock();
+        let blocked = BLOCKED_CLIENTS.read();
         let mut list: Vec<String> = blocked.iter().cloned().collect();
         list.sort();
         list


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Replace global blocked clients mutex with RwLock

- Update methods to use `read()` and `write()` locks


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>globals.rs</strong><dd><code>Switch BLOCKED_CLIENTS to RwLock</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/globals.rs

<ul><li>Changed <code>BLOCKED_CLIENTS</code> from <code>Mutex<HashSet<String>></code> to <code>RwLock<HashSet<String>></code><br> <li> Updated <code>init_blocked_clients</code>, <code>add_blocked_client</code>, <br><code>remove_blocked_client</code>, <code>clear_blocked_clients</code> to use <code>.write()</code><br> <li> Modified <code>is_client_blocked</code> and <code>list_blocked_clients</code> to use <code>.read()</code></ul>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2586/files#diff-48d6fbc3a4ed67100952dcccfada858623c931e73d6de32984d4d1457e68d3a9">+8/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

