### PR TITLE
perf: make nodemode atomic

### DIFF
--- a/src/globals.rs
+++ b/src/globals.rs
@@ -2,11 +2,11 @@ use std::collections::HashSet;
 use std::fmt::Debug;
 use std::sync::LazyLock;
 use std::sync::atomic::AtomicBool;
+use std::sync::atomic::AtomicU8;
 use std::sync::atomic::Ordering;
 
 use chrono::DateTime;
 use chrono::Utc;
-use parking_lot::Mutex;
 use parking_lot::RwLock;
 use sentry::ClientInitGuard;
 use serde::Serialize;
@@ -101,17 +101,29 @@ where
 // Node mode
 // -----------------------------------------------------------------------------
 
+#[repr(u8)]
 #[derive(Clone, Copy, PartialEq, Eq, Debug, strum::Display)]
 pub enum NodeMode {
     #[strum(to_string = "leader")]
-    Leader,
+    Leader = 0,
 
     #[strum(to_string = "follower")]
-    Follower,
+    Follower = 1,
 
     /// Fake leader feches a block, re-executes its txs and then mines it's own block.
     #[strum(to_string = "fake-leader")]
-    FakeLeader,
+    FakeLeader = 2,
+}
+
+impl NodeMode {
+    const fn from_repr(value: u8) -> Self {
+        match value {
+            value if value == Self::Leader as u8 => Self::Leader,
+            value if value == Self::Follower as u8 => Self::Follower,
+            value if value == Self::FakeLeader as u8 => Self::FakeLeader,
+            _ => unreachable!(),
+        }
+    }
 }
 
 // -----------------------------------------------------------------------------
@@ -136,7 +148,7 @@ static UNKNOWN_CLIENT_ENABLED: AtomicBool = AtomicBool::new(true);
 static BLOCKED_CLIENTS: LazyLock<RwLock<HashSet<String>>> = LazyLock::new(|| RwLock::new(HashSet::new()));
 
 /// Current node mode.
-static NODE_MODE: Mutex<NodeMode> = Mutex::new(NodeMode::Follower);
+static NODE_MODE: AtomicU8 = AtomicU8::new(NodeMode::Follower as u8);
 
 static START_TIME: LazyLock<DateTime<Utc>> = LazyLock::new(Utc::now);
 
@@ -364,11 +376,11 @@ impl GlobalState {
     }
 
     pub fn set_node_mode(mode: NodeMode) {
-        *NODE_MODE.lock() = mode;
+        NODE_MODE.store(mode as u8, Ordering::Release);
     }
 
     pub fn get_node_mode() -> NodeMode {
-        *NODE_MODE.lock()
+        NodeMode::from_repr(NODE_MODE.load(Ordering::Acquire))
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Replace Mutex-protected NodeMode with AtomicU8

- Add `#[repr(u8)]` and conversions for NodeMode

- Update get/set to atomic store/load

- Remove unused `parking_lot::Mutex` import


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>globals.rs</strong><dd><code>Make NodeMode atomic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/globals.rs

<ul><li>Imported <code>AtomicU8</code> and removed <code>parking_lot::Mutex</code><br> <li> Added <code>#[repr(u8)]</code> and explicit enum discriminants<br> <li> Implemented <code>NodeMode::from_repr</code> for atomic conversion<br> <li> Replaced mutex lock/unlock with atomic store/load</ul>


</details>


  </td>
  <td><a href="https://github.com/cloudwalk/stratus/pull/2684/files#diff-48d6fbc3a4ed67100952dcccfada858623c931e73d6de32984d4d1457e68d3a9">+19/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

