### PR TITLE
metrics tests

### DIFF
--- a/src/eth/executor/evm/session.rs
+++ b/src/eth/executor/evm/session.rs
@@ -15,6 +15,7 @@ use crate::eth::storage::StratusStorage;
 use crate::eth::types::Address;
 use crate::eth::types::SlotIndex;
 use crate::eth::types::StratusError;
+use crate::infra::metrics;
 
 /// Contextual data that is read or set durint the execution of a transaction in the EVM.
 pub struct RevmSession {
@@ -71,19 +72,27 @@ impl DatabaseRef for RevmSession {
     type Error = StratusError;
 
     fn basic_ref(&self, address: revm::primitives::Address) -> Result<Option<AccountInfo>, Self::Error> {
+        let point_in_time = self.kind.point_in_time();
+        let start = metrics::now();
+
         // retrieve account
         let address: Address = address.into();
-        let account = self.storage.read_account(address, self.kind)?;
+        let (account, found_at) = self.storage.read_account(address, self.kind)?;
+        metrics::inc_evm_basic_ref(start.elapsed(), point_in_time, found_at);
         Ok(Some(account.into()))
     }
 
     fn storage_ref(&self, address: revm::primitives::Address, index: U256) -> Result<U256, Self::Error> {
+        let point_in_time = self.kind.point_in_time();
+        let start = metrics::now();
+
         // convert slot
         let address: Address = address.into();
         let index: SlotIndex = index.into();
 
         // load slot from storage
-        let slot = self.storage.read_slot(address, index, self.kind)?;
+        let (slot, found_at) = self.storage.read_slot(address, index, self.kind)?;
+        metrics::inc_evm_storage_ref(start.elapsed(), point_in_time, found_at);
 
         Ok(slot.value.into())
     }

--- a/src/eth/executor/mod.rs
+++ b/src/eth/executor/mod.rs
@@ -219,6 +219,8 @@ impl Executor {
                     metrics::inc_executor_external_transaction(start.elapsed(), tx_contract, tx_function);
                     metrics::inc_executor_external_transaction_account_reads(evm_metrics.slot_access.account_reads, tx_contract, tx_function);
                     metrics::inc_executor_external_transaction_slot_reads(evm_metrics.slot_access.slot_reads, tx_contract, tx_function);
+                    metrics::inc_executor_external_transaction_accounts_produced(evm_result.changes.accounts.len(), tx_contract, tx_function);
+                    metrics::inc_executor_external_transaction_slots_produced(evm_result.changes.slots.len(), tx_contract, tx_function);
                     metrics::inc_executor_external_transaction_gas(evm_result.gas_used.as_u64() as usize, tx_contract, tx_function);
                 }
 
@@ -227,7 +229,7 @@ impl Executor {
             //
             // failed external transaction, re-create from receipt without re-executing
             false => {
-                let sender = self.storage.read_account(receipt.from.into(), ExecutionKind::Transaction)?;
+                let (sender, _) = self.storage.read_account(receipt.from.into(), ExecutionKind::Transaction)?;
                 if tx_input.execution_info.nonce != sender.nonce {
                     bail!(
                         "reverted external transaction should have the correct nonce. address: {:?}, input: {:?}, sender: {:?}",
@@ -256,7 +258,7 @@ impl Executor {
 
     /// Validates that the target account is a contract, reading it from storage at the given point in time.
     pub fn validate_to_is_contract(&self, to_address: Address, kind: ExecutionKind) -> Result<(), StratusError> {
-        let account = self.storage.read_account(to_address, kind)?;
+        let (account, _) = self.storage.read_account(to_address, kind)?;
         if account.bytecode.is_none() {
             if self.reject_not_contract {
                 return Err(ExecutorError::AccountNotContract { address: to_address }.into());
@@ -371,6 +373,8 @@ impl Executor {
             let function = codegen::function_sig(&tx_input.execution_info.input);
             #[cfg(feature = "metrics")]
             let contract = codegen::contract_name(&tx_input.execution_info.to);
+            #[cfg(feature = "metrics")]
+            let (accounts_produced, slots_produced) = (tx_execution.result.changes.accounts.len(), tx_execution.result.changes.slots.len());
 
             if let ExecutionResult::Reverted { reason } = &tx_execution.result.result {
                 tracing::info!(?reason, "local transaction execution reverted");
@@ -385,6 +389,8 @@ impl Executor {
                     {
                         metrics::inc_executor_local_transaction_account_reads(evm_metrics.slot_access.account_reads, contract, function);
                         metrics::inc_executor_local_transaction_slot_reads(evm_metrics.slot_access.slot_reads, contract, function);
+                        metrics::inc_executor_local_transaction_accounts_produced(accounts_produced, contract, function);
+                        metrics::inc_executor_local_transaction_slots_produced(slots_produced, contract, function);
                         metrics::inc_executor_local_transaction_gas(gas_used.as_u64() as usize, true, contract, function);
                     }
                     return Ok(());

--- a/src/eth/follower/importer/mod.rs
+++ b/src/eth/follower/importer/mod.rs
@@ -410,7 +410,7 @@ mod tests {
         // Block 3 did not change B.balance, so the committed value must equal block 3's pre-state
         // (block 2 = 200). Completing at import time (perm caught up) yields 200; completing at
         // post-process time (perm behind) would yield the stale 100.
-        let account = storage.read_account(address, ExecutionKind::RPC(PointInTime::Latest)).expect("read account");
+        let (account, _) = storage.read_account(address, ExecutionKind::RPC(PointInTime::Latest)).expect("read account");
         assert_eq!(
             account.balance,
             Wei::from(200u64),

--- a/src/eth/rpc/server.rs
+++ b/src/eth/rpc/server.rs
@@ -1455,7 +1455,7 @@ fn eth_get_transaction_count(params: Params<'_>, ctx: Arc<RpcContext>, ext: Exte
     tracing::info!(%address, %filter, "reading account nonce");
 
     let point_in_time = ctx.server.storage.translate_to_point_in_time(filter)?;
-    let account = ctx.server.storage.read_account(address, ExecutionKind::RPC(point_in_time))?;
+    let (account, _) = ctx.server.storage.read_account(address, ExecutionKind::RPC(point_in_time))?;
     Ok(hex_num(account.nonce))
 }
 
@@ -1477,7 +1477,7 @@ fn eth_get_balance(params: Params<'_>, ctx: Arc<RpcContext>, ext: Extensions) ->
 
     // execute
     let point_in_time = ctx.server.storage.translate_to_point_in_time(filter)?;
-    let account = ctx.server.storage.read_account(address, ExecutionKind::RPC(point_in_time))?;
+    let (account, _) = ctx.server.storage.read_account(address, ExecutionKind::RPC(point_in_time))?;
     Ok(hex_num(account.balance))
 }
 
@@ -1498,7 +1498,7 @@ fn eth_get_code(params: Params<'_>, ctx: Arc<RpcContext>, ext: Extensions) -> Re
 
     // execute
     let point_in_time = ctx.server.storage.translate_to_point_in_time(filter)?;
-    let account = ctx.server.storage.read_account(address, ExecutionKind::RPC(point_in_time))?;
+    let (account, _) = ctx.server.storage.read_account(address, ExecutionKind::RPC(point_in_time))?;
 
     Ok(account.bytecode.map(|bytecode| hex_data(bytecode.original_bytes())).unwrap_or_else(hex_null))
 }
@@ -1590,7 +1590,7 @@ fn eth_get_storage_at(params: Params<'_>, ctx: Arc<RpcContext>, ext: Extensions)
 
     // execute
     let point_in_time = ctx.server.storage.translate_to_point_in_time(block_filter)?;
-    let slot = ctx.server.storage.read_slot(address, index, ExecutionKind::RPC(point_in_time))?;
+    let (slot, _) = ctx.server.storage.read_slot(address, index, ExecutionKind::RPC(point_in_time))?;
 
     // It must be padded, even if it is zero.
     Ok(hex_num_zero_padded(slot.value.as_u256()))

--- a/src/eth/storage/mod.rs
+++ b/src/eth/storage/mod.rs
@@ -5,6 +5,7 @@ pub use cache::StorageCache;
 pub use error::StorageError;
 pub use permanent::PermanentStorageConfig;
 pub use permanent::RocksPermanentStorage;
+pub use stratus_storage::FoundAt;
 pub use stratus_storage::MinedPointInTime;
 pub use stratus_storage::StratusStorage;
 pub use temporary::InMemoryTemporaryStorage;

--- a/src/eth/storage/stratus_storage.rs
+++ b/src/eth/storage/stratus_storage.rs
@@ -42,6 +42,7 @@ use crate::eth::types::Wei;
 use crate::eth::types::primitives::test_accounts;
 use crate::ext::not;
 use crate::infra::metrics;
+use crate::infra::metrics::MetricLabelValue;
 use crate::infra::metrics::timed;
 use crate::infra::tracing::SpanExt;
 
@@ -73,16 +74,26 @@ impl AccountOriginalsReader for StratusStorage {
 pub use resolve_pending::MinedPointInTime;
 
 /// Where a completed read obtained its value. Drives the post-read caching decision.
-#[derive(Debug)]
-enum FoundAt {
+#[derive(Debug, Clone, Copy, strum::Display)]
+pub enum FoundAt {
     /// Hit in a cache (pending or latest). Already cached; nothing to write.
+    #[strum(to_string = "cache")]
     Cache,
     /// Found in temporary (pending or latest) storage.
+    #[strum(to_string = "temporary")]
     Temp,
     /// Read from permanent storage at the latest mined point.
+    #[strum(to_string = "permanent-latest")]
     PermLatest,
     /// Read from permanent storage at a historical block.
+    #[strum(to_string = "permanent-historical")]
     PermHistorical,
+}
+
+impl From<FoundAt> for MetricLabelValue {
+    fn from(value: FoundAt) -> Self {
+        Self::Some(value.to_string())
+    }
 }
 
 /// Abstraction over address-keyed ([`Account`]) and slot-keyed ([`Slot`]) reads
@@ -394,7 +405,7 @@ impl StratusStorage {
     }
 
     /// Generic read algorithm shared by [`read_account`] and [`read_slot`].
-    fn read<E: resolve_pending::Resolve>(&self, key: E::Key, kind: ExecutionKind) -> Result<E, StorageError> {
+    fn read<E: resolve_pending::Resolve>(&self, key: E::Key, kind: ExecutionKind) -> Result<(E, FoundAt), StorageError> {
         let (value, found_at) = 'query: {
             match E::resolve(self, key, kind)? {
                 resolve_pending::Resolved::PendingCache(value) => break 'query (value, FoundAt::Cache),
@@ -434,16 +445,16 @@ impl StratusStorage {
             // Cache / Historical / (Mined, Temp): nothing to cache.
             _ => {}
         }
-        Ok(value)
+        Ok((value, found_at))
     }
 
-    pub fn read_account(&self, address: Address, kind: ExecutionKind) -> Result<Account, StorageError> {
+    pub fn read_account(&self, address: Address, kind: ExecutionKind) -> Result<(Account, FoundAt), StorageError> {
         #[cfg(feature = "tracing")]
         let _span = tracing::debug_span!("storage::read_account", %address).entered();
         self.read::<Account>(address, kind)
     }
 
-    pub fn read_slot(&self, address: Address, index: SlotIndex, kind: ExecutionKind) -> Result<Slot, StorageError> {
+    pub fn read_slot(&self, address: Address, index: SlotIndex, kind: ExecutionKind) -> Result<(Slot, FoundAt), StorageError> {
         #[cfg(feature = "tracing")]
         let _span = tracing::debug_span!("storage::read_slot", %address, %index).entered();
         self.read::<Slot>((address, index), kind)
@@ -900,7 +911,7 @@ mod tests {
         assert_ne!(call_block, latest);
 
         // The in-flight call (pinned to the first block) reads the slot.
-        let slot = storage.read_slot(address, index, ExecutionKind::CallLatest(call_block)).expect("read slot");
+        let (slot, _) = storage.read_slot(address, index, ExecutionKind::CallLatest(call_block)).expect("read slot");
 
         // Must reflect the first block (100), not the freshly mined latest (200).
         assert_eq!(slot.value, SlotValue::from([100u64, 0, 0, 0]));
@@ -927,7 +938,7 @@ mod tests {
         let latest = mine_block(&storage, changes2);
         assert_ne!(call_block, latest);
 
-        let account = storage.read_account(address, ExecutionKind::CallLatest(call_block)).expect("read account");
+        let (account, _) = storage.read_account(address, ExecutionKind::CallLatest(call_block)).expect("read account");
 
         // Must reflect the first block (100), not the freshly mined latest (200).
         assert_eq!(account.balance, Wei::from(100u64));

--- a/src/infra/metrics/metrics_config.rs
+++ b/src/infra/metrics/metrics_config.rs
@@ -4,6 +4,7 @@ use clap::Parser;
 use display_json::DebugAsJson;
 
 use crate::infra::metrics::metrics_for_consensus;
+use crate::infra::metrics::metrics_for_evm_database_ref;
 use crate::infra::metrics::metrics_for_executor;
 use crate::infra::metrics::metrics_for_importer_online;
 use crate::infra::metrics::metrics_for_json_rpc;
@@ -29,6 +30,7 @@ impl MetricsConfig {
         metrics.extend(metrics_for_importer_online());
         metrics.extend(metrics_for_json_rpc());
         metrics.extend(metrics_for_executor());
+        metrics.extend(metrics_for_evm_database_ref());
         metrics.extend(metrics_for_storage_read());
         metrics.extend(metrics_for_storage_write());
         metrics.extend(metrics_for_rocks());

--- a/src/infra/metrics/metrics_definitions.rs
+++ b/src/infra/metrics/metrics_definitions.rs
@@ -123,6 +123,12 @@ metrics! {
     "Number of slot reads executing an external transaction."
     histogram_counter executor_external_transaction_slot_reads{contract, function},
 
+    "Number of accounts in the state produced by an external transaction."
+    histogram_counter executor_external_transaction_accounts_produced{contract, function},
+
+    "Number of slots in the state produced by an external transaction."
+    histogram_counter executor_external_transaction_slots_produced{contract, function},
+
     "Gas spent executing an external transaction."
     histogram_counter executor_external_transaction_gas{contract, function},
 
@@ -147,6 +153,12 @@ metrics! {
     "Number of slot reads when executing a local transaction."
     histogram_counter executor_local_transaction_slot_reads{contract, function},
 
+    "Number of accounts in the state produced by a local transaction."
+    histogram_counter executor_local_transaction_accounts_produced{contract, function},
+
+    "Number of slots in the state produced by a local transaction."
+    histogram_counter executor_local_transaction_slots_produced{contract, function},
+
     "Gas spent executing a local transaction."
     histogram_counter executor_local_transaction_gas{success, contract, function},
 
@@ -167,6 +179,17 @@ metrics! {
 
     "Number of EVM pool workers busy executing right now."
     gauge executor_workers_busy{pool}
+}
+
+// REVM DatabaseRef reads (account and slot reads issued by the EVM).
+metrics! {
+    group: evm_database_ref,
+
+    "Time executing the basic_ref (account read) operation in the REVM database."
+    histogram_duration evm_basic_ref{point_in_time, found_at},
+
+    "Time executing the storage_ref (slot read) operation in the REVM database."
+    histogram_duration evm_storage_ref{point_in_time, found_at}
 }
 
 metrics! {


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add REVM database_ref timing metrics

- Return `FoundAt` label from storage reads

- Record executor produced-state-size metrics

- Update metrics configuration and definitions


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>session.rs</strong><dd><code>Add EVM DB ref timing metrics</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2641/files#diff-a3f297aa82c349265936849b92746fac13837a73c493c38399c9fe9dab57c365">+11/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong><dd><code>Emit executor produced-state-size metrics</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2641/files#diff-eca067cce09d1f9f11cb3a3c23141da45439df1e7f4cca01d05a551227b29a13">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>server.rs</strong><dd><code>Destructure FoundAt in RPC storage reads</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2641/files#diff-352af3d40d3356fd3836ee6b888f9ca481b0aacc78178fe6334570dabe2a7e9a">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong><dd><code>Re-export `FoundAt` in storage module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2641/files#diff-5afdbcb51a1480f953cef6a4d26ac8eb7770439927a0ed17ca4316390633a0ac">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>stratus_storage.rs</strong><dd><code>Expose `FoundAt` and include in read API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2641/files#diff-3b2e36e47959decdfe26b2c4fab90b41f9242bfdad29cc43b2377ee851f4f40a">+19/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>mod.rs</strong><dd><code>Adapt importer tests to new read_account signature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2641/files#diff-80ef1217c14207c3e9cb48103dd8133be2c489a3fad72832df8780a8632c94f5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>metrics_config.rs</strong><dd><code>Include `evm_database_ref` metrics in config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2641/files#diff-82e80998d460f0b1c76d54cdebeeaa6b21f68e1b70d77e4085175a6f3273eae9">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>metrics_definitions.rs</strong><dd><code>Define produced-state and evm_database_ref metrics</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2641/files#diff-2ca1adc579301e6de5f9e1d69eb1ed2f70aeee0f3b54fe113346040b4eab652b">+23/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

