### PR TITLE
ci: remove deps debug symbols for smaller caches

### DIFF
--- a/.github/workflows/_setup-e2e.yml
+++ b/.github/workflows/_setup-e2e.yml
@@ -23,6 +23,7 @@ on:
         default: "stable-release"
 env:
   CACHE_SHARED_KEY: stable-release
+  STRATUS_PROFILE: ci
   CACHE_PATH: |
     ~/.cargo/registry/index/
     ~/.cargo/registry/cache/

--- a/.github/workflows/build-debug-cache.yml
+++ b/.github/workflows/build-debug-cache.yml
@@ -65,8 +65,10 @@ jobs:
         #      importer-offline) the e2e consumers require.
         run: |
           source <(cargo llvm-cov show-env --export-prefix)
-          cargo test --no-run
-          cargo build --features dev
+          # --profile ci strips debug symbols from dependencies (stratus itself keeps
+          # full debug). Consumers run with STRATUS_PROFILE=ci so they hit this cache.
+          cargo test --no-run --profile ci
+          cargo build --features dev --profile ci
 
       - name: Check all features
         # Prime the cache with `.rmeta` artifacts for every feature combination the

--- a/.github/workflows/e2e-contracts-rocks.yml
+++ b/.github/workflows/e2e-contracts-rocks.yml
@@ -31,6 +31,9 @@ on:
 
 env:
   CACHE_SHARED_KEY: stable-release
+  # Use the `ci` profile (deps stripped of debug symbols; stratus keeps full debug).
+  # See [profile.ci] in Cargo.toml and profile_flag in the justfile.
+  STRATUS_PROFILE: ci
   CACHE_PATH: |
     ~/.cargo/registry/index/
     ~/.cargo/registry/cache/

--- a/.github/workflows/e2e-leader-fake-leader.yml
+++ b/.github/workflows/e2e-leader-fake-leader.yml
@@ -31,6 +31,9 @@ on:
 
 env:
   CACHE_SHARED_KEY: stable-release
+  # Use the `ci` profile (deps stripped of debug symbols; stratus keeps full debug).
+  # See [profile.ci] in Cargo.toml and profile_flag in the justfile.
+  STRATUS_PROFILE: ci
   CACHE_PATH: |
     ~/.cargo/registry/index/
     ~/.cargo/registry/cache/

--- a/.github/workflows/e2e-leader-follower.yml
+++ b/.github/workflows/e2e-leader-follower.yml
@@ -31,6 +31,9 @@ on:
 
 env:
   CACHE_SHARED_KEY: stable-release
+  # Use the `ci` profile (deps stripped of debug symbols; stratus keeps full debug).
+  # See [profile.ci] in Cargo.toml and profile_flag in the justfile.
+  STRATUS_PROFILE: ci
   CACHE_PATH: |
     ~/.cargo/registry/index/
     ~/.cargo/registry/cache/

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -30,6 +30,9 @@ on:
 
 env:
   CACHE_SHARED_KEY: stable-release
+  # Use the `ci` profile (deps stripped of debug symbols; stratus keeps full debug).
+  # See [profile.ci] in Cargo.toml and profile_flag in the justfile.
+  STRATUS_PROFILE: ci
   CACHE_PATH: |
     ~/.cargo/registry/index/
     ~/.cargo/registry/cache/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -262,5 +262,13 @@ expect_used = "warn"
 panic = "warn"
 
 
+# CI-only profile: strips debug symbols from dependencies to keep the shared
+# `stable-release` cache small, while keeping full debug info for stratus itself.
+[profile.ci]
+inherits = "dev"
+
+[profile.ci.package."*"]
+debug = false
+
 [profile.release]
 lto = "fat"

--- a/justfile
+++ b/justfile
@@ -8,6 +8,7 @@ export CARGO_COMMAND := env("CARGO_COMMAND", "")
 # Global arguments that can be passed to receipts.
 nightly_flag := if env("NIGHTLY", "") =~ "(true|1)" { "+nightly" } else { "" }
 release_flag := if env("RELEASE", "") =~ "(true|1)" { "--release" } else { "" }
