### PR TITLE
hotfix: changing multicall decode error tracing level from error to warning

### DIFF
--- a/src/eth/multicall.rs
+++ b/src/eth/multicall.rs
@@ -42,7 +42,7 @@ impl MulticallInfo {
         })();
 
         decoded
-            .inspect_err(|err| tracing::error!(reason = ?err, "failed to decode multicall input"))
+            .inspect_err(|err| tracing::warn!(reason = %err, "failed to decode multicall input"))
             .ok()
     }
 


### PR DESCRIPTION
### **PR Type**
Hotfix


___

### **Description**
- Lowered multicall decode failure log to warning


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>multicall.rs</strong><dd><code>Lower decode error log to warning</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/multicall.rs

- Changed `tracing::error!` to `tracing::warn!` on decode errors


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2598/files#diff-6dfc82e1e9a8fc11e95f5bed936240fac900915627f0f7c3b1f0b5d44e3c78c4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

