### PR TITLE
fix: bound evm workers crossbeam channel

### DIFF
--- a/src/eth/executor/evm_worker_pool.rs
+++ b/src/eth/executor/evm_worker_pool.rs
@@ -75,7 +75,7 @@ impl EvmWorkerPool {
             storage: &Arc<StratusStorage>,
             config: &ExecutorConfig,
         ) -> crossbeam_channel::Sender<EvmTask<T>> {
-            let (evm_tx, evm_rx) = crossbeam_channel::unbounded::<EvmTask<T>>();
+            let (evm_tx, evm_rx) = crossbeam_channel::bounded::<EvmTask<T>>(4096);
 
             for evm_index in 1..=num_evms {
                 let evm_task_name = format!("{task_name}-{evm_index}");


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Replace unbounded channel with bounded capacity

- Set crossbeam channel limit to 4096


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>evm_worker_pool.rs</strong><dd><code>Use bounded channel for EVM workers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/eth/executor/evm_worker_pool.rs

<ul><li>Switched from <code>crossbeam_channel::unbounded</code> to <br><code>crossbeam_channel::bounded</code><br> <li> Applied buffer limit of 4096 for <code>EvmTask</code> channel</ul>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2672/files#diff-2598b013b615ef8070469b6fad264a20b9eab5051a29041460db47ac8a1c67f7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