+profile_flag := if env("STRATUS_PROFILE", "") != "" { "--profile " + env("STRATUS_PROFILE", "") } else { "" }
 database_url := env("DATABASE_URL", "postgres://postgres:123@0.0.0.0:5432/stratus")
 
 # Project: Show available tasks
@@ -110,8 +111,8 @@ stratus-test *args="":
         FEATURES="dev,replication"
     fi
     echo "leader features: " $FEATURES
-    cargo build --features $FEATURES
-    cargo run --bin stratus --features $FEATURES -- --leader --rocks-cf-size-metrics-interval 30s {{args}} > stratus.log &
+    cargo build {{profile_flag}} --features $FEATURES
+    cargo run {{profile_flag}} --bin stratus --features $FEATURES -- --leader --rocks-cf-size-metrics-interval 30s {{args}} > stratus.log &
     just _wait_for_stratus
 
 # Bin: Stratus main service as leader while performing memory-profiling, producing a heap dump every 2^32 allocated bytes (~4gb)
@@ -134,8 +135,8 @@ stratus-follower-test *args="":
         FEATURES="dev,replication"
     fi
     echo "follower features: " $FEATURES
-    cargo build --features $FEATURES
-    LOCAL_ENV_PATH=config/stratus-follower.env.local cargo run --bin stratus --features $FEATURES -- --follower --rocks-cf-size-metrics-interval 30s {{args}} -a 0.0.0.0:3001 > stratus_follower.log &
+    cargo build {{profile_flag}} --features $FEATURES
+    LOCAL_ENV_PATH=config/stratus-follower.env.local cargo run {{profile_flag}} --bin stratus --features $FEATURES -- --follower --rocks-cf-size-metrics-interval 30s {{args}} -a 0.0.0.0:3001 > stratus_follower.log &
     just _wait_for_stratus 3001
 
 # Bin: Stratus main service as fake leader (imports blocks like a follower, executes/mines locally like a leader)
@@ -144,8 +145,8 @@ stratus-fake-leader-test *args="":
     source <(just coverage-env)
     FEATURES="dev"
     echo "fake-leader features: " $FEATURES
-    cargo build --features $FEATURES
-    LOCAL_ENV_PATH=config/stratus-follower.env.local cargo run --bin stratus --features $FEATURES -- --fake-leader --rocks-cf-size-metrics-interval 30s {{args}} -a 0.0.0.0:3001 > stratus_fake_leader.log &
+    cargo build {{profile_flag}} --features $FEATURES
+    LOCAL_ENV_PATH=config/stratus-follower.env.local cargo run {{profile_flag}} --bin stratus --features $FEATURES -- --fake-leader --rocks-cf-size-metrics-interval 30s {{args}} -a 0.0.0.0:3001 > stratus_fake_leader.log &
     just _wait_for_stratus 3001
 
 # Bin: Download external RPC blocks and receipts to temporary storage
@@ -155,8 +156,8 @@ rpc-downloader *args="":
 rpc-downloader-test *args="":
     #!/bin/bash
     source <(just coverage-env)
-    cargo build
-    cargo run --bin rpc-downloader -- {{args}} > rpc-downloader.log
+    cargo build {{profile_flag}}
+    cargo run {{profile_flag}} --bin rpc-downloader -- {{args}} > rpc-downloader.log
 
 # Bin: Import external RPC blocks from temporary storage to Stratus storage
 importer-offline *args="":
@@ -165,8 +166,8 @@ importer-offline *args="":
 importer-offline-test *args="":
     #!/bin/bash
     source <(just coverage-env)
-    cargo build
-    cargo run --bin importer-offline -- {{args}} --rocks-file-descriptors-limit=65536 > importer-offline.log
+    cargo build {{profile_flag}}
+    cargo run {{profile_flag}} --bin importer-offline -- {{args}} --rocks-file-descriptors-limit=65536 > importer-offline.log
 
 # ------------------------------------------------------------------------------
 # Test tasks
