### PR TITLE
perf: use bytes::Bytes instead of Vec<u8> for primitives::Bytes

### DIFF
--- a/src/eth/executor/evm/types/output/transaction_execution.rs
+++ b/src/eth/executor/evm/types/output/transaction_execution.rs
@@ -230,10 +230,15 @@ impl TransactionExecutionOutput {
                 continue;
             }
 
-            let (Some(destination), Some(source)) = (execution_log.data.get_mut(0..32), receipt_log.data().data.get(0..32)) else {
+            let Some(source) = receipt_log.data().data.get(0..32) else {
+                continue;
+            };
+            let mut data = execution_log.data.0.to_vec();
+            let Some(destination) = data.get_mut(0..32) else {
                 continue;
             };
             destination.copy_from_slice(source);
+            execution_log.data = Bytes::from(data);
         }
     }
 

--- a/src/eth/genesis.rs
+++ b/src/eth/genesis.rs
@@ -238,9 +238,9 @@ impl GenesisConfig {
         // Parse extra data
         let extra_data_str = self.extraData.trim_start_matches("0x");
         let extra_data = if let Ok(bytes) = hex::decode(extra_data_str) {
-            Bytes(bytes)
+            Bytes::from(bytes)
         } else {
-            Bytes(vec![])
+            Bytes::default()
         };
 
         // Parse parent hash (if present)

--- a/src/eth/rpc/middleware/multicall.rs
+++ b/src/eth/rpc/middleware/multicall.rs
@@ -125,8 +125,7 @@ pub struct MulticallSubcall {
 }
 
 impl MulticallSubcall {
-    fn new(index: usize, to: Address, input: Vec<u8>, allow_failure: Option<bool>, value: Option<String>) -> Self {
-        let input = Bytes(input);
+    fn new(index: usize, to: Address, input: Bytes, allow_failure: Option<bool>, value: Option<String>) -> Self {
         Self {
             index,
             to,
@@ -154,7 +153,7 @@ pub fn is_multicall_contract(to: Address) -> bool {
 trait MulticallCall {
     fn target(&self) -> Address;
 
-    fn data(&self) -> &[u8];
+    fn data(self) -> Bytes;
 
     fn allow_failure(&self) -> Option<bool> {
         None
@@ -168,13 +167,10 @@ trait MulticallCall {
     where
         Self: Sized,
     {
-        MulticallSubcall::new(
-            index,
-            self.target(),
-            self.data().to_vec(),
-            allow_failure.or_else(|| self.allow_failure()),
-            self.value(),
-        )
+        let target = self.target();
+        let allow_failure = allow_failure.or_else(|| self.allow_failure());
+        let value = self.value();
+        MulticallSubcall::new(index, target, self.data(), allow_failure, value)
     }
 }
 
@@ -183,8 +179,8 @@ impl MulticallCall for Multicall3::Call {
         self.target.into()
     }
 
-    fn data(&self) -> &[u8] {
-        self.callData.as_ref()
+    fn data(self) -> Bytes {
+        self.callData.into()
     }
 }
 
@@ -193,8 +189,8 @@ impl MulticallCall for Multicall3::Call3 {
         self.target.into()
     }
 
-    fn data(&self) -> &[u8] {
-        self.callData.as_ref()
+    fn data(self) -> Bytes {
+        self.callData.into()
     }
 
     fn allow_failure(&self) -> Option<bool> {
@@ -207,8 +203,8 @@ impl MulticallCall for Multicall3::Call3Value {
         self.target.into()
     }
 
-    fn data(&self) -> &[u8] {
-        self.callData.as_ref()
+    fn data(self) -> Bytes {
+        self.callData.into()
     }
 
     fn allow_failure(&self) -> Option<bool> {
@@ -273,7 +269,7 @@ mod tests {
 
     #[test]
     fn decode_aggregate_with_one_call() {
-        let input = Bytes(
+        let input = Bytes::from(
             Multicall::aggregateCall {
                 calls: vec![Multicall3::Call {
                     target: alloy_address(brlc_address()),
@@ -300,7 +296,7 @@ mod tests {
 
     #[test]
     fn decode_try_aggregate_sets_global_allow_failure() {
-        let input = Bytes(
+        let input = Bytes::from(
             Multicall::tryAggregateCall {
                 requireSuccess: false,
                 calls: vec![Multicall3::Call {
@@ -318,7 +314,7 @@ mod tests {
 
     #[test]
     fn decode_aggregate3_sets_per_call_allow_failure() {
-        let input = Bytes(
+        let input = Bytes::from(
             Multicall::aggregate3Call {
                 calls: vec![Multicall3::Call3 {
                     target: alloy_address(brlc_address()),
@@ -336,7 +332,7 @@ mod tests {
 
     #[test]
     fn decode_aggregate3_value_sets_value() {
-        let input = Bytes(
+        let input = Bytes::from(
             Multicall::aggregate3ValueCall {
                 calls: vec![Multicall3::Call3Value {
                     target: alloy_address(brlc_address()),
@@ -356,7 +352,7 @@ mod tests {
 
     #[test]
     fn decode_block_and_aggregate_with_one_call() {
-        let input = Bytes(
+        let input = Bytes::from(
             Multicall::blockAndAggregateCall {
                 calls: vec![Multicall3::Call {
                     target: alloy_address(brlc_address()),
@@ -374,7 +370,7 @@ mod tests {
 
     #[test]
     fn decode_try_block_and_aggregate_sets_global_allow_failure() {
-        let input = Bytes(
+        let input = Bytes::from(
             Multicall::tryBlockAndAggregateCall {
                 requireSuccess: true,
                 calls: vec![Multicall3::Call {
@@ -392,14 +388,14 @@ mod tests {
 
     #[test]
     fn decode_opt_returns_none_for_malformed_known_selector() {
-        let input = Bytes(Vec::from(Multicall::aggregateCall::SELECTOR));
+        let input = Bytes::from(Vec::from(Multicall::aggregateCall::SELECTOR));
 
         assert!(multicall_info(&input).is_none());
     }
 
     #[test]
     fn unknown_selector_is_decode_error() {
-        let input = Bytes(vec![0xff; 4]);
+        let input = Bytes::from(vec![0xff; 4]);
         let Err(err) = Multicall::MulticallCalls::abi_decode(input.as_ref()).map_err(MulticallError::from) else {
             panic!("expected decode error");
         };
@@ -421,14 +417,14 @@ mod tests {
 
     #[test]
     fn decode_opt_returns_none_for_non_multicall_contract() {
-        let input = Bytes(Multicall::aggregateCall { calls: Vec::new() }.abi_encode());
+        let input = Bytes::from(Multicall::aggregateCall { calls: Vec::new() }.abi_encode());
 
         assert!(MulticallInfo::decode_opt(Some(brlc_address()), &input).is_none());
     }
 
     #[test]
     fn decode_unknown_target_and_empty_input_to_existing_labels() {
-        let input = Bytes(
+        let input = Bytes::from(
             Multicall::aggregateCall {
                 calls: vec![Multicall3::Call {
                     target: alloy_address(unknown_address()),
@@ -452,7 +448,7 @@ mod tests {
                 callData: transfer_input().into(),
             })
             .collect();
-        let input = Bytes(Multicall::aggregateCall { calls }.abi_encode());
+        let input = Bytes::from(Multicall::aggregateCall { calls }.abi_encode());
 
         let info = multicall_info(&input).unwrap();
 

--- a/src/eth/storage/permanent/rocks/types/bytes.rs
+++ b/src/eth/storage/permanent/rocks/types/bytes.rs
@@ -38,13 +38,13 @@ impl Debug for BytesRocksdb {
 
 impl From<Bytes> for BytesRocksdb {
     fn from(value: Bytes) -> Self {
-        Self(value.0)
+        Self(value.0.to_vec())
     }
 }
 
 impl From<BytesRocksdb> for Bytes {
     fn from(value: BytesRocksdb) -> Self {
-        Self(value.0)
+        Self(value.0.into())
     }
 }
 

--- a/src/eth/types/primitives/bytes.rs
+++ b/src/eth/types/primitives/bytes.rs
@@ -1,6 +1,5 @@
 use std::fmt::Display;
 use std::ops::Deref;
-use std::ops::DerefMut;
 
 use display_json::DebugAsJson;
 
@@ -8,8 +7,7 @@ use crate::alias::RevmBytes;
 use crate::alias::RevmOutput;
 
 #[derive(DebugAsJson, Clone, Default, Eq, PartialEq)]
-#[cfg_attr(test, derive(fake::Dummy))]
-pub struct Bytes(pub Vec<u8>);
+pub struct Bytes(pub bytes::Bytes);
 
 impl Display for Bytes {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -40,7 +38,7 @@ impl<'de> serde::Deserialize<'de> for Bytes {
     {
         let value = String::deserialize(deserializer)?;
         match const_hex::decode(value) {
-            Ok(value) => Ok(Self(value)),
+            Ok(value) => Ok(Self::from(value)),
             Err(e) => {
                 tracing::warn!(reason = ?e, "failed to parse hex bytes");
                 Err(serde::de::Error::custom(e))
@@ -52,36 +50,35 @@ impl<'de> serde::Deserialize<'de> for Bytes {
 // -----------------------------------------------------------------------------
 // Conversions: Other -> Self
 // -----------------------------------------------------------------------------
-
 impl From<Vec<u8>> for Bytes {
     fn from(value: Vec<u8>) -> Self {
-        Self(value)
+        Self(value.into())
     }
 }
 
 impl From<&[u8]> for Bytes {
     fn from(value: &[u8]) -> Self {
-        Self(value.to_vec())
+        Self(bytes::Bytes::copy_from_slice(value))
     }
 }
 
 impl From<[u8; 32]> for Bytes {
     fn from(value: [u8; 32]) -> Self {
-        Self(value.to_vec())
+        Self(bytes::Bytes::copy_from_slice(&value))
     }
 }
 
 impl From<RevmBytes> for Bytes {
     fn from(value: RevmBytes) -> Self {
-        Self(value.0.into())
+        Self(value.0)
     }
 }
 
 impl From<RevmOutput> for Bytes {
     fn from(value: RevmOutput) -> Self {
         match value {
-            RevmOutput::Call(bytes) => Self(bytes.0.into()),
-            RevmOutput::Create(bytes, _) => Self(bytes.0.into()),
+            RevmOutput::Call(bytes) => Self(bytes.0),
+            RevmOutput::Create(bytes, _) => Self(bytes.0),
         }
     }
 }
@@ -91,26 +88,30 @@ impl From<RevmOutput> for Bytes {
 // -----------------------------------------------------------------------------
 impl AsRef<[u8]> for Bytes {
     fn as_ref(&self) -> &[u8] {
-        &self.0
+        self.0.as_ref()
     }
 }
 
 impl Deref for Bytes {
-    type Target = Vec<u8>;
+    type Target = [u8];
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl DerefMut for Bytes {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-
 impl From<Bytes> for RevmBytes {
     fn from(value: Bytes) -> Self {
         value.0.into()
+    }
+}
+
+#[cfg(test)]
+impl<U> fake::Dummy<U> for Bytes
+where
+    Vec<u8>: fake::Dummy<U>,
+{
+    fn dummy_with_rng<R: fake::Rng + ?Sized>(config: &U, rng: &mut R) -> Self {
+        Self::from(Vec::<u8>::dummy_with_rng(config, rng))
     }
 }

--- a/src/ledger/events.rs
+++ b/src/ledger/events.rs
@@ -228,7 +228,7 @@ pub fn transaction_to_events(block_timestamp: UnixTime, tx: Cow<TransactionMined
         .iter()
         .filter(|log| log.topic0.is_some_and(|topic0| topic0 == TRANSFER_EVENT))
         .filter_map(|log| {
-            let amount_bytes: [u8; 32] = match log.data.0.clone().try_into() {
+            let amount_bytes: [u8; 32] = match log.data.as_ref().try_into() {
                 Ok(amount_bytes) => amount_bytes,
                 Err(_) => {
                     tracing::error!(
@@ -399,21 +399,21 @@ mod tests {
         // 2. generate fake tx data
         let mut tx: TransactionMined = Fake::fake(&Faker);
         tx.execution.evm_input.to = Some(Faker::fake(&Faker));
-        tx.execution.evm_input.data = Bytes(vec![1, 2, 3, 4, 5, 6, 7, 8]);
+        tx.execution.evm_input.data = Bytes::from(vec![1, 2, 3, 4, 5, 6, 7, 8]);
 
         let mut log_transfer1: Log = Fake::fake(&Faker);
         log_transfer1.address = token_address;
         log_transfer1.topic0 = Some(TRANSFER_EVENT);
         log_transfer1.topic1 = Some(alice.address.into());
         log_transfer1.topic2 = Some(bob.address.into());
-        log_transfer1.data = Bytes(amount_bytes.to_vec());
+        log_transfer1.data = Bytes::from(amount_bytes.to_vec());
 
         let mut log_transfer2: Log = Fake::fake(&Faker);
         log_transfer2.address = token_address;
         log_transfer2.topic0 = Some(TRANSFER_EVENT);
         log_transfer2.topic1 = Some(bob.address.into());
         log_transfer2.topic2 = Some(charlie.address.into());
-        log_transfer2.data = Bytes(amount_bytes.to_vec());
+        log_transfer2.data = Bytes::from(amount_bytes.to_vec());
 
         let log_random: Log = Fake::fake(&Faker);
 
@@ -429,7 +429,7 @@ mod tests {
         for event in events {
             assert_eq!(&event.transaction_hash, &tx.info.hash);
             assert_eq!(&event.contract_address, &tx.evm_input.to.unwrap());
-            assert_eq!(&event.function_id[0..], &tx.evm_input.data.0[0..4]);
+            assert_eq!(&event.function_id[0..], &tx.evm_input.data[0..4]);
             assert_eq!(&event.block_number, &tx.evm_input.block_number);
             assert_eq!(&event.block_datetime, &DateTime::<Utc>::from(block_timestamp));
 


### PR DESCRIPTION
### **User description**
very cheap to clone


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Use bytes::Bytes for primitive `Bytes`

- Refactor EVM log overwrite to Bytes::from

- Update multicall RPC API to return Bytes

- Adjust tests and conversions to new Bytes


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>transaction_execution.rs</strong><dd><code>Use Bytes::from in EVM log overwrite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/executor/evm/types/output/transaction_execution.rs

<ul><li>Extract mutable slice from owned Vec for destination<br> <li> Convert <code>execution_log.data</code> to <code>Bytes::from(data)</code></ul>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2609/files#diff-eb7b958fe3e94028d8ba4166b2ede9b9c3e1dc9b07f810875e47c34ea5322358">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>genesis.rs</strong><dd><code>Use Bytes::from for genesis extra data</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/genesis.rs

<ul><li>Replace <code>Bytes(bytes)</code> with <code>Bytes::from(bytes)</code><br> <li> Use <code>Bytes::default()</code> for empty data</ul>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2609/files#diff-d09e240f407ef1a47fa0bbe3c6f992e78666dd0d47d86dd9f2308d34d877c530">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>multicall.rs</strong><dd><code>Refactor MulticallCall API to Bytes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/rpc/middleware/multicall.rs

<ul><li>Change <code>MulticallSubcall::new</code> input to <code>Bytes</code><br> <li> Update <code>MulticallCall::data</code> to return <code>Bytes</code><br> <li> Simplify <code>into_multicall_subcall</code> to use Bytes directly<br> <li> Adjust tests to use <code>Bytes::from</code> for inputs</ul>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2609/files#diff-a4c8ac0a3be59f9f670ed4a94e4e3495f78d245cfd2df9f6147befb9c79cc276">+23/-27</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>bytes.rs</strong><dd><code>Adjust BytesRocksdb conversions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/permanent/rocks/types/bytes.rs

<ul><li>Convert <code>From<Bytes> for BytesRocksdb</code> to use <code>to_vec()</code><br> <li> Convert <code>From<BytesRocksdb> for Bytes</code> using <code>into()</code></ul>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2609/files#diff-b78a3fde040248ef2027e316656a1dc609f6089ff6dd7a86de0ecdf213e1c55b">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>bytes.rs</strong><dd><code>Switch Bytes to bytes::Bytes wrapper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/types/primitives/bytes.rs

<ul><li>Change <code>Bytes</code> struct to wrap <code>bytes::Bytes</code><br> <li> Update <code>From</code> and <code>AsRef</code> implementations<br> <li> Remove <code>DerefMut</code>, update <code>Deref</code> to <code>[u8]</code><br> <li> Add <code>fake::Dummy</code> impl for tests</ul>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2609/files#diff-02aed529c9673da0d142535d8dfaacec2c4eb96845122e6740ce147fb273fbce">+20/-19</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>events.rs</strong><dd><code>Use Bytes::as_ref in event parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/ledger/events.rs

<ul><li>Use <code>log.data.as_ref()</code> instead of <code>.0.clone()</code><br> <li> Update tests to construct <code>Bytes::from</code> and slice data</ul>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2609/files#diff-3c32fd4a5d4c71b18e0d1b10b6f00f18c4dca2d3acd63d314343f7be6a219515">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

