### PR TITLE
chore(deps): bump quick-cache to 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,7 +176,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom 0.3.3",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -4610,13 +4609,13 @@ dependencies = [
 
 [[package]]
 name = "quick_cache"
-version = "0.6.22"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1c821816e9b928e20e92ed59bb3ac4aab321d16ca2316871c9fe7ca739cd477"
+checksum = "403c1a912fec895cafb223201e368234842acb9220aaf08ab042ae89ba5f135c"
 dependencies = [
- "ahash",
  "equivalent",
- "hashbrown 0.16.1",
+ "foldhash 0.2.0",
+ "hashbrown 0.17.0",
  "parking_lot",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ rustc-hash = "=2.1.1"
 smallvec = "=1.15.1"
 static_assertions = "=1.1.0"
 strum = { version = "=0.27.2", features = ["derive"] }
-quick_cache = "=0.6.22"
+quick_cache = "=0.7.0"
 sugars = "=3.0.1"
 thiserror = "=2.0.18"
 uuid = { version = "=1.23.3", features = ["v7"]}

--- a/src/eth/executor/evm/types/output/transaction_execution.rs
+++ b/src/eth/executor/evm/types/output/transaction_execution.rs
@@ -271,7 +271,8 @@ impl TransactionExecutionOutput {
     fn parse_revm_state(revm_state: EvmState) -> Result<(State<Complete>, Option<Address>), StratusError> {
         let mut deployed_contract_address = None;
         let mut execution_changes = State::default();
-
+        // might be improved by only keeping slots read from perm and modified slots
+        // and discard stots found in temp and cache
         for (revm_address, mut revm_account) in revm_state {
             let address: Address = revm_address.into();
 

--- a/src/eth/storage/cache.rs
+++ b/src/eth/storage/cache.rs
@@ -58,8 +58,8 @@ impl StorageCache {
 
     fn _cache_account_and_slots_from_changes_impl(
         changes: State<Complete>,
-        account_cache: &Cache<Address, Account, UnitWeighter, FxBuildHasher>,
-        slot_cache: &Cache<(Address, SlotIndex), SlotValue, UnitWeighter, FxBuildHasher>,
+        account_cache: &Cache<Address, Account, UnitWeighter>,
+        slot_cache: &Cache<(Address, SlotIndex), SlotValue, UnitWeighter>,
     ) {
         // cache accounts
         for (address, change) in changes.accounts.into_iter() {

--- a/src/eth/storage/cache.rs
+++ b/src/eth/storage/cache.rs
@@ -3,11 +3,9 @@ use std::time::Duration;
 
 use clap::Parser;
 use display_json::DebugAsJson;
-use foldhash::fast::FixedState;
 use indexmap::Equivalent;
 use quick_cache::UnitWeighter;
 use quick_cache::sync::Cache;
-use quick_cache::sync::DefaultLifecycle;
 use quick_cache::sync::GuardResult;
 
 use crate::eth::executor::State;
@@ -19,11 +17,9 @@ use crate::eth::types::Slot;
 use crate::eth::types::SlotIndex;
 use crate::eth::types::SlotValue;
 
-type CacheHasher = FixedState;
-
 pub struct StorageCache {
-    account_latest_cache: Cache<Address, Account, UnitWeighter, CacheHasher>,
-    slot_latest_cache: Cache<(Address, SlotIndex), SlotValue, UnitWeighter, CacheHasher>,
+    account_latest_cache: Cache<Address, Account, UnitWeighter>,
+    slot_latest_cache: Cache<(Address, SlotIndex), SlotValue, UnitWeighter>,
 }
 
 #[derive(DebugAsJson, Clone, Parser, serde::Serialize)]
@@ -46,20 +42,12 @@ impl CacheConfig {
 impl StorageCache {
     pub fn new(config: &CacheConfig) -> Self {
         Self {
-            account_latest_cache: Cache::with(
+            account_latest_cache: Cache::with_weighter(
                 config.account_history_cache_capacity,
                 config.account_history_cache_capacity as u64,
                 UnitWeighter,
-                CacheHasher::default(),
-                DefaultLifecycle::default(),
             ),
-            slot_latest_cache: Cache::with(
-                config.slot_history_cache_capacity,
-                config.slot_history_cache_capacity as u64,
-                UnitWeighter,
-                CacheHasher::default(),
-                DefaultLifecycle::default(),
-            ),
+            slot_latest_cache: Cache::with_weighter(config.slot_history_cache_capacity, config.slot_history_cache_capacity as u64, UnitWeighter),
         }
     }
 

--- a/src/eth/storage/cache.rs
+++ b/src/eth/storage/cache.rs
@@ -3,12 +3,12 @@ use std::time::Duration;
 
 use clap::Parser;
 use display_json::DebugAsJson;
+use foldhash::fast::FixedState;
 use indexmap::Equivalent;
 use quick_cache::UnitWeighter;
 use quick_cache::sync::Cache;
 use quick_cache::sync::DefaultLifecycle;
 use quick_cache::sync::GuardResult;
-use rustc_hash::FxBuildHasher;
 
 use crate::eth::executor::State;
 use crate::eth::executor::types::state::Change;
@@ -19,9 +19,11 @@ use crate::eth::types::Slot;
 use crate::eth::types::SlotIndex;
 use crate::eth::types::SlotValue;
 
+type CacheHasher = FixedState;
+
 pub struct StorageCache {
-    account_latest_cache: Cache<Address, Account, UnitWeighter, FxBuildHasher>,
-    slot_latest_cache: Cache<(Address, SlotIndex), SlotValue, UnitWeighter, FxBuildHasher>,
+    account_latest_cache: Cache<Address, Account, UnitWeighter, CacheHasher>,
+    slot_latest_cache: Cache<(Address, SlotIndex), SlotValue, UnitWeighter, CacheHasher>,
 }
 
 #[derive(DebugAsJson, Clone, Parser, serde::Serialize)]
@@ -48,14 +50,14 @@ impl StorageCache {
                 config.account_history_cache_capacity,
                 config.account_history_cache_capacity as u64,
                 UnitWeighter,
-                FxBuildHasher,
+                CacheHasher::default(),
                 DefaultLifecycle::default(),
             ),
             slot_latest_cache: Cache::with(
                 config.slot_history_cache_capacity,
                 config.slot_history_cache_capacity as u64,
                 UnitWeighter,
-                FxBuildHasher,
+                CacheHasher::default(),
                 DefaultLifecycle::default(),
             ),
         }

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -1037,6 +1037,12 @@ criteria = "safe-to-deploy"
 delta = "0.6.18 -> 0.6.22"
 notes = "Bug fixes for cache capacity edge-case and JoinFuture::poll race condition. New entry/try_* APIs and optional crossbeam-utils backend are additive. All unsafe usage is localized to existing internal performance paths with documented safety invariants. No advisories, no FFI, no build scripts, no proc-macros."
 
+[[audits.quick_cache]]
+who = "Daniel Freire <daniel.freire@cloudwalk.io> (audited by pi with cloudwalk/glm-5.2)"
+criteria = "safe-to-deploy"
+delta = "0.6.22 -> 0.7.0"
+notes = "Reviewed the complete 0.6.22->0.7.0 source diff. It fixes placeholder slab-slot leakage and reserve over-allocation, moves lifecycle cleanup outside locks, changes the default hasher from ahash to foldhash, and adds optional stats. No new unsafe, build script, proc macro, I/O, or advisories. Breaking Lifecycle APIs are unused by Stratus; MSRV 1.85 is below the project toolchain."
+
 [[audits.quote]]
 who = "Daniel Freire <daniel.freire@cloudwalk.io> (audited by pi with glm-5.2)"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
### **PR Type**
Enhancement, Documentation


___

### **Description**
- Bump `quick_cache` to v0.7.0 and adapt cache API

- Replace `Cache::with` with `Cache::with_weighter`

- Update `supply-chain/audits.toml` with quick_cache audit

- Add comment for `parse_revm_state` improvement


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Cargo.toml: bump quick_cache to 0.7.0"]
  B["storage/cache.rs: migrate to Cache::with_weighter API"]
  C["supply-chain/audits.toml: add quick_cache audit entry"]
  D["transaction_execution.rs: add parse_revm_state comment"]
  A --> B
  A --> C
  B --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>transaction_execution.rs</strong><dd><code>Add improvement comment in parse_revm_state</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/executor/evm/types/output/transaction_execution.rs

- Add comment on filtering temp and cache slots


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2645/files#diff-eb7b958fe3e94028d8ba4166b2ede9b9c3e1dc9b07f810875e47c34ea5322358">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependency update</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cache.rs</strong><dd><code>Adapt StorageCache to quick_cache v0.7 API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/storage/cache.rs

<ul><li>Remove <code>FxBuildHasher</code> and <code>DefaultLifecycle</code> imports<br> <li> Change <code>Cache</code> generics to three parameters<br> <li> Replace <code>Cache::with</code> with <code>Cache::with_weighter</code></ul>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2645/files#diff-b8200ddbedbd8dab58d6c980baad75e39c70b818c009a4d556ee71b13f046307">+4/-14</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Bump quick_cache to v0.7.0</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Cargo.toml

- Bump `quick_cache` version from 0.6.22 to 0.7.0


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2645/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>audits.toml</strong><dd><code>Add quick_cache supply-chain audit entry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

supply-chain/audits.toml

<ul><li>Add new <code>audits.quick_cache</code> entry for v0.7.0<br> <li> Document audit criteria, delta, and notes</ul>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2645/files#diff-eb494298b7630e575978d77f3bdd3178163bb7f5dbbf7e24316abe77210549f6">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

