### PR TITLE
fix: distinguish invalid multicall input from helper calls

### DIFF
--- a/src/eth/multicall.rs
+++ b/src/eth/multicall.rs
@@ -11,6 +11,7 @@ use crate::eth::codegen;
 use crate::eth::codegen::ContractName;
 use crate::eth::primitives::Address;
 use crate::eth::primitives::Bytes;
+use crate::eth::primitives::MulticallError;
 #[cfg(feature = "metrics")]
 use crate::eth::rpc::RpcClientApp;
 #[cfg(feature = "metrics")]
@@ -32,16 +33,10 @@ pub struct MulticallInfo {
 
 impl MulticallInfo {
     pub fn decode_opt(to: Option<Address>, input: &Bytes) -> Option<Self> {
-        if !to.is_some_and(is_multicall_contract) {
-            return None;
-        }
-
-        let decoded = (|| -> anyhow::Result<Self> {
-            let decoded = Multicall::MulticallCalls::abi_decode(input.as_ref()).map_err(crate::eth::primitives::MulticallError::from)?;
-            decoded.try_into()
-        })();
-
-        decoded
+        to.is_some_and(is_multicall_contract)
+            .then(|| Multicall::MulticallCalls::abi_decode(input.as_ref()))?
+            .map_err(MulticallError::from)
+            .and_then(TryInto::try_into)
             .inspect_err(|err| tracing::warn!(reason = %err, "failed to decode multicall input"))
             .ok()
     }
@@ -94,7 +89,7 @@ impl MulticallInfo {
 }
 
 impl TryFrom<Multicall::MulticallCalls> for MulticallInfo {
-    type Error = anyhow::Error;
+    type Error = MulticallError;
 
     fn try_from(value: Multicall::MulticallCalls) -> Result<Self, Self::Error> {
         let (parent_function, subcalls) = match value {
@@ -110,7 +105,10 @@ impl TryFrom<Multicall::MulticallCalls> for MulticallInfo {
                 Multicall::tryBlockAndAggregateCall::SIGNATURE,
                 subcalls_from_calls(call.calls, Some(!call.requireSuccess)),
             ),
-            _ => anyhow::bail!("unsupported multicall function"),
+            helper_call => (
+                Multicall::MulticallCalls::signature_by_selector(helper_call.selector()).unwrap_or("unknown"),
+                Vec::new(),
+            ),
         };
 
         Ok(Self::from_subcalls(parent_function, subcalls))
@@ -400,6 +398,31 @@ mod tests {
         let input = Bytes(Vec::from(Multicall::aggregateCall::SELECTOR));
 
         assert!(multicall_info(&input).is_none());
+    }
+
+    #[test]
+    fn unknown_selector_is_invalid_input() {
+        let input = Bytes(vec![0xff; 4]);
+        let err = match Multicall::MulticallCalls::abi_decode(input.as_ref()).map_err(MulticallError::from) {
+            Ok(_) => panic!("expected invalid input error"),
+            Err(err) => err,
+        };
+
+        assert!(matches!(
+            err,
+            MulticallError::InvalidInput {
+                source: alloy_sol_types::Error::UnknownSelector { .. },
+            }
+        ));
+    }
+
+    #[test]
+    fn known_helper_function_decodes_with_no_subcalls() {
+        let info = MulticallInfo::try_from(Multicall::MulticallCalls::getBasefee(Multicall::getBasefeeCall {})).unwrap();
+
+        assert_eq!(info.parent_function, Multicall::getBasefeeCall::SIGNATURE);
+        assert_eq!(info.total_subcalls, 0);
+        assert!(info.subcalls.is_empty());
     }
 
     #[test]

--- a/src/eth/multicall.rs
+++ b/src/eth/multicall.rs
@@ -105,7 +105,7 @@ impl TryFrom<Multicall::MulticallCalls> for MulticallInfo {
                 Multicall::tryBlockAndAggregateCall::SIGNATURE,
                 subcalls_from_calls(call.calls, Some(!call.requireSuccess)),
             ),
-            _non_subcall_call => return Err(MulticallError::UnsupportedFunction),
+            _non_subcall_call => return Err(MulticallError::UnsupportedMulticallFunction),
         };
 
         Ok(Self::from_subcalls(parent_function, subcalls))
@@ -417,7 +417,7 @@ mod tests {
     fn known_non_subcall_function_is_unsupported() {
         let err = MulticallInfo::try_from(Multicall::MulticallCalls::getBasefee(Multicall::getBasefeeCall {})).unwrap_err();
 
-        assert!(matches!(err, MulticallError::UnsupportedFunction));
+        assert!(matches!(err, MulticallError::UnsupportedMulticallFunction));
     }
 
     #[test]

--- a/src/eth/multicall.rs
+++ b/src/eth/multicall.rs
@@ -400,9 +400,8 @@ mod tests {
     #[test]
     fn unknown_selector_is_decode_error() {
         let input = Bytes(vec![0xff; 4]);
-        let err = match Multicall::MulticallCalls::abi_decode(input.as_ref()).map_err(MulticallError::from) {
-            Ok(_) => panic!("expected invalid input error"),
-            Err(err) => err,
+        let Err(err) = Multicall::MulticallCalls::abi_decode(input.as_ref()).map_err(MulticallError::from) else {
+            panic!("expected decode error");
         };
 
         assert!(matches!(

--- a/src/eth/multicall.rs
+++ b/src/eth/multicall.rs
@@ -105,10 +105,7 @@ impl TryFrom<Multicall::MulticallCalls> for MulticallInfo {
                 Multicall::tryBlockAndAggregateCall::SIGNATURE,
                 subcalls_from_calls(call.calls, Some(!call.requireSuccess)),
             ),
-            helper_call => (
-                Multicall::MulticallCalls::signature_by_selector(helper_call.selector()).unwrap_or("unknown"),
-                Vec::new(),
-            ),
+            _non_subcall_call => return Err(MulticallError::UnsupportedFunction),
         };
 
         Ok(Self::from_subcalls(parent_function, subcalls))
@@ -401,7 +398,7 @@ mod tests {
     }
 
     #[test]
-    fn unknown_selector_is_invalid_input() {
+    fn unknown_selector_is_decode_error() {
         let input = Bytes(vec![0xff; 4]);
         let err = match Multicall::MulticallCalls::abi_decode(input.as_ref()).map_err(MulticallError::from) {
             Ok(_) => panic!("expected invalid input error"),
@@ -410,19 +407,17 @@ mod tests {
 
         assert!(matches!(
             err,
-            MulticallError::InvalidInput {
+            MulticallError::DecodeError {
                 source: alloy_sol_types::Error::UnknownSelector { .. },
             }
         ));
     }
 
     #[test]
-    fn known_helper_function_decodes_with_no_subcalls() {
-        let info = MulticallInfo::try_from(Multicall::MulticallCalls::getBasefee(Multicall::getBasefeeCall {})).unwrap();
+    fn known_non_subcall_function_is_unsupported() {
+        let err = MulticallInfo::try_from(Multicall::MulticallCalls::getBasefee(Multicall::getBasefeeCall {})).unwrap_err();
 
-        assert_eq!(info.parent_function, Multicall::getBasefeeCall::SIGNATURE);
-        assert_eq!(info.total_subcalls, 0);
-        assert!(info.subcalls.is_empty());
+        assert!(matches!(err, MulticallError::UnsupportedFunction));
     }
 
     #[test]

--- a/src/eth/primitives/stratus_error.rs
+++ b/src/eth/primitives/stratus_error.rs
@@ -80,6 +80,10 @@ pub enum MulticallError {
         #[from]
         source: alloy_sol_types::Error,
     },
+
+    #[error("unsupported multicall function: {function}")]
+    #[error_code = 2]
+    UnsupportedFunction { function: &'static str },
 }
 
 #[derive(Debug, thiserror::Error, strum::EnumProperty, strum::IntoStaticStr, ErrorCode)]

--- a/src/eth/primitives/stratus_error.rs
+++ b/src/eth/primitives/stratus_error.rs
@@ -74,16 +74,16 @@ pub enum RpcError {
 #[derive(Debug, thiserror::Error, strum::EnumProperty, strum::IntoStaticStr, ErrorCode)]
 #[major_error_code = 8000]
 pub enum MulticallError {
-    #[error("invalid multicall ABI: {source}")]
+    #[error("failed to decode multicall ABI: {source}")]
     #[error_code = 1]
-    InvalidInput {
+    DecodeError {
         #[from]
         source: alloy_sol_types::Error,
     },
 
-    #[error("unsupported multicall function: {function}")]
+    #[error("unsupported multicall function")]
     #[error_code = 2]
-    UnsupportedFunction { function: &'static str },
+    UnsupportedFunction,
 }
 
 #[derive(Debug, thiserror::Error, strum::EnumProperty, strum::IntoStaticStr, ErrorCode)]

--- a/src/eth/primitives/stratus_error.rs
+++ b/src/eth/primitives/stratus_error.rs
@@ -83,7 +83,7 @@ pub enum MulticallError {
 
     #[error("unsupported multicall function")]
     #[error_code = 2]
-    UnsupportedFunction,
+    UnsupportedMulticallFunction,
 }
 
 #[derive(Debug, thiserror::Error, strum::EnumProperty, strum::IntoStaticStr, ErrorCode)]


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Refactor multicall input decoding logic

- Handle unsupported helper function calls gracefully

- Distinguish invalid input errors with MulticallError

- Add tests for unknown/helper selectors


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>multicall.rs</strong><dd><code>Refactor multicall decode and errors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/multicall.rs

<ul><li>Refactor <code>decode_opt</code> to functional chain<br> <li> Map unknown selectors to empty subcalls<br> <li> Update <code>TryFrom</code> impl to use <code>MulticallError</code><br> <li> Add tests for invalid/helper selectors</ul>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2599/files#diff-6dfc82e1e9a8fc11e95f5bed936240fac900915627f0f7c3b1f0b5d44e3c78c4">+35/-12</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>stratus_error.rs</strong><dd><code>Add UnsupportedFunction error variant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/primitives/stratus_error.rs

<ul><li>Add <code>UnsupportedFunction</code> error variant<br> <li> Define error message and error code</ul>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2599/files#diff-301cded01d772388e3e5c08ede093b91c3e4478c08e11a48f70e3d44351385fb">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