@@ -175,11 +176,11 @@ importer-offline-test *args="":
 test:
     #!/bin/bash
     source <(just coverage-env)
-    cargo test
+    cargo test {{profile_flag}}
     if command -v cargo-llvm-cov >/dev/null 2>&1; then
         mkdir -p target/llvm-cov/reports
-        cargo llvm-cov report --html --ignore-filename-regex data_migration.rs
-        cargo llvm-cov report --lcov --output-path target/llvm-cov/reports/rust_tests.info --ignore-filename-regex data_migration.rs
+        cargo llvm-cov report {{profile_flag}} --html --ignore-filename-regex data_migration.rs
+        cargo llvm-cov report {{profile_flag}} --lcov --output-path target/llvm-cov/reports/rust_tests.info --ignore-filename-regex data_migration.rs
     fi
 
 
@@ -205,8 +206,8 @@ run-test recipe="" *args="":
     if command -v cargo-llvm-cov >/dev/null 2>&1; then
         echo "Generating reports"
         mkdir -p target/llvm-cov/reports
-        cargo llvm-cov report --html --ignore-filename-regex data_migration.rs
-        cargo llvm-cov report --lcov --output-path target/llvm-cov/reports/{{recipe}}.info --ignore-filename-regex data_migration.rs
+        cargo llvm-cov report {{profile_flag}} --html --ignore-filename-regex data_migration.rs
+        cargo llvm-cov report {{profile_flag}} --lcov --output-path target/llvm-cov/reports/{{recipe}}.info --ignore-filename-regex data_migration.rs
     fi
     exit $result_code
 


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Introduce `ci` profile strips debug symbols

- Update workflows to use `STRATUS_PROFILE=ci`
  - Add env var in CI YAML files
  - Use `--profile ci` in build commands

- Extend `justfile` with `profile_flag` support


___

### Diagram Walkthrough


```mermaid
flowchart LR
  CT["Cargo.toml: add profile ci"]
  JF["justfile: add profile_flag"]
  WF["Workflows: set STRATUS_PROFILE, use --profile ci"]
  CT -- "defines ci profile" --> WF
  CT -- "defines ci profile" --> JF
  JF -- "passes profile_flag" --> WF
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td><strong>_setup-e2e.yml</strong><dd><code>Add STRATUS_PROFILE env var for CI tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2621/files#diff-41e89a8381754cea161274f93967da9d766868c2ee6083c52bf19d5f554ec332">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>build-debug-cache.yml</strong><dd><code>Use `ci` profile in debug cache build</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2621/files#diff-de3ca1cdbb315263c8656c77b4a1999d6732de0721e6d4e7e345c13b73d8a4cc">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>e2e-contracts-rocks.yml</strong><dd><code>Add `ci` profile in e2e-contracts-rocks workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2621/files#diff-68f3b7a6f3576ab20f596c2bbc5e0e09be41692b016d8240c289d126a684175f">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>e2e-leader-fake-leader.yml</strong><dd><code>Add `ci` profile env in e2e-leader-fake-leader</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2621/files#diff-24e14e9e5f457fd1dd1d1df5facc85c915a187ffd31fb70488a527836e5b06df">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>e2e-leader-follower.yml</strong><dd><code>Add `ci` profile env in e2e-leader-follower</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2621/files#diff-6cb08ce033aeec24672fd91944789df5188b47bbf56f16d034c600ba66ea1461">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>rust-test.yml</strong><dd><code>Add `ci` profile env in rust-test workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2621/files#diff-3f5af03076e3de13193be9238d177aac226369d95a06e94b0d2ae2aca3aabae1">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Cargo.toml</strong><dd><code>Define CI-only profile stripping debug symbols</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2621/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>justfile</strong><dd><code>Add `profile_flag` for STRATUS_PROFILE in justfile</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2621/files#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1">+16/-15</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

